### PR TITLE
RAG-0 PR #1: Chunking com overlap configurável

### DIFF
--- a/backend/rag/__init__.py
+++ b/backend/rag/__init__.py
@@ -1,0 +1,2 @@
+"""Local RAG primitives for Quimera/OpenClaw."""
+

--- a/backend/rag/chunking.py
+++ b/backend/rag/chunking.py
@@ -1,0 +1,208 @@
+"""Chunk text for local RAG ingestion.
+
+The chunker is pure Python and dependency-free. It prefers paragraph boundaries,
+falls back to multilingual sentence boundaries, and prefixes each chunk after the
+first with a configurable overlap from the previous chunk.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+DEFAULT_MAX_TOKENS = 400
+DEFAULT_OVERLAP_TOKENS = 80
+
+_TOKEN_RE = re.compile(r"\S+")
+_PARAGRAPH_RE = re.compile(r"\S[\s\S]*?(?=\n\s*\n|\Z)")
+_SENTENCE_RE = re.compile(r"[^.!?…。！？]+(?:[.!?…。！？]+|$)", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """A source text chunk ready for embedding."""
+
+    text: str
+    index: int
+    start_char: int
+    end_char: int
+
+
+@dataclass(frozen=True)
+class _TextUnit:
+    text: str
+    start_char: int
+    end_char: int
+    token_count: int
+
+
+def chunk_text(
+    text: str,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
+) -> list[Chunk]:
+    """Split text into chunks with configurable overlap.
+
+    Tokens are approximated with non-whitespace spans. This keeps the
+    implementation deterministic and dependency-free for RAG-0.
+    """
+
+    _validate_options(max_tokens=max_tokens, overlap_tokens=overlap_tokens)
+    if not text or not text.strip():
+        return []
+
+    units = _split_text_units(text, max_tokens=max_tokens)
+    chunks: list[Chunk] = []
+    current_units: list[_TextUnit] = []
+    current_tokens = 0
+    previous_body = ""
+
+    for unit in units:
+        would_exceed = current_units and current_tokens + unit.token_count > max_tokens
+        if would_exceed:
+            chunk, previous_body = _build_chunk(
+                index=len(chunks),
+                units=current_units,
+                overlap_tokens=overlap_tokens,
+                previous_body=previous_body,
+            )
+            chunks.append(chunk)
+            current_units = []
+            current_tokens = 0
+
+        current_units.append(unit)
+        current_tokens += unit.token_count
+
+    if current_units:
+        chunk, _previous_body = _build_chunk(
+            index=len(chunks),
+            units=current_units,
+            overlap_tokens=overlap_tokens,
+            previous_body=previous_body,
+        )
+        chunks.append(chunk)
+
+    return chunks
+
+
+def _validate_options(max_tokens: int, overlap_tokens: int) -> None:
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be greater than zero")
+    if overlap_tokens < 0:
+        raise ValueError("overlap_tokens cannot be negative")
+    if overlap_tokens >= max_tokens:
+        raise ValueError("overlap_tokens must be smaller than max_tokens")
+
+
+def _split_text_units(text: str, max_tokens: int) -> list[_TextUnit]:
+    units: list[_TextUnit] = []
+
+    for paragraph_match in _PARAGRAPH_RE.finditer(text):
+        paragraph = _trim_unit(
+            text=paragraph_match.group(0),
+            start_char=paragraph_match.start(),
+            end_char=paragraph_match.end(),
+        )
+        if paragraph is None:
+            continue
+
+        if _count_tokens(paragraph.text) <= max_tokens:
+            units.append(paragraph)
+            continue
+
+        units.extend(_split_large_paragraph(paragraph, max_tokens=max_tokens))
+
+    return units
+
+
+def _split_large_paragraph(paragraph: _TextUnit, max_tokens: int) -> list[_TextUnit]:
+    sentence_units: list[_TextUnit] = []
+
+    for sentence_match in _SENTENCE_RE.finditer(paragraph.text):
+        absolute_start = paragraph.start_char + sentence_match.start()
+        absolute_end = paragraph.start_char + sentence_match.end()
+        sentence = _trim_unit(
+            text=sentence_match.group(0),
+            start_char=absolute_start,
+            end_char=absolute_end,
+        )
+        if sentence is None:
+            continue
+
+        if sentence.token_count <= max_tokens:
+            sentence_units.append(sentence)
+        else:
+            sentence_units.extend(_split_large_sentence(sentence, max_tokens=max_tokens))
+
+    return sentence_units
+
+
+def _split_large_sentence(sentence: _TextUnit, max_tokens: int) -> list[_TextUnit]:
+    token_matches = list(_TOKEN_RE.finditer(sentence.text))
+    units: list[_TextUnit] = []
+
+    for start_index in range(0, len(token_matches), max_tokens):
+        group = token_matches[start_index : start_index + max_tokens]
+        absolute_start = sentence.start_char + group[0].start()
+        absolute_end = sentence.start_char + group[-1].end()
+        unit_text = sentence.text[group[0].start() : group[-1].end()]
+        units.append(
+            _TextUnit(
+                text=unit_text,
+                start_char=absolute_start,
+                end_char=absolute_end,
+                token_count=len(group),
+            )
+        )
+
+    return units
+
+
+def _trim_unit(text: str, start_char: int, end_char: int) -> _TextUnit | None:
+    left_trimmed = len(text) - len(text.lstrip())
+    right_trimmed = len(text.rstrip())
+    trimmed_text = text.strip()
+
+    if not trimmed_text:
+        return None
+
+    trimmed_start = start_char + left_trimmed
+    trimmed_end = start_char + right_trimmed
+    return _TextUnit(
+        text=trimmed_text,
+        start_char=trimmed_start,
+        end_char=trimmed_end,
+        token_count=_count_tokens(trimmed_text),
+    )
+
+
+def _build_chunk(
+    index: int,
+    units: list[_TextUnit],
+    overlap_tokens: int,
+    previous_body: str,
+) -> tuple[Chunk, str]:
+    body = "\n\n".join(unit.text for unit in units)
+    chunk_text_value = body
+
+    if index > 0 and overlap_tokens:
+        overlap = _last_tokens(previous_body, overlap_tokens)
+        if overlap:
+            chunk_text_value = f"{overlap}\n\n{body}"
+
+    return Chunk(
+        text=chunk_text_value,
+        index=index,
+        start_char=units[0].start_char,
+        end_char=units[-1].end_char,
+    ), body
+
+
+def _count_tokens(text: str) -> int:
+    return len(_TOKEN_RE.findall(text))
+
+
+def _last_tokens(text: str, token_count: int) -> str:
+    tokens = _TOKEN_RE.findall(text)
+    return " ".join(tokens[-token_count:])

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -1,0 +1,88 @@
+import unittest
+
+from backend.rag.chunking import Chunk, chunk_text
+
+
+class ChunkingTests(unittest.TestCase):
+    def test_short_text_returns_one_chunk(self):
+        chunks = chunk_text("Primeiro documento sintetico.", max_tokens=10, overlap_tokens=2)
+
+        self.assertEqual(
+            chunks,
+            [Chunk(text="Primeiro documento sintetico.", index=0, start_char=0, end_char=29)],
+        )
+
+    def test_long_text_returns_multiple_chunks_with_overlap(self):
+        text = (
+            "alfa beta gama delta.\n\n"
+            "epsilon zeta eta theta.\n\n"
+            "iota kappa lambda mu."
+        )
+
+        chunks = chunk_text(text, max_tokens=4, overlap_tokens=2)
+
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(chunks[0].text, "alfa beta gama delta.")
+        self.assertTrue(chunks[1].text.startswith("gama delta."))
+        self.assertIn("epsilon zeta eta theta.", chunks[1].text)
+        self.assertTrue(chunks[2].text.startswith("eta theta."))
+        self.assertIn("iota kappa lambda mu.", chunks[2].text)
+
+    def test_markdown_headers_lists_and_code_are_chunked(self):
+        text = (
+            "# Titulo\n\n"
+            "- item um\n"
+            "- item dois\n\n"
+            "```python\n"
+            "print('ola')\n"
+            "```\n\n"
+            "Paragrafo final."
+        )
+
+        chunks = chunk_text(text, max_tokens=5, overlap_tokens=1)
+
+        self.assertGreaterEqual(len(chunks), 3)
+        joined = "\n".join(chunk.text for chunk in chunks)
+        self.assertIn("# Titulo", joined)
+        self.assertIn("- item um", joined)
+        self.assertIn("```python", joined)
+        self.assertIn("print('ola')", joined)
+
+    def test_portuguese_text_with_accents_abbreviations_and_decimal_commas(self):
+        text = (
+            "O Dr. Silva avaliou inflação de 4,25% no cenário sintético. "
+            "A Selic ficou em 10,50%, sem carteira real."
+        )
+
+        chunks = chunk_text(text, max_tokens=6, overlap_tokens=0)
+        joined = " ".join(chunk.text for chunk in chunks)
+
+        self.assertGreaterEqual(len(chunks), 2)
+        self.assertIn("Dr.", joined)
+        self.assertIn("4,25%", joined)
+        self.assertIn("10,50%", joined)
+        self.assertIn("sintético", joined)
+
+    def test_edge_cases_empty_text_and_single_paragraph(self):
+        self.assertEqual(chunk_text("   \n\n  "), [])
+
+        chunks = chunk_text("Um unico paragrafo sem quebra.", max_tokens=20, overlap_tokens=3)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].text, "Um unico paragrafo sem quebra.")
+
+    def test_rejects_invalid_options(self):
+        invalid_options = [
+            {"max_tokens": 0, "overlap_tokens": 0},
+            {"max_tokens": 5, "overlap_tokens": -1},
+            {"max_tokens": 5, "overlap_tokens": 5},
+        ]
+
+        for options in invalid_options:
+            with self.subTest(options=options):
+                with self.assertRaises(ValueError):
+                    chunk_text("texto sintetico", **options)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Objetivo
Implementa o primeiro bloco do Sprint RAG-0: chunking puro em Python com overlap configurável.

## Escopo
- Cria backend/rag/__init__.py.
- Cria backend/rag/chunking.py.
- Cria tests/unit/test_chunking.py.

## Implementação
- chunk_text(text, max_tokens=400, overlap_tokens=80) -> list[Chunk].
- Chunk dataclass com text, index, start_char, end_char.
- Split por parágrafo primeiro.
- Fallback para sentença com regex multilíngue.
- Fallback final por tokens quando uma sentença excede max_tokens.
- Overlap prefixado a partir do corpo real do chunk anterior.
- Sem LangChain e sem dependências externas.

## Validação local
- .venv/bin/python -B -m unittest tests/unit/test_chunking.py
- .venv/bin/python -m py_compile backend/rag/chunking.py tests/unit/test_chunking.py
- .venv/bin/python -m mypy --explicit-package-bases backend/rag/chunking.py tests/unit/test_chunking.py
- .venv/bin/pyright backend/rag/chunking.py tests/unit/test_chunking.py

## Resultado
- Unit tests: 6/6 OK.
- py_compile: OK.
- mypy: Success, no issues found.
- pyright: 0 errors, 0 warnings, 0 informations.

## Restrições preservadas
- Sem dados reais.
- Sem carteira real.
- Sem .env.
- Sem dependências novas de runtime.
- Sem Qdrant, embeddings, retriever, gateway ou IA remota neste PR.