### PR TITLE
[RAG-05] feat/rag-local-pipeline-smoke: local pipeline + fake smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — OpenAI/Codex Memory Entry Point
+
+> Compact operational instructions for OpenAI agents working in OpenClaw.
+> The shared cross-agent memory lives in `docs/04_MEM/AGENT_CONTEXT.md`.
+
+## First Reads
+
+Start with the smallest useful context:
+
+1. `git status --short --branch`
+2. `docs/04_MEM/AGENT_CONTEXT.md`
+3. `docs/04_MEM/current_state.md`
+4. `docs/04_MEM/decisions.md`
+5. Task-specific files found with `rg`
+
+Do not read `.env`, `.env.*`, `.claude/`, secrets, caches, `.venv`, `dist`, or large generated files.
+
+## Prime Directive
+
+Quimera/OpenClaw is local-first and security-first.
+
+- Product name: Quimera.
+- Repository name: OpenClaw.
+- RAG-0 is local only.
+- Ollama is the local runtime.
+- Qwen model: `qwen3:14b`.
+- Embedding model: `nomic-embed-text`.
+- Vector database: Qdrant.
+- Python handles deterministic calculations.
+- GitHub is the source of truth for issues, PRs, branches, and merge state.
+
+## Forbidden Without Explicit Human Authorization
+
+- Modify `CLAUDE.md`.
+- Modify `.claude/`.
+- Read or modify `.env` or `.env.*`.
+- Access real portfolio data, real brokerage data, private documents, production databases, or secrets.
+- Add LiteLLM, FastAPI, Redis, MCP, or remote AI fallback.
+- Install dependencies.
+- Commit or push secrets.
+
+## Workflow
+
+Before changes:
+
+1. Restate the task.
+2. State risk level.
+3. List likely files to touch.
+4. State validation plan.
+5. Ask for confirmation when risk is medium/high or services/secrets/data/dependencies are affected.
+
+During changes:
+
+- Work one issue per session.
+- Prefer small branches and small diffs.
+- Use `rg` before opening files.
+- Stage only intended files.
+- Do not touch unrelated dirty worktree files.
+
+After changes:
+
+1. Files changed.
+2. What changed.
+3. What was intentionally not changed.
+4. Validation commands and results.
+5. Remaining risks.
+6. Next action for Claude/human review.
+
+## Current Pointer
+
+For the latest sprint state, always read:
+
+```bash
+sed -n '1,240p' docs/04_MEM/current_state.md
+```
+
+For durable coordination rules, read:
+
+```bash
+sed -n '1,260p' docs/04_MEM/AGENT_CONTEXT.md
+```

