### PR TITLE
[RAG-04] feat/rag-retriever-context: Retriever + ContextPacker

### DIFF
--- a/backend/rag/context_packer.py
+++ b/backend/rag/context_packer.py
@@ -1,0 +1,219 @@
+"""Context packing primitives for the local RAG pipeline.
+
+The packer is deterministic and network-free: it deduplicates retrieved chunks,
+keeps the highest-scoring candidate for near-duplicate text, and trims the final
+context to a token budget.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+DEFAULT_MAX_CONTEXT_TOKENS = 8000
+DEFAULT_DEDUP_SIMILARITY_THRESHOLD = 0.92
+DEFAULT_SECURITY_LEVEL = "Level 2"
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class RetrievedChunk:
+    """A retrieved text chunk ready for context packing and prompting."""
+
+    id: str
+    score: float
+    doc_id: str
+    chunk_index: int
+    text: str
+    token_count: int
+    rank: int = 0
+    security_level: str = DEFAULT_SECURITY_LEVEL
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any],
+        rank: int = 0,
+    ) -> RetrievedChunk:
+        """Build a retrieved chunk from a vector-store result dictionary."""
+
+        payload = _payload_from_mapping(data)
+        doc_id = _string_field(data, payload, "doc_id")
+        chunk_index = _integer_field(data, payload, "chunk_index")
+        text = _string_field(data, payload, "text")
+        token_count = _token_count_field(data, payload, text)
+        security_level = _optional_string_field(
+            data,
+            payload,
+            "security_level",
+            DEFAULT_SECURITY_LEVEL,
+        )
+
+        chunk_id = str(data.get("id") or f"{doc_id}#{chunk_index}")
+        return cls(
+            id=chunk_id,
+            score=float(data.get("score", 0.0)),
+            doc_id=doc_id,
+            chunk_index=chunk_index,
+            text=text,
+            token_count=token_count,
+            rank=rank,
+            security_level=security_level,
+            payload=payload,
+        )
+
+    @property
+    def citation_id(self) -> str:
+        """Return the stable source citation id for prompt builders."""
+
+        return f"{self.doc_id}#{self.chunk_index}"
+
+
+@dataclass(frozen=True)
+class ContextPacker:
+    """Deduplicate and trim retrieved chunks for prompt construction."""
+
+    max_context_tokens: int = DEFAULT_MAX_CONTEXT_TOKENS
+    dedup_similarity_threshold: float = DEFAULT_DEDUP_SIMILARITY_THRESHOLD
+
+    def __post_init__(self) -> None:
+        if self.max_context_tokens <= 0:
+            raise ValueError("max_context_tokens must be greater than zero")
+        if not 0.0 <= self.dedup_similarity_threshold <= 1.0:
+            raise ValueError(
+                "dedup_similarity_threshold must be between 0.0 and 1.0"
+            )
+
+    def pack(self, chunks: Sequence[RetrievedChunk]) -> list[RetrievedChunk]:
+        """Return deduplicated chunks that fit the configured token budget.
+
+        Selection is score-first: near-duplicates lose to the higher-scoring
+        chunk. The final output is reordered by document position so the local
+        model receives a readable context.
+        """
+
+        if not chunks:
+            return []
+
+        deduplicated = self._deduplicate(chunks)
+        limited = self._apply_token_limit(deduplicated)
+        return sorted(limited, key=lambda chunk: (chunk.doc_id, chunk.chunk_index))
+
+    def _deduplicate(
+        self,
+        chunks: Sequence[RetrievedChunk],
+    ) -> list[RetrievedChunk]:
+        ordered = sorted(chunks, key=lambda chunk: (-chunk.score, chunk.rank))
+        kept: list[RetrievedChunk] = []
+
+        for candidate in ordered:
+            if not any(
+                _jaccard_similarity(candidate.text, existing.text)
+                >= self.dedup_similarity_threshold
+                for existing in kept
+            ):
+                kept.append(candidate)
+
+        return kept
+
+    def _apply_token_limit(
+        self,
+        chunks: Sequence[RetrievedChunk],
+    ) -> list[RetrievedChunk]:
+        selected: list[RetrievedChunk] = []
+        total_tokens = 0
+
+        for chunk in chunks:
+            if total_tokens + chunk.token_count > self.max_context_tokens:
+                continue
+            selected.append(chunk)
+            total_tokens += chunk.token_count
+
+        return selected
+
+
+def _payload_from_mapping(data: Mapping[str, Any]) -> dict[str, Any]:
+    payload = data.get("payload", {})
+    if payload is None:
+        return {}
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping when provided")
+    return dict(payload)
+
+
+def _string_field(
+    data: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    key: str,
+) -> str:
+    raw_value = data.get(key, payload.get(key))
+    if not isinstance(raw_value, str):
+        raise TypeError(f"{key} must be a string")
+    value = raw_value.strip()
+    if not value:
+        raise ValueError(f"{key} cannot be empty")
+    return value
+
+
+def _optional_string_field(
+    data: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    key: str,
+    default: str,
+) -> str:
+    raw_value = data.get(key, payload.get(key, default))
+    if not isinstance(raw_value, str):
+        raise TypeError(f"{key} must be a string")
+    value = raw_value.strip()
+    if not value:
+        raise ValueError(f"{key} cannot be empty")
+    return value
+
+
+def _integer_field(
+    data: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    key: str,
+) -> int:
+    raw_value = data.get(key, payload.get(key))
+    if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+        raise TypeError(f"{key} must be an integer")
+    if raw_value < 0:
+        raise ValueError(f"{key} cannot be negative")
+    return int(raw_value)
+
+
+def _token_count_field(
+    data: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    text: str,
+) -> int:
+    raw_value = data.get("token_count", payload.get("token_count"))
+    if raw_value is None:
+        return _count_tokens(text)
+    if isinstance(raw_value, bool) or not isinstance(raw_value, int):
+        raise TypeError("token_count must be an integer")
+    if raw_value <= 0:
+        raise ValueError("token_count must be greater than zero")
+    return int(raw_value)
+
+
+def _count_tokens(text: str) -> int:
+    return len(_TOKEN_RE.findall(text))
+
+
+def _jaccard_similarity(left: str, right: str) -> float:
+    left_tokens = set(_TOKEN_RE.findall(left.casefold()))
+    right_tokens = set(_TOKEN_RE.findall(right.casefold()))
+
+    if not left_tokens and not right_tokens:
+        return 1.0
+    if not left_tokens or not right_tokens:
+        return 0.0
+
+    return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)

--- a/backend/rag/retriever.py
+++ b/backend/rag/retriever.py
@@ -1,0 +1,177 @@
+"""Retriever orchestration for the local RAG pipeline."""
+
+from __future__ import annotations
+
+import inspect
+import time
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, TypeVar, cast
+
+from loguru import logger
+
+from backend.rag.context_packer import ContextPacker, RetrievedChunk
+
+
+DEFAULT_TOP_K = 5
+DEFAULT_SCORE_THRESHOLD = 0.3
+
+T = TypeVar("T")
+
+
+class EmbedderProtocol(Protocol):
+    """Minimal async embedding interface required by Retriever."""
+
+    def embed(self, text: str) -> Awaitable[list[float]]:
+        """Embed one query string."""
+        ...
+
+
+class VectorStoreProtocol(Protocol):
+    """Minimal vector-store search interface required by Retriever."""
+
+    def search(
+        self,
+        vector: Sequence[float],
+        top_k: int = DEFAULT_TOP_K,
+        score_threshold: float | None = DEFAULT_SCORE_THRESHOLD,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]] | Awaitable[list[dict[str, Any]]]:
+        """Search vector neighbors and return dictionaries."""
+        ...
+
+
+class ContextPackerProtocol(Protocol):
+    """Minimal context-packer interface required by Retriever."""
+
+    def pack(self, chunks: Sequence[RetrievedChunk]) -> list[RetrievedChunk]:
+        """Pack retrieved chunks for prompting."""
+        ...
+
+
+@dataclass(frozen=True)
+class RetrievalTimings:
+    """Latency timings for one retrieval call, in milliseconds."""
+
+    embed_ms: float
+    search_ms: float
+    pack_ms: float
+    total_ms: float
+
+    def as_dict(self) -> dict[str, float]:
+        """Return a plain dictionary for logs or future CLI output."""
+
+        return {
+            "embed_ms": self.embed_ms,
+            "search_ms": self.search_ms,
+            "pack_ms": self.pack_ms,
+            "total_ms": self.total_ms,
+        }
+
+
+@dataclass
+class Retriever:
+    """Orchestrate query embedding, vector search, and context packing."""
+
+    embedder: EmbedderProtocol
+    store: VectorStoreProtocol
+    packer: ContextPackerProtocol = field(default_factory=ContextPacker)
+    top_k: int = DEFAULT_TOP_K
+    score_threshold: float | None = DEFAULT_SCORE_THRESHOLD
+    last_timings: RetrievalTimings | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        _validate_top_k(self.top_k)
+        _validate_score_threshold(self.score_threshold)
+
+    async def retrieve(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[RetrievedChunk]:
+        """Retrieve and pack local context for one question.
+
+        The method performs no remote calls by itself. It delegates embedding and
+        vector search to injected local components, which keeps the workflow
+        testable with fakes and mocks.
+        """
+
+        clean_question = _validate_question(question)
+        effective_top_k = self.top_k if top_k is None else top_k
+        _validate_top_k(effective_top_k)
+
+        total_start = time.perf_counter()
+
+        embed_start = time.perf_counter()
+        query_vector = await self.embedder.embed(clean_question)
+        embed_ms = _elapsed_ms(embed_start)
+
+        search_start = time.perf_counter()
+        raw_results = await _maybe_await(
+            self.store.search(
+                query_vector,
+                top_k=effective_top_k,
+                score_threshold=self.score_threshold,
+                filters=filters,
+            )
+        )
+        search_ms = _elapsed_ms(search_start)
+
+        pack_start = time.perf_counter()
+        retrieved_chunks = [
+            RetrievedChunk.from_mapping(result, rank=index + 1)
+            for index, result in enumerate(raw_results)
+        ]
+        packed_chunks = self.packer.pack(retrieved_chunks)
+        pack_ms = _elapsed_ms(pack_start)
+
+        self.last_timings = RetrievalTimings(
+            embed_ms=embed_ms,
+            search_ms=search_ms,
+            pack_ms=pack_ms,
+            total_ms=_elapsed_ms(total_start),
+        )
+        logger.debug(
+            "retrieve | top_k={} raw={} packed={} timings={}",
+            effective_top_k,
+            len(raw_results),
+            len(packed_chunks),
+            self.last_timings.as_dict(),
+        )
+        return packed_chunks
+
+
+async def _maybe_await(value: T | Awaitable[T]) -> T:
+    if inspect.isawaitable(value):
+        return await cast(Awaitable[T], value)
+    return value
+
+
+def _validate_question(question: str) -> str:
+    if not isinstance(question, str):
+        raise TypeError("question must be a string")
+    clean_question = question.strip()
+    if not clean_question:
+        raise ValueError("question cannot be empty or whitespace")
+    return clean_question
+
+
+def _validate_top_k(top_k: int) -> None:
+    if isinstance(top_k, bool) or not isinstance(top_k, int):
+        raise TypeError("top_k must be an integer")
+    if top_k <= 0:
+        raise ValueError("top_k must be greater than zero")
+
+
+def _validate_score_threshold(score_threshold: float | None) -> None:
+    if score_threshold is None:
+        return
+    if isinstance(score_threshold, bool) or not isinstance(score_threshold, (int, float)):
+        raise TypeError("score_threshold must be numeric or None")
+    if not 0.0 <= float(score_threshold) <= 1.0:
+        raise ValueError("score_threshold must be between 0.0 and 1.0")
+
+
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -1,108 +1,147 @@
 # current_state.md — OPENCLAW Operational Memory
 
-> Update this file at the end of every session. Claude Code reads this before starting work.
+> Volatile project state for Codex, Claude Code, ChatGPT Thinking, and human review.
+> Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of meaningful sessions.
 
-**Last updated:** 2026-04-25
-**Updated by:** Claude (Cowork) — ops/memory-foundation branch
+**Last updated:** 2026-04-26
+**Updated by:** Codex — PR #10 preparation
 
 ---
 
 ## Active Sprint: RAG-0
 
-**Goal:** Full pipeline local: chunk → embed → Qdrant → retrieve → prompt → Qwen3 answer with citations.
-**Constraint:** Ollama only. No LiteLLM, no remote APIs, no FastAPI, no LangChain.
+**Goal:** Full local pipeline: chunk -> embed -> Qdrant -> retrieve -> pack context -> prompt -> Qwen3 answer with citations.
+
+**Hard constraints:**
+- Local only for RAG-0.
+- Ollama only for embeddings/generation.
+- Qdrant local for vector storage.
+- No LiteLLM, remote providers, FastAPI, LangChain, sentence-transformers, real portfolio data, or private documents.
 
 ---
 
-## PR Status
+## GitHub State
 
-| # | Branch | State | What |
+| RAG step | Branch | State | Scope |
 |---|---|---|---|
-| 1 | sprint/RAG-PR1 | ✅ MERGED | `chunking.py` + `test_chunking.py` (types, config, overlap) |
-| 2 | sprint/LF-S01 | ✅ MERGED | 30 knowledge files `LIBERDADE FINANCEIRA/` |
-| ops | ops/memory-foundation | 🔄 OPEN | CLAUDE.md, pyproject.toml, config/, docs/04_MEM/ |
-| 3 | feat/rag-ollama-embeddings | ⏳ NEXT | `embeddings.py` + 5 unit tests (mocked) |
+| RAG-01 | `feat/rag-chunking-*` | Merged | `chunking.py` + unit tests |
+| RAG-02 | `feat/rag-embeddings` | Merged | `OllamaEmbedder` + mocked unit tests |
+| RAG-03 | `feat/rag-qdrant-store` | Merged | `QdrantVectorStore` + integration tests |
+| RAG-04 | `feat/rag-retriever-context` | In review prep | `ContextPacker` + `Retriever` + unit tests |
+| RAG-05 | `feat/rag-prompt-generator` | Next | Prompt builder + local generator |
+| RAG-06 | `feat/rag-cli-smoke` | Planned | Synthetic ingest/query CLI + smoke tests |
+| RAG-07 | `feat/rag-docs-runbook` | Planned | Runbook + ADR + final checklist |
+
+Current issue for active work: <https://github.com/franciscosalido/OPENCLAW/issues/10>
 
 ---
 
-## What Exists in `main` Right Now
+## What Exists in `main` Now
 
-```
+```text
 backend/rag/
-  __init__.py       ✅
-  chunking.py       ✅  pure Python, paragraph→sentence, overlap
-tests/unit/
-  test_chunking.py  ✅
-scripts/
-  setup-claude-mem.sh
-.claude/
-  settings.json
-  hooks.json
-Knowledge/
-LIBERDADE FINANCEIRA/   ← 30 files added in PR#2
-Projects/ Research/ Workflows/
-```
+  __init__.py
+  chunking.py
+  embeddings.py
+  qdrant_store.py
 
-**Not yet in main:**
-`embeddings.py`, `qdrant_store.py`, `retriever.py`, `context_packer.py`,
-`prompt_builder.py`, `generator.py`, `pyproject.toml`, `config/`, `docker/`
+tests/
+  unit/test_chunking.py
+  unit/test_embeddings.py
+  integration/test_qdrant_store.py
+
+config/rag_config.yaml
+docker/docker-compose.qdrant.yml
+docs/04_MEM/AGENT_CONTEXT.md
+docs/04_MEM/current_state.md
+docs/04_MEM/decisions.md
+docs/04_MEM/next_actions.md
+```
 
 ---
 
-## Local Worktree Warning
+## Active Branch: `feat/rag-retriever-context`
 
-During branch creation, git reported untracked files:
+Planned files for PR #10:
+
+```text
+backend/rag/context_packer.py
+backend/rag/retriever.py
+tests/unit/test_context_packer.py
+tests/unit/test_retriever.py
+docs/04_MEM/current_state.md
 ```
-backend/rag/__init__.py
-backend/rag/chunking.py
-tests/unit/test_chunking.py
-```
-These exist locally but git treats them as untracked on the `ops/memory-foundation` branch.
-After merging this PR, run:
+
+Current implementation summary:
+
+- `ContextPacker` is pure Python and deterministic.
+- It deduplicates retrieved chunks with Jaccard similarity over tokens.
+- It keeps the higher-scoring chunk when two chunks are near-duplicates.
+- It truncates context by token budget.
+- It reorders final chunks by document id and chunk index for prompt readability.
+- `Retriever` orchestrates query embedding, vector search, result conversion, packing, and latency logging.
+- Retriever dependencies are injected and testable with fakes.
+- No Ollama or Qdrant real service is required for unit tests.
+
+---
+
+## Latest Local Validation
+
+Run on 2026-04-26 from `/Users/fas/projetos/OPENCLAW`:
+
 ```bash
-git checkout main && git pull
+uv run pytest -v
 ```
-to realign local and remote.
+
+Result:
+
+```text
+31 passed, 3 subtests passed
+```
+
+```bash
+uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration
+```
+
+Result:
+
+```text
+Success: no issues found in 11 source files
+```
+
+```bash
+uv run pyright backend/rag tests/unit tests/integration
+```
+
+Result:
+
+```text
+0 errors, 0 warnings, 0 informations
+```
 
 ---
 
-## PR#3 Contract (Ready to Execute)
+## Next Action
 
-**Branch:** `feat/rag-ollama-embeddings`
+Claude should review and independently test PR #10 after Codex opens it.
 
-**File 1 — `backend/rag/embeddings.py`**
+Suggested Claude commands:
+
+```bash
+git fetch --prune
+git checkout feat/rag-retriever-context
+git pull --ff-only
+uv run pytest -v
+uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration
+uv run pyright backend/rag tests/unit tests/integration
+uv run python -m py_compile backend/rag/*.py tests/unit/*.py tests/integration/*.py
+rg -n "LangChain|sentence_transformers|openai|anthropic|remote" backend tests || true
 ```
-class OllamaEmbedder:
-  endpoint: POST http://localhost:11434/api/embed
-  body:     {"model": "nomic-embed-text", "input": [texts]}
-  response: {"embeddings": [[float, ...], ...]}
-  validate: len(embedding) == 768  (config.embedding.expected_dimensions)
-  retry:    3x backoff 1s → 2s → 4s
-  client:   httpx.AsyncClient, async, close() in destructor
-  raises:   EmbeddingError on wrong dimensions or persistent failure
-```
-
-**File 2 — `tests/unit/test_embeddings.py`** (5 tests, ALL mocked)
-1. `test_embed_returns_correct_dimensions`
-2. `test_embed_batch_multiple_texts`
-3. `test_embed_retry_on_timeout`
-4. `test_embed_raises_on_wrong_dimensions`
-5. `test_embed_empty_text`
-
-**Merge criteria:**
-- `pytest tests/unit/test_embeddings.py` → 5/5 (no Ollama needed)
-- `mypy backend/rag/embeddings.py --strict` → 0 errors
-- No `sentence_transformers` import
-- `httpx.AsyncClient` with proper `close()`
 
 ---
 
-## Environment
+## Remaining Risks
 
-| Service | Status |
-|---|---|
-| Ollama | ✅ installed — qwen3:14b + nomic-embed-text pulled |
-| Qdrant | ⚠️ needs `docker compose up` (docker-compose.qdrant.yml added in this PR) |
-| Python | 3.12 via uv |
-| mypy + pyright | ✅ installed in .venv |
-| httpx | ⚠️ will be available after `uv sync` (pyproject.toml added in this PR) |
+- PR #10 has not yet been reviewed by Claude.
+- Smoke tests with real Ollama + Docker Qdrant remain for later RAG-0 PRs.
+- No real data has been used or accessed.

--- a/tests/unit/test_context_packer.py
+++ b/tests/unit/test_context_packer.py
@@ -1,0 +1,128 @@
+import unittest
+
+from backend.rag.context_packer import ContextPacker, RetrievedChunk
+
+
+def chunk(
+    doc_id: str,
+    chunk_index: int,
+    text: str,
+    score: float,
+    token_count: int | None = None,
+    rank: int = 0,
+) -> RetrievedChunk:
+    return RetrievedChunk(
+        id=f"{doc_id}:{chunk_index}",
+        score=score,
+        doc_id=doc_id,
+        chunk_index=chunk_index,
+        text=text,
+        token_count=token_count or len(text.split()),
+        rank=rank,
+        payload={"source": "synthetic"},
+    )
+
+
+class ContextPackerTests(unittest.TestCase):
+    def test_empty_chunks_returns_empty_list(self) -> None:
+        packer = ContextPacker()
+
+        self.assertEqual(packer.pack([]), [])
+
+    def test_single_chunk_passes_through(self) -> None:
+        packer = ContextPacker(max_context_tokens=20)
+        item = chunk("doc-a", 0, "conteudo sintetico unico", 0.8)
+
+        self.assertEqual(packer.pack([item]), [item])
+
+    def test_dedup_removes_similar_and_keeps_higher_score(self) -> None:
+        packer = ContextPacker(
+            max_context_tokens=50,
+            dedup_similarity_threshold=0.75,
+        )
+        lower_score = chunk(
+            "doc-a",
+            0,
+            "Selic sintetica impacta renda fixa em cenario local",
+            0.70,
+            rank=1,
+        )
+        higher_score = chunk(
+            "doc-a",
+            1,
+            "Selic sintetica impacta renda fixa no cenario local",
+            0.91,
+            rank=2,
+        )
+        different = chunk(
+            "doc-b",
+            0,
+            "Rebalanceamento usa bandas de tolerancia",
+            0.65,
+            rank=3,
+        )
+
+        packed = packer.pack([lower_score, higher_score, different])
+
+        self.assertEqual([item.id for item in packed], ["doc-a:1", "doc-b:0"])
+
+    def test_token_limit_truncates_by_score_before_reordering(self) -> None:
+        packer = ContextPacker(max_context_tokens=8)
+        highest = chunk("doc-b", 3, "um dois tres quatro cinco", 0.95, token_count=5)
+        second = chunk("doc-a", 1, "seis sete oito", 0.90, token_count=3)
+        excluded = chunk("doc-a", 0, "nove dez onze", 0.80, token_count=3)
+
+        packed = packer.pack([excluded, second, highest])
+
+        self.assertEqual([item.id for item in packed], ["doc-a:1", "doc-b:3"])
+
+    def test_reorder_by_document_position(self) -> None:
+        packer = ContextPacker(max_context_tokens=50)
+        later = chunk("doc-a", 2, "terceiro trecho", 0.95)
+        earlier = chunk("doc-a", 0, "primeiro trecho", 0.70)
+        middle = chunk("doc-a", 1, "segundo trecho", 0.80)
+
+        packed = packer.pack([later, earlier, middle])
+
+        self.assertEqual([item.chunk_index for item in packed], [0, 1, 2])
+
+    def test_from_mapping_uses_payload_and_computes_token_count(self) -> None:
+        item = RetrievedChunk.from_mapping(
+            {
+                "id": "point-1",
+                "score": 0.88,
+                "payload": {
+                    "doc_id": "doc-a",
+                    "chunk_index": 4,
+                    "text": "texto sintetico com quatro tokens",
+                    "security_level": "Level 2",
+                },
+            },
+            rank=3,
+        )
+
+        self.assertEqual(item.id, "point-1")
+        self.assertEqual(item.doc_id, "doc-a")
+        self.assertEqual(item.chunk_index, 4)
+        self.assertEqual(item.token_count, 5)
+        self.assertEqual(item.rank, 3)
+        self.assertEqual(item.citation_id, "doc-a#4")
+
+    def test_validation_errors(self) -> None:
+        with self.assertRaises(ValueError):
+            ContextPacker(max_context_tokens=0)
+        with self.assertRaises(ValueError):
+            ContextPacker(dedup_similarity_threshold=1.5)
+        with self.assertRaises(ValueError):
+            RetrievedChunk.from_mapping(
+                {
+                    "score": 0.5,
+                    "doc_id": "doc-a",
+                    "chunk_index": -1,
+                    "text": "texto",
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.retriever import Retriever
+
+
+class FakeEmbedder:
+    def __init__(self) -> None:
+        self.seen_texts: list[str] = []
+
+    async def embed(self, text: str) -> list[float]:
+        self.seen_texts.append(text)
+        return [1.0, 0.0, 0.0]
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.seen_vector: Sequence[float] | None = None
+        self.seen_top_k: int | None = None
+        self.seen_threshold: float | None = None
+        self.seen_filters: Mapping[str, Any] | None = None
+
+    def search(
+        self,
+        vector: Sequence[float],
+        top_k: int = 5,
+        score_threshold: float | None = 0.3,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.seen_vector = vector
+        self.seen_top_k = top_k
+        self.seen_threshold = score_threshold
+        self.seen_filters = filters
+        return [
+            {
+                "id": "point-a",
+                "score": 0.91,
+                "doc_id": "doc-a",
+                "chunk_index": 1,
+                "text": "conteudo sintetico de selic",
+                "payload": {"token_count": 4, "source": "synthetic"},
+            },
+            {
+                "id": "point-b",
+                "score": 0.82,
+                "doc_id": "doc-a",
+                "chunk_index": 0,
+                "text": "introducao sintetica de selic",
+                "payload": {"token_count": 4, "source": "synthetic"},
+            },
+        ]
+
+
+class FakeAsyncStore:
+    def __init__(self) -> None:
+        self.delegate = FakeStore()
+
+    async def search(
+        self,
+        vector: Sequence[float],
+        top_k: int = 5,
+        score_threshold: float | None = 0.3,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        return self.delegate.search(
+            vector=vector,
+            top_k=top_k,
+            score_threshold=score_threshold,
+            filters=filters,
+        )
+
+
+class FakePacker:
+    def __init__(self) -> None:
+        self.seen_chunks: list[RetrievedChunk] = []
+
+    def pack(self, chunks: Sequence[RetrievedChunk]) -> list[RetrievedChunk]:
+        self.seen_chunks = list(chunks)
+        return sorted(self.seen_chunks, key=lambda chunk: chunk.chunk_index)
+
+
+class RetrieverTests(unittest.IsolatedAsyncioTestCase):
+    async def test_retrieve_orchestrates_embed_search_and_pack(self) -> None:
+        embedder = FakeEmbedder()
+        store = FakeStore()
+        packer = FakePacker()
+        retriever = Retriever(
+            embedder=embedder,
+            store=store,
+            packer=packer,
+            top_k=5,
+            score_threshold=0.4,
+        )
+
+        chunks = await retriever.retrieve(
+            "  Qual o impacto da Selic sintetica?  ",
+            top_k=2,
+            filters={"source": "synthetic"},
+        )
+
+        self.assertEqual(embedder.seen_texts, ["Qual o impacto da Selic sintetica?"])
+        self.assertEqual(store.seen_vector, [1.0, 0.0, 0.0])
+        self.assertEqual(store.seen_top_k, 2)
+        self.assertEqual(store.seen_threshold, 0.4)
+        self.assertEqual(store.seen_filters, {"source": "synthetic"})
+        self.assertEqual([chunk.rank for chunk in packer.seen_chunks], [1, 2])
+        self.assertEqual([chunk.chunk_index for chunk in chunks], [0, 1])
+        self.assertIsNotNone(retriever.last_timings)
+
+    async def test_retrieve_accepts_async_vector_store(self) -> None:
+        retriever = Retriever(
+            embedder=FakeEmbedder(),
+            store=FakeAsyncStore(),
+            packer=FakePacker(),
+        )
+
+        chunks = await retriever.retrieve("pergunta sintetica")
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].doc_id, "doc-a")
+
+    async def test_retrieve_uses_default_top_k_when_not_overridden(self) -> None:
+        store = FakeStore()
+        retriever = Retriever(
+            embedder=FakeEmbedder(),
+            store=store,
+            packer=FakePacker(),
+            top_k=7,
+            score_threshold=None,
+        )
+
+        await retriever.retrieve("pergunta sintetica")
+
+        self.assertEqual(store.seen_top_k, 7)
+        self.assertIsNone(store.seen_threshold)
+
+    async def test_retrieve_validates_question_and_top_k(self) -> None:
+        retriever = Retriever(
+            embedder=FakeEmbedder(),
+            store=FakeStore(),
+            packer=FakePacker(),
+        )
+
+        with self.assertRaises(ValueError):
+            await retriever.retrieve("   ")
+        with self.assertRaises(ValueError):
+            await retriever.retrieve("pergunta", top_k=0)
+
+    async def test_constructor_validates_options(self) -> None:
+        with self.assertRaises(ValueError):
+            Retriever(
+                embedder=FakeEmbedder(),
+                store=FakeStore(),
+                top_k=0,
+            )
+        with self.assertRaises(ValueError):
+            Retriever(
+                embedder=FakeEmbedder(),
+                store=FakeStore(),
+                score_threshold=1.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `ContextPacker` and `RetrievedChunk` for deterministic context selection.
- Adds `Retriever` to orchestrate local query embedding, Qdrant search result conversion, context packing, and latency logging.
- Adds mocked unit tests for packer and retriever; no real Ollama or Qdrant service required.
- Updates `docs/04_MEM/current_state.md` with the PR #10 handoff for Claude review.

## Security
- Local-only RAG-0 scope.
- No real portfolio data, private documents, secrets, or `.env` access.
- No remote AI fallback, no LangChain, no sentence-transformers.

## Validation
- `uv run pytest -v` -> 31 passed, 3 subtests passed
- `uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration` -> Success
- `uv run pyright backend/rag tests/unit tests/integration` -> 0 errors, 0 warnings
- `uv run python -m py_compile backend/rag/chunking.py backend/rag/embeddings.py backend/rag/qdrant_store.py backend/rag/context_packer.py backend/rag/retriever.py tests/unit/test_chunking.py tests/unit/test_embeddings.py tests/unit/test_context_packer.py tests/unit/test_retriever.py tests/integration/test_qdrant_store.py` -> passed
- `git diff --check` -> passed

## Claude Review Request
Please independently run the validation commands above and review the retrieval contract before this leaves draft.

Closes #10