--- a/backend/rag/generator.py
+++ b/backend/rag/generator.py
@@ -1,0 +1,140 @@
+"""Local answer generation via Ollama chat API."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import httpx
+from loguru import logger
+
+
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+DEFAULT_GENERATION_MODEL = "qwen3:14b"
+DEFAULT_GENERATION_TIMEOUT_SECONDS = 120.0
+DEFAULT_TEMPERATURE = 0.2
+DEFAULT_MAX_TOKENS = 2048
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+class GenerationError(Exception):
+    """Raised when local generation returns an invalid response."""
+
+
+@dataclass
+class LocalGenerator:
+    """Small async client for local Ollama `/api/chat` generation."""
+
+    model: str = DEFAULT_GENERATION_MODEL
+    base_url: str = DEFAULT_OLLAMA_BASE_URL
+    timeout_seconds: float = DEFAULT_GENERATION_TIMEOUT_SECONDS
+    temperature: float = DEFAULT_TEMPERATURE
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    client: httpx.AsyncClient | None = None
+    _owns_client: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        if not self.model.strip():
+            raise ValueError("model cannot be empty")
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be greater than zero")
+        if not 0.0 <= self.temperature <= 2.0:
+            raise ValueError("temperature must be between 0.0 and 2.0")
+        if self.max_tokens <= 0:
+            raise ValueError("max_tokens must be greater than zero")
+
+        self.base_url = self.base_url.rstrip("/")
+        if self.client is None:
+            self.client = httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=httpx.Timeout(self.timeout_seconds),
+            )
+            self._owns_client = True
+
+    async def __aenter__(self) -> LocalGenerator:
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the owned HTTP client."""
+
+        if self._owns_client and self.client is not None:
+            await self.client.aclose()
+
+    async def chat(
+        self,
+        messages: Sequence[dict[str, str]],
+        temperature: float | None = None,
+        thinking_mode: bool = False,
+    ) -> str:
+        """Generate one local answer with Ollama chat API."""
+
+        if self.client is None:
+            raise RuntimeError("HTTP client is not initialized")
+
+        clean_messages = _validate_messages(messages)
+        effective_temperature = self.temperature if temperature is None else temperature
+        if not 0.0 <= effective_temperature <= 2.0:
+            raise ValueError("temperature must be between 0.0 and 2.0")
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": clean_messages,
+            "stream": False,
+            "options": {
+                "temperature": effective_temperature,
+                "num_predict": self.max_tokens,
+            },
+        }
+        start = time.perf_counter()
+        response = await self.client.post("/api/chat", json=payload)
+        response.raise_for_status()
+        body = cast(dict[str, Any], response.json())
+        answer = _extract_answer(body)
+        if not thinking_mode:
+            answer = _strip_thinking(answer)
+
+        logger.debug(
+            "generate | model={} chars={} latency={:.1f}ms",
+            self.model,
+            len(answer),
+            (time.perf_counter() - start) * 1000,
+        )
+        return answer
+
+
+def _validate_messages(messages: Sequence[dict[str, str]]) -> list[dict[str, str]]:
+    if not messages:
+        raise ValueError("messages cannot be empty")
+
+    clean_messages: list[dict[str, str]] = []
+    for message in messages:
+        role = message.get("role", "").strip()
+        content = message.get("content", "").strip()
+        if role not in {"system", "user", "assistant"}:
+            raise ValueError("message role must be system, user, or assistant")
+        if not content:
+            raise ValueError("message content cannot be empty")
+        clean_messages.append({"role": role, "content": content})
+    return clean_messages
+
+
+def _extract_answer(body: dict[str, Any]) -> str:
+    message = body.get("message")
+    if not isinstance(message, dict):
+        raise GenerationError("Ollama response did not include message")
+
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise GenerationError("Ollama response message content is empty")
+    return content.strip()
+
+
+def _strip_thinking(answer: str) -> str:
+    return _THINK_BLOCK_RE.sub("", answer).strip()

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -1,0 +1,135 @@
+"""End-to-end local RAG pipeline orchestration."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loguru import logger
+
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.prompt_builder import PromptBuilder
+
+
+class RetrieverProtocol(Protocol):
+    """Minimal retrieval interface required by the local RAG pipeline."""
+
+    def retrieve(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> Awaitable[list[RetrievedChunk]]:
+        """Return packed chunks for a question."""
+        ...
+
+
+class GeneratorProtocol(Protocol):
+    """Minimal generation interface required by the local RAG pipeline."""
+
+    def chat(
+        self,
+        messages: Sequence[dict[str, str]],
+        temperature: float | None = None,
+        thinking_mode: bool = False,
+    ) -> Awaitable[str]:
+        """Generate an answer from chat messages."""
+        ...
+
+
+@dataclass(frozen=True)
+class RagPipelineResult:
+    """Final local RAG answer with citations and latency metadata."""
+
+    question: str
+    answer: str
+    chunks_used: list[RetrievedChunk]
+    messages: list[dict[str, str]]
+    latency_ms: dict[str, float]
+
+    @property
+    def citations(self) -> list[str]:
+        """Return citation ids for chunks used in the answer context."""
+
+        return [chunk.citation_id for chunk in self.chunks_used]
+
+
+@dataclass
+class LocalRagPipeline:
+    """Compose retrieval, prompt construction, and local generation."""
+
+    retriever: RetrieverProtocol
+    generator: GeneratorProtocol
+    prompt_builder: PromptBuilder
+    temperature: float | None = None
+    thinking_mode: bool = False
+
+    async def ask(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> RagPipelineResult:
+        """Run retrieval, build a prompt, and generate a local answer."""
+
+        clean_question = _validate_question(question)
+        total_start = time.perf_counter()
+
+        retrieval_start = time.perf_counter()
+        chunks = await self.retriever.retrieve(
+            clean_question,
+            top_k=top_k,
+            filters=filters,
+        )
+        retrieval_ms = _elapsed_ms(retrieval_start)
+
+        prompt_start = time.perf_counter()
+        messages = self.prompt_builder.build(
+            clean_question,
+            chunks,
+            thinking_mode=self.thinking_mode,
+        )
+        prompt_ms = _elapsed_ms(prompt_start)
+
+        generation_start = time.perf_counter()
+        answer = await self.generator.chat(
+            messages,
+            temperature=self.temperature,
+            thinking_mode=self.thinking_mode,
+        )
+        generation_ms = _elapsed_ms(generation_start)
+
+        latency = {
+            "retrieval_ms": retrieval_ms,
+            "prompt_ms": prompt_ms,
+            "generation_ms": generation_ms,
+            "total_ms": _elapsed_ms(total_start),
+        }
+        logger.info(
+            "rag_pipeline | chunks={} citations={} latency={}",
+            len(chunks),
+            [chunk.citation_id for chunk in chunks],
+            latency,
+        )
+        return RagPipelineResult(
+            question=clean_question,
+            answer=answer,
+            chunks_used=list(chunks),
+            messages=messages,
+            latency_ms=latency,
+        )
+
+
+def _validate_question(question: str) -> str:
+    if not isinstance(question, str):
+        raise TypeError("question must be a string")
+    clean_question = question.strip()
+    if not clean_question:
+        raise ValueError("question cannot be empty or whitespace")
+    return clean_question
+
+
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000

--- a/backend/rag/prompt_builder.py
+++ b/backend/rag/prompt_builder.py
@@ -1,0 +1,83 @@
+"""Prompt construction for local RAG answers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from backend.rag.context_packer import RetrievedChunk
+
+
+DEFAULT_SYSTEM_PROMPT = """Voce e o assistente local do OpenClaw.
+Responda somente com base no CONTEXTO recuperado.
+Nao use conhecimento externo para fatos especificos.
+Se o contexto nao sustentar a resposta, diga:
+"Nao ha contexto local suficiente para responder com seguranca."
+Cite fontes no formato [doc_id#chunk_index].
+Nunca peca nem revele dados reais de carteira, credenciais ou documentos privados.
+"""
+
+NO_CONTEXT_MESSAGE = (
+    "Nao ha contexto local recuperado. Responda apenas que nao ha contexto local "
+    "suficiente para responder com seguranca."
+)
+
+
+@dataclass(frozen=True)
+class PromptBuilder:
+    """Build Ollama chat messages from retrieved local context."""
+
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT
+    no_context_message: str = NO_CONTEXT_MESSAGE
+
+    def build(
+        self,
+        question: str,
+        chunks: Sequence[RetrievedChunk],
+        thinking_mode: bool = False,
+    ) -> list[dict[str, str]]:
+        """Return chat messages with recovered context and citation rules."""
+
+        clean_question = _validate_question(question)
+        context = self._format_context(chunks)
+        thinking_directive = "/think" if thinking_mode else "/no_think"
+        user_content = (
+            f"{thinking_directive}\n\n"
+            f"PERGUNTA:\n{clean_question}\n\n"
+            f"CONTEXTO RECUPERADO:\n{context}\n\n"
+            "INSTRUCOES DE RESPOSTA:\n"
+            "- Responda em portugues brasileiro.\n"
+            "- Use apenas o contexto recuperado.\n"
+            "- Inclua citacoes no formato [doc_id#chunk_index].\n"
+            "- Se o contexto for insuficiente, diga isso claramente."
+        )
+
+        return [
+            {"role": "system", "content": self.system_prompt.strip()},
+            {"role": "user", "content": user_content},
+        ]
+
+    def _format_context(self, chunks: Sequence[RetrievedChunk]) -> str:
+        if not chunks:
+            return self.no_context_message
+
+        blocks = []
+        for chunk in chunks:
+            blocks.append(
+                "\n".join(
+                    [
+                        f"[{chunk.citation_id}] (score: {chunk.score:.3f})",
+                        chunk.text.strip(),
+                    ]
+                )
+            )
+        return "\n\n---\n\n".join(blocks)
+
+
+def _validate_question(question: str) -> str:
+    if not isinstance(question, str):
+        raise TypeError("question must be a string")
+    clean_question = question.strip()
+    if not clean_question:
+        raise ValueError("question cannot be empty or whitespace")
+    return clean_question

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -132,8 +132,8 @@ Near-term PR sequence:
 | RAG-01 | `feat/rag-chunking-*` | Chunking + tests | Merged ✅ |
 | RAG-02 | `feat/rag-embeddings` | Ollama embeddings + tests | Merged ✅ |
 | RAG-03 | `feat/rag-qdrant-store` | Qdrant store + integration tests | Merged ✅ |
-| RAG-04 | `feat/rag-retriever-context` | Retriever + ContextPacker | PR #11 — ready to merge |
-| RAG-05 | `feat/rag-prompt-generator` | PromptBuilder + LocalGenerator | Next |
+| RAG-04 | `feat/rag-retriever-context` | Retriever + ContextPacker | Merged ✅ |
+| RAG-05 | `feat/rag-local-pipeline-smoke` | PromptBuilder + LocalGenerator + fake smoke | Active PR prep |
 | RAG-06 | `feat/rag-cli-smoke` | Synthetic ingest/query CLI + smoke | Planned |
 | RAG-07 | `feat/rag-docs-runbook` | Runbook + ADR + final checklist | Planned |
 
@@ -309,3 +309,35 @@ Append or paste this at the end of substantial sessions:
 ### Risks
 - Smoke tests with real Ollama + Docker Qdrant remain for RAG-06.
 - None known for this PR.
+
+---
+
+## Handoff — 2026-04-26
+
+**Agent:** Codex
+**Branch:** `feat/rag-local-pipeline-smoke`
+**Issue/PR:** #12 / PR pending
+**Task:** RAG-05 — close local RAG path with prompt, local generator, pipeline, and fake smoke test.
+
+### Changed
+- `backend/rag/prompt_builder.py`: builds local RAG chat messages with `/no_think`, context blocks, and citations.
+- `backend/rag/generator.py`: adds local Ollama `/api/chat` client with `stream=false`, timeout, temperature, and `<think>` stripping when thinking mode is off.
+- `backend/rag/pipeline.py`: orchestrates retriever -> prompt builder -> generator and returns answer, chunks, citations, messages, and latency.
+- `tests/unit/test_prompt_builder.py`: prompt formatting tests.
+- `tests/unit/test_generator.py`: mocked Ollama chat tests.
+- `tests/smoke/test_rag_pipeline_smoke.py`: fake end-to-end smoke test with no Ollama/Qdrant requirement.
+- `AGENTS.md`: compact OpenAI/Codex memory entrypoint.
+
+### Validation
+- Targeted PR tests passed: 12 passed.
+- mypy strict on new files passed.
+- pyright on new files passed.
+
+### Not Changed
+- `CLAUDE.md`, `.claude/`, `.env`, dependencies, real data, and remote AI untouched.
+
+### Next Action
+- Run full validation, commit, push, and open draft PR for Claude independent testing.
+
+### Risks
+- Real Ollama + real Qdrant end-to-end remains for a later smoke/CLI PR.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,7 +4,7 @@
 > Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of meaningful sessions.
 
 **Last updated:** 2026-04-26
-**Updated by:** Codex — PR #10 preparation
+**Updated by:** Codex — RAG-05 local pipeline smoke prep
 
 ---
 
@@ -24,15 +24,15 @@
 
 | RAG step | Branch | State | Scope |
 |---|---|---|---|
-| RAG-01 | `feat/rag-chunking-*` | Merged | `chunking.py` + unit tests |
-| RAG-02 | `feat/rag-embeddings` | Merged | `OllamaEmbedder` + mocked unit tests |
-| RAG-03 | `feat/rag-qdrant-store` | Merged | `QdrantVectorStore` + integration tests |
-| RAG-04 | `feat/rag-retriever-context` | In review prep | `ContextPacker` + `Retriever` + unit tests |
-| RAG-05 | `feat/rag-prompt-generator` | Next | Prompt builder + local generator |
-| RAG-06 | `feat/rag-cli-smoke` | Planned | Synthetic ingest/query CLI + smoke tests |
+| RAG-01 | `feat/rag-chunking-*` | Merged | Chunking + unit tests |
+| RAG-02 | `feat/rag-embeddings` | Merged | Ollama embeddings + mocked unit tests |
+| RAG-03 | `feat/rag-qdrant-store` | Merged | Qdrant store + integration tests |
+| RAG-04 | `feat/rag-retriever-context` | Merged | Retriever + ContextPacker |
+| RAG-05 | `feat/rag-local-pipeline-smoke` | Active PR prep | PromptBuilder + LocalGenerator + LocalRagPipeline + fake smoke |
+| RAG-06 | `feat/rag-cli-smoke` | Planned | Synthetic ingest/query CLI + real local smoke |
 | RAG-07 | `feat/rag-docs-runbook` | Planned | Runbook + ADR + final checklist |
 
-Current issue for active work: <https://github.com/franciscosalido/OPENCLAW/issues/10>
+Current issue for active work: <https://github.com/franciscosalido/OPENCLAW/issues/12>
 
 ---
 
@@ -42,12 +42,16 @@ Current issue for active work: <https://github.com/franciscosalido/OPENCLAW/issu
 backend/rag/
   __init__.py
   chunking.py
+  context_packer.py
   embeddings.py
   qdrant_store.py
+  retriever.py
 
 tests/
   unit/test_chunking.py
+  unit/test_context_packer.py
   unit/test_embeddings.py
+  unit/test_retriever.py
   integration/test_qdrant_store.py
 
 config/rag_config.yaml
@@ -60,57 +64,58 @@ docs/04_MEM/next_actions.md
 
 ---
 
-## Active Branch: `feat/rag-retriever-context`
+## Active Branch: `feat/rag-local-pipeline-smoke`
 
-Planned files for PR #10:
+Planned files for PR #12:
 
 ```text
-backend/rag/context_packer.py
-backend/rag/retriever.py
-tests/unit/test_context_packer.py
-tests/unit/test_retriever.py
+backend/rag/prompt_builder.py
+backend/rag/generator.py
+backend/rag/pipeline.py
+tests/unit/test_prompt_builder.py
+tests/unit/test_generator.py
+tests/smoke/test_rag_pipeline_smoke.py
+AGENTS.md
+docs/04_MEM/AGENT_CONTEXT.md
 docs/04_MEM/current_state.md
 ```
 
 Current implementation summary:
 
-- `ContextPacker` is pure Python and deterministic.
-- It deduplicates retrieved chunks with Jaccard similarity over tokens.
-- It keeps the higher-scoring chunk when two chunks are near-duplicates.
-- It truncates context by token budget.
-- It reorders final chunks by document id and chunk index for prompt readability.
-- `Retriever` orchestrates query embedding, vector search, result conversion, packing, and latency logging.
-- Retriever dependencies are injected and testable with fakes.
-- No Ollama or Qdrant real service is required for unit tests.
+- `PromptBuilder` formats context blocks with citations and uses `/no_think` by default.
+- `LocalGenerator` calls Ollama `/api/chat` with `stream=false` and can be fully mocked.
+- `LocalRagPipeline` orchestrates retrieval, prompt building, local generation, chunks used, citations, and latency.
+- Fake smoke test validates the complete flow without real Ollama or Qdrant.
+- Real local service smoke remains for a later CLI/smoke PR.
 
 ---
 
 ## Latest Local Validation
 
-Run on 2026-04-26 from `/Users/fas/projetos/OPENCLAW`:
+Targeted RAG-05 checks already passed:
 
 ```bash
-uv run pytest -v
+uv run pytest tests/unit/test_prompt_builder.py tests/unit/test_generator.py tests/smoke/test_rag_pipeline_smoke.py -v
 ```
 
 Result:
 
 ```text
-31 passed, 3 subtests passed
+12 passed
 ```
 
 ```bash
-uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration
+uv run mypy --explicit-package-bases --strict backend/rag/prompt_builder.py backend/rag/generator.py backend/rag/pipeline.py tests/unit/test_prompt_builder.py tests/unit/test_generator.py tests/smoke/test_rag_pipeline_smoke.py
 ```
 
 Result:
 
 ```text
-Success: no issues found in 11 source files
+Success: no issues found in 6 source files
 ```
 
 ```bash
-uv run pyright backend/rag tests/unit tests/integration
+uv run pyright backend/rag/prompt_builder.py backend/rag/generator.py backend/rag/pipeline.py tests/unit/test_prompt_builder.py tests/unit/test_generator.py tests/smoke/test_rag_pipeline_smoke.py
 ```
 
 Result:
@@ -123,18 +128,18 @@ Result:
 
 ## Next Action
 
-Claude should review and independently test PR #10 after Codex opens it.
+Codex should run full validation, open a draft PR, and hand it to Claude for independent testing.
 
-Suggested Claude commands:
+Suggested Claude commands after PR opens:
 
 ```bash
 git fetch --prune
-git checkout feat/rag-retriever-context
+git checkout feat/rag-local-pipeline-smoke
 git pull --ff-only
 uv run pytest -v
-uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration
-uv run pyright backend/rag tests/unit tests/integration
-uv run python -m py_compile backend/rag/*.py tests/unit/*.py tests/integration/*.py
+uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration tests/smoke
+uv run pyright backend/rag tests/unit tests/integration tests/smoke
+uv run python -m py_compile backend/rag/*.py tests/unit/*.py tests/integration/*.py tests/smoke/*.py
 rg -n "LangChain|sentence_transformers|openai|anthropic|remote" backend tests || true
 ```
 
@@ -142,6 +147,6 @@ rg -n "LangChain|sentence_transformers|openai|anthropic|remote" backend tests ||
 
 ## Remaining Risks
 
-- PR #10 has not yet been reviewed by Claude.
-- Smoke tests with real Ollama + Docker Qdrant remain for later RAG-0 PRs.
+- PR has not yet been reviewed by Claude.
+- Real Ollama + Docker Qdrant end-to-end remains for RAG-06.
 - No real data has been used or accessed.

--- a/tests/smoke/test_rag_pipeline_smoke.py
+++ b/tests/smoke/test_rag_pipeline_smoke.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+
+
+class FakeRetriever:
+    def __init__(self) -> None:
+        self.last_timings: dict[str, float] | None = None
+        self.seen_question: str | None = None
+        self.seen_top_k: int | None = None
+
+    async def retrieve(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[RetrievedChunk]:
+        self.seen_question = question
+        self.seen_top_k = top_k
+        self.last_timings = {"embed_ms": 1.0, "search_ms": 2.0, "pack_ms": 1.0}
+        return [
+            RetrievedChunk(
+                id="selic:0",
+                score=0.91,
+                doc_id="selic_sintetica",
+                chunk_index=0,
+                text=(
+                    "Documento sintetico: Selic mais alta tende a elevar a "
+                    "atratividade relativa da renda fixa local."
+                ),
+                token_count=14,
+                rank=1,
+                payload={"source": "synthetic"},
+            ),
+            RetrievedChunk(
+                id="rebalanceamento:1",
+                score=0.74,
+                doc_id="rebalanceamento_sintetico",
+                chunk_index=1,
+                text=(
+                    "Documento sintetico: rebalanceamento pode usar bandas "
+                    "predefinidas para reduzir decisoes emocionais."
+                ),
+                token_count=13,
+                rank=2,
+                payload={"source": "synthetic"},
+            ),
+        ]
+
+
+class FakeGenerator:
+    def __init__(self) -> None:
+        self.seen_messages: Sequence[dict[str, str]] = []
+        self.seen_thinking_mode: bool | None = None
+
+    async def chat(
+        self,
+        messages: Sequence[dict[str, str]],
+        temperature: float | None = None,
+        thinking_mode: bool = False,
+    ) -> str:
+        self.seen_messages = messages
+        self.seen_thinking_mode = thinking_mode
+        return (
+            "Com base no contexto local sintetico, Selic mais alta favorece "
+            "renda fixa em relacao a ativos de maior risco [selic_sintetica#0]. "
+            "O rebalanceamento deve seguir bandas previamente definidas "
+            "[rebalanceamento_sintetico#1]."
+        )
+
+
+class LocalRagPipelineSmokeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pipeline_returns_answer_citations_chunks_and_latency(self) -> None:
+        retriever = FakeRetriever()
+        generator = FakeGenerator()
+        pipeline = LocalRagPipeline(
+            retriever=retriever,
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            thinking_mode=False,
+        )
+
+        result = await pipeline.ask(
+            "Qual o impacto sintetico da Selic?",
+            top_k=2,
+            filters={"source": "synthetic"},
+        )
+
+        self.assertGreater(len(result.answer), 50)
+        self.assertIn("[selic_sintetica#0]", result.answer)
+        self.assertIn("[rebalanceamento_sintetico#1]", result.answer)
+        self.assertEqual(result.citations, ["selic_sintetica#0", "rebalanceamento_sintetico#1"])
+        self.assertEqual(len(result.chunks_used), 2)
+        self.assertEqual(retriever.seen_question, "Qual o impacto sintetico da Selic?")
+        self.assertEqual(retriever.seen_top_k, 2)
+        self.assertFalse(generator.seen_thinking_mode)
+        self.assertIn("/no_think", generator.seen_messages[1]["content"])
+        self.assertGreaterEqual(result.latency_ms["retrieval_ms"], 0.0)
+        self.assertGreaterEqual(result.latency_ms["prompt_ms"], 0.0)
+        self.assertGreaterEqual(result.latency_ms["generation_ms"], 0.0)
+        self.assertGreaterEqual(result.latency_ms["total_ms"], 0.0)
+
+    async def test_pipeline_rejects_empty_question(self) -> None:
+        pipeline = LocalRagPipeline(
+            retriever=FakeRetriever(),
+            generator=FakeGenerator(),
+            prompt_builder=PromptBuilder(),
+        )
+
+        with self.assertRaises(ValueError):
+            await pipeline.ask("   ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+import httpx
+
+from backend.rag.generator import GenerationError, LocalGenerator
+
+
+class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_chat_posts_to_ollama_chat_endpoint(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            self.assertEqual(request.url.path, "/api/chat")
+            return httpx.Response(
+                200,
+                json={"message": {"content": "Resposta com [doc-a#0]."}},
+            )
+
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            generator = LocalGenerator(
+                client=client,
+                model="qwen3:14b",
+                max_tokens=128,
+            )
+            answer = await generator.chat(
+                [
+                    {"role": "system", "content": "sistema"},
+                    {"role": "user", "content": "/no_think pergunta"},
+                ]
+            )
+
+        self.assertEqual(answer, "Resposta com [doc-a#0].")
+        self.assertEqual(seen_payloads[0]["model"], "qwen3:14b")
+        self.assertEqual(seen_payloads[0]["stream"], False)
+        self.assertEqual(seen_payloads[0]["options"], {"temperature": 0.2, "num_predict": 128})
+
+    async def test_chat_strips_thinking_blocks_when_disabled(self) -> None:
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    json={
+                        "message": {
+                            "content": "<think>rascunho interno</think>Resposta final [doc-a#0]."
+                        }
+                    },
+                )
+            ),
+        ) as client:
+            generator = LocalGenerator(client=client)
+            answer = await generator.chat(
+                [{"role": "user", "content": "pergunta sintetica"}],
+                thinking_mode=False,
+            )
+
+        self.assertEqual(answer, "Resposta final [doc-a#0].")
+
+    async def test_chat_keeps_thinking_blocks_when_enabled(self) -> None:
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    json={
+                        "message": {
+                            "content": "<think>rascunho</think>Resposta final [doc-a#0]."
+                        }
+                    },
+                )
+            ),
+        ) as client:
+            generator = LocalGenerator(client=client)
+            answer = await generator.chat(
+                [{"role": "user", "content": "pergunta sintetica"}],
+                thinking_mode=True,
+            )
+
+        self.assertIn("<think>rascunho</think>", answer)
+
+    async def test_invalid_response_raises_generation_error(self) -> None:
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(200, json={"message": {}})
+            ),
+        ) as client:
+            generator = LocalGenerator(client=client)
+            with self.assertRaises(GenerationError):
+                await generator.chat([{"role": "user", "content": "pergunta"}])
+
+    async def test_validation_errors(self) -> None:
+        with self.assertRaises(ValueError):
+            LocalGenerator(model="")
+        with self.assertRaises(ValueError):
+            LocalGenerator(timeout_seconds=0)
+        with self.assertRaises(ValueError):
+            LocalGenerator(temperature=3.0)
+        with self.assertRaises(ValueError):
+            LocalGenerator(max_tokens=0)
+
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200)),
+        ) as client:
+            generator = LocalGenerator(client=client)
+            with self.assertRaises(ValueError):
+                await generator.chat([])
+            with self.assertRaises(ValueError):
+                await generator.chat([{"role": "tool", "content": "x"}])
+            with self.assertRaises(ValueError):
+                await generator.chat([{"role": "user", "content": "x"}], temperature=3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -1,0 +1,72 @@
+import unittest
+
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.prompt_builder import PromptBuilder
+
+
+def chunk(doc_id: str = "doc-a", chunk_index: int = 0) -> RetrievedChunk:
+    return RetrievedChunk(
+        id=f"{doc_id}:{chunk_index}",
+        score=0.87,
+        doc_id=doc_id,
+        chunk_index=chunk_index,
+        text="Conteudo sintetico sobre Selic e renda fixa.",
+        token_count=7,
+        rank=1,
+        payload={"source": "synthetic"},
+    )
+
+
+class PromptBuilderTests(unittest.TestCase):
+    def test_factual_prompt_uses_no_think_and_citations(self) -> None:
+        builder = PromptBuilder()
+
+        messages = builder.build("Qual o impacto da Selic?", [chunk()])
+
+        self.assertEqual([message["role"] for message in messages], ["system", "user"])
+        self.assertIn("/no_think", messages[1]["content"])
+        self.assertIn("[doc-a#0]", messages[1]["content"])
+        self.assertIn("Qual o impacto da Selic?", messages[1]["content"])
+
+    def test_thinking_prompt_uses_think_directive(self) -> None:
+        builder = PromptBuilder()
+
+        messages = builder.build(
+            "Analise o contexto sintetico.",
+            [chunk()],
+            thinking_mode=True,
+        )
+
+        self.assertIn("/think", messages[1]["content"])
+        self.assertNotIn("/no_think", messages[1]["content"])
+
+    def test_zero_chunks_includes_insufficient_context_instruction(self) -> None:
+        builder = PromptBuilder()
+
+        messages = builder.build("Pergunta sem contexto?", [])
+
+        self.assertIn("Nao ha contexto local recuperado", messages[1]["content"])
+        self.assertIn("contexto local suficiente", messages[1]["content"])
+
+    def test_multiple_chunks_are_separated_and_scored(self) -> None:
+        builder = PromptBuilder()
+
+        messages = builder.build(
+            "Compare os trechos.",
+            [chunk("doc-a", 0), chunk("doc-b", 2)],
+        )
+
+        user_content = messages[1]["content"]
+        self.assertIn("[doc-a#0] (score: 0.870)", user_content)
+        self.assertIn("[doc-b#2] (score: 0.870)", user_content)
+        self.assertIn("---", user_content)
+
+    def test_rejects_empty_question(self) -> None:
+        builder = PromptBuilder()
+
+        with self.assertRaises(ValueError):
+            builder.build("  ", [chunk()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `PromptBuilder` for local RAG messages with `/no_think`, context blocks, and source citations.
- Adds `LocalGenerator` for local Ollama `/api/chat` with `stream=false`, timeout/temperature controls, and optional thinking-block stripping.
- Adds `LocalRagPipeline` to orchestrate retrieval -> prompt -> generation and return answer, chunks used, citations, messages, and latency.
- Adds a fake end-to-end smoke test that requires no real Ollama or Qdrant services.
- Adds compact root `AGENTS.md` for OpenAI/Codex memory and updates shared `docs/04_MEM` state.

## Security
- RAG-0 remains local-only.
- No LiteLLM, Redis, FastAPI, remote providers, LangChain, or sentence-transformers.
- No `.env`, secrets, real portfolio data, real brokerage data, or private documents accessed.

## Validation
- `uv run pytest -v` -> 43 passed, 3 subtests passed
- `uv run mypy --explicit-package-bases --strict backend/rag tests/unit tests/integration tests/smoke` -> Success
- `uv run pyright backend/rag tests/unit tests/integration tests/smoke` -> 0 errors, 0 warnings
- `uv run python -m py_compile backend/rag/*.py tests/unit/*.py tests/integration/*.py tests/smoke/*.py` -> passed
- `git diff --check` -> passed
- forbidden import/provider scan -> no implementation hits

## Claude Review Request
Please independently run the validation commands above. This should merge only if Claude gets 100% green.

Closes #12
