### PR TITLE
feat(gateway): Gateway-0 — LiteLLM routing, contracts, infra, smoke tests (GW-01–04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ logs/
 *.claude_session
 .claude/todos/
 .claude/cache/
+.claude/worktrees/
 
 # claude-mem — banco de dados e estado local (ficam em ~/.claude-mem/, nunca no repo)
 claude-mem.db

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""OpenClaw backend package."""

--- a/backend/gateway/__init__.py
+++ b/backend/gateway/__init__.py
@@ -1,0 +1,61 @@
+"""Gateway contracts for Quimera/OpenClaw model routing.
+
+Runtime chat calls route through the local LiteLLM gateway. Gateway-0 establishes:
+
+* Domain exceptions (errors.py) — stable error taxonomy isolated from LiteLLM
+  internals.
+* Configuration schema (config.py) — Pydantic validation of
+  litellm_config.yaml; rejects remote providers and missing aliases at load
+  time.
+* Semantic health checks (health.py) — verifies Ollama is running *and* the
+  required models are loaded, not just that the HTTP port is open.
+"""
+
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_JSON_MODEL,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_RAG_MODEL,
+    DEFAULT_LLM_REASONING_MODEL,
+    GatewayChatClient,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.config import GatewayConfig, load_gateway_config
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConnectionError,
+    GatewayConfigurationError,
+    GatewayError,
+    GatewayModelAliasError,
+    GatewayProviderUnavailableError,
+    GatewayRequestRejectedError,
+    GatewayResponseError,
+    GatewayTimeoutError,
+)
+from backend.gateway.health import check_gateway_services, check_litellm_gateway
+
+__all__ = [
+    # Config
+    "DEFAULT_LLM_BASE_URL",
+    "DEFAULT_LLM_JSON_MODEL",
+    "DEFAULT_LLM_MODEL",
+    "DEFAULT_LLM_RAG_MODEL",
+    "DEFAULT_LLM_REASONING_MODEL",
+    "GatewayChatClient",
+    "GatewayConfig",
+    "GatewayRuntimeConfig",
+    "load_gateway_config",
+    # Health
+    "check_gateway_services",
+    "check_litellm_gateway",
+    # Errors
+    "GatewayAuthenticationError",
+    "GatewayConnectionError",
+    "GatewayConfigurationError",
+    "GatewayError",
+    "GatewayModelAliasError",
+    "GatewayProviderUnavailableError",
+    "GatewayRequestRejectedError",
+    "GatewayResponseError",
+    "GatewayTimeoutError",
+]

--- a/backend/gateway/client.py
+++ b/backend/gateway/client.py
@@ -1,0 +1,291 @@
+"""OpenAI-compatible client for the local LiteLLM gateway."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+from urllib.parse import urlparse
+
+import httpx
+from loguru import logger
+
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConfigurationError,
+    GatewayConnectionError,
+    GatewayResponseError,
+    GatewayTimeoutError,
+)
+from backend.gateway.messages import validate_chat_messages
+
+
+DEFAULT_LLM_BASE_URL = "http://127.0.0.1:4000/v1"
+DEFAULT_LLM_MODEL = "local_chat"
+DEFAULT_LLM_REASONING_MODEL = "local_think"
+DEFAULT_LLM_RAG_MODEL = "local_rag"
+DEFAULT_LLM_JSON_MODEL = "local_json"
+DEFAULT_LLM_TIMEOUT_SECONDS = 120.0
+
+ENV_LLM_BASE_URL = "QUIMERA_LLM_BASE_URL"
+ENV_LLM_API_KEY = "QUIMERA_LLM_API_KEY"
+ENV_LLM_MODEL = "QUIMERA_LLM_MODEL"
+ENV_LLM_REASONING_MODEL = "QUIMERA_LLM_REASONING_MODEL"
+ENV_LLM_RAG_MODEL = "QUIMERA_LLM_RAG_MODEL"
+ENV_LLM_JSON_MODEL = "QUIMERA_LLM_JSON_MODEL"
+
+_LOCAL_BASE_PREFIXES = ("http://127.0.0.1:", "http://localhost:")
+
+
+@dataclass(frozen=True)
+class GatewayRuntimeConfig:
+    """Runtime configuration for OpenClaw -> LiteLLM model calls."""
+
+    base_url: str = DEFAULT_LLM_BASE_URL
+    api_key: str | None = None
+    default_model: str = DEFAULT_LLM_MODEL
+    reasoning_model: str = DEFAULT_LLM_REASONING_MODEL
+    rag_model: str = DEFAULT_LLM_RAG_MODEL
+    json_model: str = DEFAULT_LLM_JSON_MODEL
+    timeout_seconds: float = DEFAULT_LLM_TIMEOUT_SECONDS
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> GatewayRuntimeConfig:
+        """Load runtime gateway settings from environment variables."""
+        values = os.environ if env is None else env
+        return cls(
+            base_url=values.get(ENV_LLM_BASE_URL, DEFAULT_LLM_BASE_URL),
+            api_key=values.get(ENV_LLM_API_KEY),
+            default_model=values.get(ENV_LLM_MODEL, DEFAULT_LLM_MODEL),
+            reasoning_model=values.get(
+                ENV_LLM_REASONING_MODEL,
+                DEFAULT_LLM_REASONING_MODEL,
+            ),
+            rag_model=values.get(ENV_LLM_RAG_MODEL, DEFAULT_LLM_RAG_MODEL),
+            json_model=values.get(ENV_LLM_JSON_MODEL, DEFAULT_LLM_JSON_MODEL),
+        )
+
+    def validated(self) -> GatewayRuntimeConfig:
+        """Return a normalized config or raise a clear setup error."""
+        base_url = self.base_url.rstrip("/")
+        if not any(base_url.startswith(prefix) for prefix in _LOCAL_BASE_PREFIXES):
+            raise GatewayConfigurationError(
+                "QUIMERA_LLM_BASE_URL must point to the local LiteLLM gateway "
+                f"at {DEFAULT_LLM_BASE_URL}. Got: {base_url!r}"
+            )
+        if not self.api_key or not self.api_key.strip():
+            raise GatewayAuthenticationError(
+                "QUIMERA_LLM_API_KEY is required and should match the local "
+                "LITELLM_MASTER_KEY."
+            )
+        for label, alias in {
+            ENV_LLM_MODEL: self.default_model,
+            ENV_LLM_REASONING_MODEL: self.reasoning_model,
+            ENV_LLM_RAG_MODEL: self.rag_model,
+            ENV_LLM_JSON_MODEL: self.json_model,
+        }.items():
+            if not alias.strip():
+                raise GatewayConfigurationError(f"{label} cannot be empty")
+
+        return GatewayRuntimeConfig(
+            base_url=base_url,
+            api_key=self.api_key.strip(),
+            default_model=self.default_model.strip(),
+            reasoning_model=self.reasoning_model.strip(),
+            rag_model=self.rag_model.strip(),
+            json_model=self.json_model.strip(),
+            timeout_seconds=self.timeout_seconds,
+        )
+
+
+@dataclass
+class GatewayChatClient:
+    """Small async client for LiteLLM OpenAI-compatible chat completions."""
+
+    config: GatewayRuntimeConfig = field(
+        default_factory=lambda: GatewayRuntimeConfig.from_env().validated()
+    )
+    client: httpx.AsyncClient | None = None
+    _owns_client: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        self.config = self.config.validated()
+        if self.config.timeout_seconds <= 0:
+            raise GatewayConfigurationError("Gateway timeout must be greater than zero")
+        if self.client is None:
+            self.client = httpx.AsyncClient(
+                base_url=self.config.base_url,
+                timeout=httpx.Timeout(self.config.timeout_seconds),
+            )
+            self._owns_client = True
+
+    async def __aenter__(self) -> GatewayChatClient:
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the owned HTTP client."""
+        if self._owns_client and self.client is not None:
+            await self.client.aclose()
+
+    async def chat_completion(
+        self,
+        messages: Sequence[dict[str, str]],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        response_format: Mapping[str, object] | None = None,
+    ) -> str:
+        """Call ``/chat/completions`` and return normalized assistant text."""
+        if self.client is None:
+            raise GatewayConnectionError("Gateway HTTP client is not initialized")
+
+        model_alias = (model or self.config.default_model).strip()
+        if not model_alias:
+            raise GatewayConfigurationError("Gateway model alias cannot be empty")
+
+        payload: dict[str, Any] = {
+            "model": model_alias,
+            "messages": validate_chat_messages(messages),
+        }
+        if temperature is not None:
+            if not 0.0 <= temperature <= 2.0:
+                raise ValueError("temperature must be between 0.0 and 2.0")
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            if max_tokens <= 0:
+                raise ValueError("max_tokens must be greater than zero")
+            payload["max_tokens"] = max_tokens
+        if response_format is not None:
+            payload["response_format"] = dict(response_format)
+
+        start = time.perf_counter()
+        base_url_host = _base_url_host(self.config.base_url)
+        try:
+            response = await self.client.post(
+                "/chat/completions",
+                json=payload,
+                headers={"Authorization": f"Bearer {self.config.api_key}"},
+            )
+        except httpx.TimeoutException as exc:
+            _log_gateway_call(
+                model_alias=model_alias,
+                base_url_host=base_url_host,
+                started_at=start,
+                status="failure",
+                error_category="timeout",
+            )
+            raise GatewayTimeoutError(
+                "Timed out calling local LiteLLM gateway.",
+                alias=model_alias,
+            ) from exc
+        except httpx.RequestError as exc:
+            _log_gateway_call(
+                model_alias=model_alias,
+                base_url_host=base_url_host,
+                started_at=start,
+                status="failure",
+                error_category="connection",
+            )
+            raise GatewayConnectionError(
+                "Could not reach local LiteLLM gateway. "
+                "Start infra/litellm/start_litellm.sh and verify /v1/models.",
+                alias=model_alias,
+            ) from exc
+
+        if response.status_code in {401, 403}:
+            _log_gateway_call(
+                model_alias=model_alias,
+                base_url_host=base_url_host,
+                started_at=start,
+                status="failure",
+                error_category="authentication",
+            )
+            raise GatewayAuthenticationError(
+                "LiteLLM gateway authentication failed. "
+                "QUIMERA_LLM_API_KEY should match LITELLM_MASTER_KEY.",
+                alias=model_alias,
+            )
+        if response.status_code >= 400:
+            _log_gateway_call(
+                model_alias=model_alias,
+                base_url_host=base_url_host,
+                started_at=start,
+                status="failure",
+                error_category=f"http_{response.status_code}",
+            )
+            raise GatewayResponseError(
+                f"LiteLLM gateway returned HTTP {response.status_code}.",
+                alias=model_alias,
+            )
+
+        try:
+            body = cast(dict[str, Any], response.json())
+        except ValueError as exc:
+            raise GatewayResponseError(
+                "LiteLLM gateway returned invalid JSON.",
+                alias=model_alias,
+            ) from exc
+        answer = _extract_assistant_text(body, alias=model_alias)
+        _log_gateway_call(
+            model_alias=model_alias,
+            base_url_host=base_url_host,
+            started_at=start,
+            status="success",
+            error_category=None,
+        )
+        return answer
+
+
+def _extract_assistant_text(body: dict[str, Any], *, alias: str) -> str:
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise GatewayResponseError(
+            "LiteLLM response did not include choices.",
+            alias=alias,
+        )
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise GatewayResponseError("LiteLLM response choice is invalid.", alias=alias)
+    message = first.get("message")
+    if not isinstance(message, dict):
+        raise GatewayResponseError(
+            "LiteLLM response choice did not include a message.",
+            alias=alias,
+        )
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise GatewayResponseError(
+            "LiteLLM response message content is empty.",
+            alias=alias,
+        )
+    return content.strip()
+
+
+def _base_url_host(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    return parsed.netloc or "unknown"
+
+
+def _log_gateway_call(
+    *,
+    model_alias: str,
+    base_url_host: str,
+    started_at: float,
+    status: str,
+    error_category: str | None,
+) -> None:
+    logger.debug(
+        "gateway_call | model_alias={} base_url_host={} latency_ms={:.1f} "
+        "status={} error_category={}",
+        model_alias,
+        base_url_host,
+        (time.perf_counter() - started_at) * 1000,
+        status,
+        error_category or "none",
+    )

--- a/backend/gateway/config.py
+++ b/backend/gateway/config.py
@@ -1,0 +1,198 @@
+"""Gateway configuration schema and loader for LiteLLM alias config.
+
+Validates ``config/litellm_config.yaml`` at load time so a misconfigured
+alias fails immediately — with a clear error — rather than at the runtime
+model-call boundary.
+
+Usage::
+
+    from backend.gateway.config import load_gateway_config
+
+    cfg = load_gateway_config("config/litellm_config.yaml")
+    alias = cfg.get_alias("local_chat")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from backend.gateway.errors import GatewayConfigurationError, GatewayModelAliasError
+
+# ─── Contract constants ───────────────────────────────────────────────────────
+
+#: All five aliases must be present in every valid gateway config.
+REQUIRED_ALIASES: frozenset[str] = frozenset(
+    {"local_chat", "local_think", "local_rag", "local_json", "local_embed"}
+)
+
+#: Permitted ``api_base`` prefixes. Any other prefix is treated as a remote
+#: provider and is rejected by :class:`LiteLLMParams`.
+ALLOWED_LOCAL_PREFIXES: tuple[str, ...] = (
+    "http://localhost:",
+    "http://127.0.0.1:",
+)
+
+
+# ─── Schema models ────────────────────────────────────────────────────────────
+
+
+class LiteLLMParams(BaseModel):
+    """Parameters forwarded verbatim to the LiteLLM router for one alias."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    model: str
+    api_base: str
+    timeout: int
+
+    @field_validator("api_base")
+    @classmethod
+    def must_be_local(cls, v: str) -> str:
+        """Reject any ``api_base`` that is not a loopback address.
+
+        This enforces the Gateway-0 local-only policy at schema validation
+        time rather than at runtime.
+        """
+        if not any(v.startswith(prefix) for prefix in ALLOWED_LOCAL_PREFIXES):
+            raise ValueError(
+                f"api_base '{v}' points to a remote host. "
+                "Remote providers are not permitted in Gateway-0. "
+                "Add remote aliases only after explicit sanitisation approval."
+            )
+        return v
+
+
+class ModelInfo(BaseModel):
+    """Semantic metadata attached to a gateway alias.
+
+    ``thinking_mode`` is the contract field that will drive the future
+    adapter: when ``True`` the adapter must inject ``/think`` into the
+    prompt before dispatching to Qwen3 via Ollama.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str
+    purpose: str
+    thinking_mode: bool = False
+    response_contract: str | None = None
+    output_dimensions: int | None = None
+
+
+class GatewayAlias(BaseModel):
+    """One named alias entry in the LiteLLM ``model_list``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    model_name: str
+    litellm_params: LiteLLMParams
+    model_info: ModelInfo
+
+
+class LiteLLMSettings(BaseModel):
+    """Top-level LiteLLM global settings block."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    drop_params: bool = True
+    set_verbose: bool = False
+
+
+class GatewayConfig(BaseModel):
+    """Validated representation of ``litellm_config.yaml``.
+
+    Raises ``ValueError`` (wrapped by :func:`load_gateway_config` into
+    :class:`~backend.gateway.errors.GatewayConfigurationError`) if any
+    required alias is absent or any alias resolves to a remote provider.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    model_list: list[GatewayAlias]
+    litellm_settings: LiteLLMSettings = LiteLLMSettings()
+
+    @model_validator(mode="after")
+    def required_aliases_present(self) -> "GatewayConfig":
+        """Fail at load time if a required alias is missing from the config."""
+        names = {alias.model_name for alias in self.model_list}
+        missing = sorted(REQUIRED_ALIASES - names)
+        if missing:
+            raise ValueError(
+                f"Gateway config is missing required aliases: {missing}. "
+                "All five semantic aliases must be defined before wiring."
+            )
+        return self
+
+    # ── Accessors ──────────────────────────────────────────────────────────
+
+    def get_alias(self, name: str) -> GatewayAlias:
+        """Return the alias named *name*.
+
+        Raises:
+            GatewayModelAliasError: if *name* is not defined in the config.
+        """
+        for alias in self.model_list:
+            if alias.model_name == name:
+                return alias
+        raise GatewayModelAliasError(
+            f"Unknown gateway alias: {name!r}", alias=name
+        )
+
+    @property
+    def alias_names(self) -> set[str]:
+        """Return the set of all defined alias names."""
+        return {alias.model_name for alias in self.model_list}
+
+
+# ─── Loader ───────────────────────────────────────────────────────────────────
+
+
+def load_gateway_config(path: Path | str) -> GatewayConfig:
+    """Load and validate *path* as a ``GatewayConfig``.
+
+    Args:
+        path: Path to ``litellm_config.yaml``.
+
+    Returns:
+        A fully validated :class:`GatewayConfig` instance.
+
+    Raises:
+        GatewayConfigurationError: if the file is missing, cannot be parsed
+            as YAML, or fails schema validation (e.g. missing alias, remote
+            ``api_base``).
+    """
+    config_path = Path(path)
+
+    try:
+        raw_text = config_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise GatewayConfigurationError(
+            f"Gateway config file not found: {config_path}"
+        ) from exc
+    except OSError as exc:
+        raise GatewayConfigurationError(
+            f"Gateway config file could not be read: {exc}"
+        ) from exc
+
+    try:
+        raw: object = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise GatewayConfigurationError(
+            f"Gateway config YAML parse error in {config_path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise GatewayConfigurationError(
+            f"Gateway config is not a YAML mapping: {config_path}"
+        )
+
+    try:
+        return GatewayConfig.model_validate(cast("dict[str, object]", raw))
+    except Exception as exc:  # pydantic ValidationError or GatewayModelAliasError
+        raise GatewayConfigurationError(
+            f"Gateway config validation failed: {exc}"
+        ) from exc

--- a/backend/gateway/errors.py
+++ b/backend/gateway/errors.py
@@ -1,0 +1,64 @@
+"""Domain exceptions for the Quimera/OpenClaw model gateway.
+
+These exceptions intentionally do not depend on LiteLLM internals. Gateway
+callers should catch local domain errors, while adapter code can translate
+provider-specific exceptions at the boundary.
+"""
+
+from __future__ import annotations
+
+
+class GatewayError(Exception):
+    """Base class for local model gateway failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        alias: str | None = None,
+        provider: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.alias = alias
+        self.provider = provider
+
+    def to_log_context(self) -> dict[str, str]:
+        """Return non-sensitive structured metadata for logs."""
+        context: dict[str, str] = {}
+        if self.alias is not None:
+            context["alias"] = self.alias
+        if self.provider is not None:
+            context["provider"] = self.provider
+        return context
+
+
+class GatewayConfigurationError(GatewayError):
+    """Gateway configuration is missing, invalid, or unsafe."""
+
+
+class GatewayModelAliasError(GatewayError):
+    """A semantic model alias is missing or cannot be resolved."""
+
+
+class GatewayConnectionError(GatewayError):
+    """The local gateway could not be reached."""
+
+
+class GatewayAuthenticationError(GatewayError):
+    """Gateway authentication failed or the API key is missing."""
+
+
+class GatewayProviderUnavailableError(GatewayError):
+    """A configured local provider is unavailable."""
+
+
+class GatewayRequestRejectedError(GatewayError):
+    """A request was rejected before provider execution."""
+
+
+class GatewayResponseError(GatewayError):
+    """A provider response was malformed or unusable."""
+
+
+class GatewayTimeoutError(GatewayError):
+    """A provider call exceeded the configured timeout."""

--- a/backend/gateway/health.py
+++ b/backend/gateway/health.py
@@ -1,0 +1,237 @@
+"""Semantic health checks for the gateway's local service dependencies.
+
+Unlike a plain HTTP-200 check, these checks verify that the specific models
+required by the gateway aliases are *actually available* in Ollama — not
+just that the server process is running.
+
+Typical call site (CLI entry point)::
+
+    from backend.gateway.health import check_gateway_services
+
+    check_gateway_services()          # require chat + embed
+    check_gateway_services(require_embed=False)  # chat only
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_JSON_MODEL,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_RAG_MODEL,
+    DEFAULT_LLM_REASONING_MODEL,
+    ENV_LLM_API_KEY,
+    GatewayRuntimeConfig,
+)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+OLLAMA_TAGS_URL: str = "http://localhost:11434/api/tags"
+REQUIRED_GATEWAY_ALIASES: frozenset[str] = frozenset(
+    {
+        DEFAULT_LLM_MODEL,
+        DEFAULT_LLM_REASONING_MODEL,
+        DEFAULT_LLM_RAG_MODEL,
+        DEFAULT_LLM_JSON_MODEL,
+    }
+)
+
+#: Base name of the chat/reasoning model required by local_chat, local_think,
+#: local_rag, and local_json aliases.
+REQUIRED_CHAT_MODEL: str = "qwen3:14b"
+
+#: Base name of the embedding model required by the local_embed alias.
+REQUIRED_EMBED_MODEL: str = "nomic-embed-text"
+
+PREFLIGHT_TIMEOUT_SECONDS: float = 3.0
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+def check_gateway_services(
+    *,
+    require_chat: bool = True,
+    require_embed: bool = True,
+) -> None:
+    """Verify that Ollama is reachable and the required models are loaded.
+
+    This is a *semantic* check: it confirms not only that Ollama responds to
+    HTTP but that the specific models required by the five gateway aliases are
+    present in ``ollama list``. A server that is running but missing a model
+    will fail here with an actionable pull command rather than deep inside the
+    LiteLLM call path.
+
+    Exits the process with status 1 on any failure, printing a human-readable
+    message with a suggested corrective command.
+
+    Args:
+        require_chat: Verify that :data:`REQUIRED_CHAT_MODEL` is available.
+        require_embed: Verify that :data:`REQUIRED_EMBED_MODEL` is available.
+    """
+    tags = _fetch_ollama_tags()
+
+    models: list[dict[str, Any]] = []
+    raw_models = tags.get("models")
+    if isinstance(raw_models, list):
+        models = [m for m in raw_models if isinstance(m, dict)]
+
+    available: set[str] = {str(m.get("name", "")) for m in models}
+    # Base names (without :tag suffix) for loose matching, e.g. "qwen3" matches
+    # "qwen3:14b-instruct-q4_K_M".
+    base_names: set[str] = {name.split(":")[0] for name in available if name}
+
+    if require_chat:
+        _assert_model_available(
+            REQUIRED_CHAT_MODEL,
+            available,
+            base_names,
+            pull_hint=f"ollama pull {REQUIRED_CHAT_MODEL}",
+        )
+
+    if require_embed:
+        _assert_model_available(
+            REQUIRED_EMBED_MODEL,
+            available,
+            base_names,
+            pull_hint=f"ollama pull {REQUIRED_EMBED_MODEL}",
+        )
+
+    logger.debug(
+        "Gateway service check passed (chat={}, embed={})",
+        require_chat,
+        require_embed,
+    )
+
+
+def check_litellm_gateway() -> None:
+    """Verify that local LiteLLM is reachable and exposes runtime aliases.
+
+    This check only validates the local gateway surface. It does not call
+    remote providers, Qdrant, embeddings, or RAG retrieval.
+    """
+    try:
+        config = GatewayRuntimeConfig.from_env().validated()
+    except Exception as exc:
+        print(f"ERROR: LiteLLM gateway configuration invalid: {exc}")
+        sys.exit(1)
+
+    models_url = f"{config.base_url.rstrip('/')}/models"
+    try:
+        response = httpx.get(
+            models_url,
+            headers={"Authorization": f"Bearer {config.api_key}"},
+            timeout=PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in {401, 403}:
+            print(
+                "ERROR: LiteLLM authentication failed.\n"
+                f"  Ensure {ENV_LLM_API_KEY} matches LITELLM_MASTER_KEY."
+            )
+        else:
+            print(
+                f"ERROR: LiteLLM returned HTTP {exc.response.status_code} at "
+                f"{models_url}."
+            )
+        sys.exit(1)
+    except httpx.RequestError:
+        print(
+            f"ERROR: LiteLLM is not reachable at {models_url}.\n"
+            "  Start it with: infra/litellm/start_litellm.sh"
+        )
+        sys.exit(1)
+
+    raw: object = response.json()
+    if not isinstance(raw, dict):
+        print("ERROR: LiteLLM /models response was not a JSON object.")
+        sys.exit(1)
+    data = raw.get("data")
+    if not isinstance(data, list):
+        print("ERROR: LiteLLM /models response is missing a data list.")
+        sys.exit(1)
+    seen = {
+        str(item.get("id") or item.get("model_name") or item.get("model") or "")
+        for item in data
+        if isinstance(item, dict)
+    }
+    missing = sorted(REQUIRED_GATEWAY_ALIASES - seen)
+    if missing:
+        print(f"ERROR: LiteLLM is missing required aliases: {missing}")
+        sys.exit(1)
+
+    logger.debug(
+        "LiteLLM gateway check passed | base_url_host={} aliases={}",
+        config.base_url.replace("http://", "").replace("https://", ""),
+        sorted(REQUIRED_GATEWAY_ALIASES),
+    )
+
+
+# ─── Internal helpers ─────────────────────────────────────────────────────────
+
+
+def _fetch_ollama_tags() -> dict[str, Any]:
+    """Fetch the Ollama model list. Exits with status 1 on any failure."""
+    try:
+        response = httpx.get(OLLAMA_TAGS_URL, timeout=PREFLIGHT_TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except httpx.ConnectError:
+        logger.error("Ollama is not reachable at {}", OLLAMA_TAGS_URL)
+        print(
+            "ERROR: Ollama is not running.\n"
+            "  Start it with:  ollama serve\n"
+            f"  Then verify:    curl -fsS {OLLAMA_TAGS_URL}"
+        )
+        sys.exit(1)
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "Ollama returned unexpected status {}",
+            exc.response.status_code,
+        )
+        print(
+            f"ERROR: Ollama returned HTTP {exc.response.status_code}.\n"
+            "  Check the Ollama server logs for details."
+        )
+        sys.exit(1)
+
+    raw: object = response.json()
+    if not isinstance(raw, dict):
+        logger.error("Unexpected Ollama /api/tags response shape")
+        print(
+            "ERROR: Unexpected response format from Ollama /api/tags.\n"
+            "  Ensure you are running a supported Ollama version."
+        )
+        sys.exit(1)
+
+    return raw
+
+
+def _assert_model_available(
+    model_name: str,
+    available: set[str],
+    base_names: set[str],
+    *,
+    pull_hint: str,
+) -> None:
+    """Exit with a clear message if *model_name* is not loaded in Ollama.
+
+    Matching is done on both the full name (e.g. ``qwen3:14b``) and the base
+    name (e.g. ``qwen3``) to accommodate quantised variants such as
+    ``qwen3:14b-instruct-q4_K_M``.
+    """
+    base = model_name.split(":")[0]
+    if model_name not in available and base not in base_names:
+        logger.error("Required model '{}' not found in Ollama", model_name)
+        print(
+            f"ERROR: Model '{model_name}' is not loaded in Ollama.\n"
+            f"  Pull it with:  {pull_hint}\n"
+            "  Then verify:   ollama list"
+        )
+        sys.exit(1)

--- a/backend/gateway/messages.py
+++ b/backend/gateway/messages.py
@@ -1,0 +1,25 @@
+"""Shared validation for OpenAI-compatible chat messages."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+VALID_CHAT_ROLES = frozenset({"system", "user", "assistant"})
+
+
+def validate_chat_messages(messages: Sequence[dict[str, str]]) -> list[dict[str, str]]:
+    """Validate and normalize chat messages without logging their contents."""
+    if not messages:
+        raise ValueError("messages cannot be empty")
+
+    clean_messages: list[dict[str, str]] = []
+    for message in messages:
+        role = message.get("role", "").strip()
+        content = message.get("content", "").strip()
+        if role not in VALID_CHAT_ROLES:
+            raise ValueError("message role must be system, user, or assistant")
+        if not content:
+            raise ValueError("message content cannot be empty")
+        clean_messages.append({"role": role, "content": content})
+    return clean_messages

--- a/backend/rag/generator.py
+++ b/backend/rag/generator.py
@@ -1,4 +1,4 @@
-"""Local answer generation via Ollama chat API."""
+"""Local answer generation through the LiteLLM gateway."""
 
 from __future__ import annotations
 
@@ -6,14 +6,21 @@ import re
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, cast
 
 import httpx
 from loguru import logger
 
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_MODEL,
+    GatewayChatClient,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.messages import validate_chat_messages
 
-DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
-DEFAULT_GENERATION_MODEL = "qwen3:14b"
+
+DEFAULT_GENERATION_BASE_URL = DEFAULT_LLM_BASE_URL
+DEFAULT_GENERATION_MODEL = DEFAULT_LLM_MODEL
 DEFAULT_GENERATION_TIMEOUT_SECONDS = 120.0
 DEFAULT_TEMPERATURE = 0.2
 DEFAULT_MAX_TOKENS = 2048
@@ -27,19 +34,19 @@ class GenerationError(Exception):
 
 @dataclass
 class LocalGenerator:
-    """Small async client for local Ollama `/api/chat` generation."""
+    """Small async generator backed by the local LiteLLM gateway."""
 
     model: str = DEFAULT_GENERATION_MODEL
-    base_url: str = DEFAULT_OLLAMA_BASE_URL
+    base_url: str = DEFAULT_GENERATION_BASE_URL
+    api_key: str | None = None
     timeout_seconds: float = DEFAULT_GENERATION_TIMEOUT_SECONDS
     temperature: float = DEFAULT_TEMPERATURE
     max_tokens: int = DEFAULT_MAX_TOKENS
     client: httpx.AsyncClient | None = None
+    gateway_client: GatewayChatClient | None = None
     _owns_client: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
-        if not self.model.strip():
-            raise ValueError("model cannot be empty")
         if self.timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be greater than zero")
         if not 0.0 <= self.temperature <= 2.0:
@@ -47,13 +54,42 @@ class LocalGenerator:
         if self.max_tokens <= 0:
             raise ValueError("max_tokens must be greater than zero")
 
-        self.base_url = self.base_url.rstrip("/")
-        if self.client is None:
-            self.client = httpx.AsyncClient(
+        env_config = GatewayRuntimeConfig.from_env()
+        effective_model = (
+            env_config.default_model
+            if self.model == DEFAULT_GENERATION_MODEL
+            else self.model
+        )
+        effective_base_url = (
+            env_config.base_url
+            if self.base_url == DEFAULT_GENERATION_BASE_URL
+            else self.base_url
+        )
+        if not effective_model.strip():
+            raise ValueError("model cannot be empty")
+
+        # Validate BEFORE creating any HTTP resource so that a bad api_key
+        # raises GatewayAuthenticationError immediately — no client leaks.
+        runtime_config = GatewayRuntimeConfig(
+            base_url=effective_base_url,
+            api_key=self.api_key if self.api_key is not None else env_config.api_key,
+            default_model=effective_model,
+            timeout_seconds=self.timeout_seconds,
+        ).validated()
+
+        if self.gateway_client is None:
+            self.model = runtime_config.default_model
+            self.base_url = runtime_config.base_url  # already normalised by validated()
+            active_client = self.client or httpx.AsyncClient(
                 base_url=self.base_url,
                 timeout=httpx.Timeout(self.timeout_seconds),
             )
-            self._owns_client = True
+            self.gateway_client = GatewayChatClient(
+                config=runtime_config,
+                client=active_client,
+            )
+            self._owns_client = self.client is None
+            self.client = active_client
 
     async def __aenter__(self) -> LocalGenerator:
         return self
@@ -64,7 +100,9 @@ class LocalGenerator:
     async def aclose(self) -> None:
         """Close the owned HTTP client."""
 
-        if self._owns_client and self.client is not None:
+        if self.gateway_client is not None:
+            await self.gateway_client.aclose()
+        elif self._owns_client and self.client is not None:
             await self.client.aclose()
 
     async def chat(
@@ -73,30 +111,23 @@ class LocalGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
     ) -> str:
-        """Generate one local answer with Ollama chat API."""
+        """Generate one local answer through LiteLLM chat completions."""
 
-        if self.client is None:
-            raise RuntimeError("HTTP client is not initialized")
+        if self.gateway_client is None:
+            raise RuntimeError("Gateway client is not initialized")
 
-        clean_messages = _validate_messages(messages)
+        clean_messages = validate_chat_messages(messages)
         effective_temperature = self.temperature if temperature is None else temperature
         if not 0.0 <= effective_temperature <= 2.0:
             raise ValueError("temperature must be between 0.0 and 2.0")
 
-        payload: dict[str, Any] = {
-            "model": self.model,
-            "messages": clean_messages,
-            "stream": False,
-            "options": {
-                "temperature": effective_temperature,
-                "num_predict": self.max_tokens,
-            },
-        }
         start = time.perf_counter()
-        response = await self.client.post("/api/chat", json=payload)
-        response.raise_for_status()
-        body = cast(dict[str, Any], response.json())
-        answer = _extract_answer(body)
+        answer = await self.gateway_client.chat_completion(
+            clean_messages,
+            model=self.model,
+            temperature=effective_temperature,
+            max_tokens=self.max_tokens,
+        )
         if not thinking_mode:
             answer = _strip_thinking(answer)
 
@@ -107,33 +138,6 @@ class LocalGenerator:
             (time.perf_counter() - start) * 1000,
         )
         return answer
-
-
-def _validate_messages(messages: Sequence[dict[str, str]]) -> list[dict[str, str]]:
-    if not messages:
-        raise ValueError("messages cannot be empty")
-
-    clean_messages: list[dict[str, str]] = []
-    for message in messages:
-        role = message.get("role", "").strip()
-        content = message.get("content", "").strip()
-        if role not in {"system", "user", "assistant"}:
-            raise ValueError("message role must be system, user, or assistant")
-        if not content:
-            raise ValueError("message content cannot be empty")
-        clean_messages.append({"role": role, "content": content})
-    return clean_messages
-
-
-def _extract_answer(body: dict[str, Any]) -> str:
-    message = body.get("message")
-    if not isinstance(message, dict):
-        raise GenerationError("Ollama response did not include message")
-
-    content = message.get("content")
-    if not isinstance(content, str) or not content.strip():
-        raise GenerationError("Ollama response message content is empty")
-    return content.strip()
 
 
 def _strip_thinking(answer: str) -> str:

--- a/backend/rag/prompt_builder.py
+++ b/backend/rag/prompt_builder.py
@@ -26,7 +26,7 @@ NO_CONTEXT_MESSAGE = (
 
 @dataclass(frozen=True)
 class PromptBuilder:
-    """Build Ollama chat messages from retrieved local context."""
+    """Build chat messages from retrieved local context."""
 
     system_prompt: str = DEFAULT_SYSTEM_PROMPT
     no_context_message: str = NO_CONTEXT_MESSAGE

--- a/config/litellm_config.yaml
+++ b/config/litellm_config.yaml
@@ -1,0 +1,73 @@
+# LiteLLM Gateway Configuration — Quimera/OpenClaw Gateway-0
+#
+# Local-only MVP:
+# - LiteLLM is the single future gateway for model calls.
+# - This file defines semantic aliases only; existing runtime code is not wired
+#   to LiteLLM in this PR.
+# - Remote providers stay absent until an explicit sanitized fallback sprint.
+# - Do not place API keys, tokens, passwords, or private endpoints in this file.
+
+x-ollama-base-url: &ollama_base_url "http://localhost:11434"
+x-local-chat-model: &local_chat_model "ollama_chat/qwen3:14b"
+x-local-embed-model: &local_embed_model "ollama/nomic-embed-text"
+
+model_list:
+  - model_name: local_chat
+    litellm_params:
+      model: *local_chat_model
+      api_base: *ollama_base_url
+      timeout: 60
+    model_info:
+      provider: ollama
+      purpose: "default local chat"
+      thinking_mode: false
+
+  - model_name: local_think
+    litellm_params:
+      model: *local_chat_model
+      api_base: *ollama_base_url
+      timeout: 120
+    model_info:
+      provider: ollama
+      purpose: "local reasoning calls for approved agents"
+      thinking_mode: true
+
+  - model_name: local_rag
+    litellm_params:
+      model: *local_chat_model
+      api_base: *ollama_base_url
+      timeout: 60
+    model_info:
+      provider: ollama
+      purpose: "RAG answer synthesis from Qdrant context"
+      thinking_mode: false
+
+  - model_name: local_json
+    litellm_params:
+      model: *local_chat_model
+      api_base: *ollama_base_url
+      timeout: 60
+    model_info:
+      provider: ollama
+      purpose: "structured local JSON responses"
+      response_contract: json
+      thinking_mode: false
+
+  - model_name: local_embed
+    litellm_params:
+      model: *local_embed_model
+      api_base: *ollama_base_url
+      timeout: 30
+    model_info:
+      provider: ollama
+      purpose: "local embeddings for Qdrant RAG"
+      output_dimensions: 768
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+
+# Future sanitized remote fallback placeholder:
+# - Remote provider aliases must be added only by explicit architecture approval.
+# - Remote calls must pass sanitization, audit logging, and budget controls first.
+# - No remote provider is enabled in Gateway-0.

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -29,8 +29,11 @@ rag:
     dedup_similarity_threshold: 0.92
 
   generation:
-    model: "qwen3:14b"
-    endpoint: "http://localhost:11434"
+    model: "local_rag"
+    reasoning_model: "local_think"
+    json_model: "local_json"
+    endpoint: "http://127.0.0.1:4000/v1"
+    # api_key read from env: QUIMERA_LLM_API_KEY (not loaded from YAML — set via shell export)
     temperature: 0.2
     max_tokens: 2048
     thinking_mode: false  # /no_think by default for factual RAG

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -99,45 +99,79 @@ RAG-0 is **local only**. No remote AI fallback in this sprint.
 
 - Product name: Quimera.
 - Repository name: OpenClaw.
-- Local LLM runtime: Ollama.
-- Primary local generation model: `qwen3:14b`.
-- Embedding model: `nomic-embed-text`.
+- Model gateway: LiteLLM at `http://127.0.0.1:4000/v1` (Gateway-0 — local only).
+- Semantic aliases: `local_chat`, `local_think`, `local_rag`, `local_json`, `local_embed`.
+- Local LLM runtime: Ollama (via LiteLLM gateway for chat; direct for embeddings until Gateway-1).
+- Primary local generation model: `qwen3:14b` (vendor name confined to LiteLLM config — application code uses aliases).
+- Embedding model: `nomic-embed-text` (direct Ollama until a tested embedding-gateway PR).
 - Vector database: Qdrant.
 - Mathematical co-processor: deterministic Python modules.
-- Remote AI: sanitized fallback only in a future Gateway sprint.
+- Remote AI: disabled. Sanitized fallback only after explicit sprint approval.
 - GitHub is the source of truth for issues, branches, PRs, and merge state.
+
+Runtime env vars (must be set locally before running OpenClaw):
+
+| Var | Default | Notes |
+|---|---|---|
+| `QUIMERA_LLM_BASE_URL` | `http://127.0.0.1:4000/v1` | Local LiteLLM only |
+| `QUIMERA_LLM_API_KEY` | — | Must match `LITELLM_MASTER_KEY` |
+| `QUIMERA_LLM_MODEL` | `local_chat` | Semantic alias |
+| `QUIMERA_LLM_REASONING_MODEL` | `local_think` | Semantic alias |
+| `QUIMERA_LLM_RAG_MODEL` | `local_rag` | Semantic alias |
+| `QUIMERA_LLM_JSON_MODEL` | `local_json` | Semantic alias |
 
 ---
 
-## 4. Sprint RAG-0 Direction
+## 4. Sprint History and Current State
+
+### Sprint RAG-0 — COMPLETE ✅
 
 Canonical pipeline:
 
 ```text
 SyntheticDocument
   -> Chunker
-  -> Ollama Embeddings
+  -> Ollama Embeddings (direct)
   -> Qdrant VectorStore
   -> Retriever
   -> ContextPacker
   -> PromptBuilder
-  -> LocalGenerator
+  -> LocalGenerator  ← now routes through LiteLLM gateway
   -> AnswerWithCitations
 ```
 
-Near-term PR sequence:
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| RAG-01 | `feat/rag-chunking-*` | Chunking + tests | ✅ Merged |
+| RAG-02 | `feat/rag-embeddings` | Ollama embeddings + tests | ✅ Merged |
+| RAG-03 | `feat/rag-qdrant-store` | Qdrant store + integration tests | ✅ Merged |
+| RAG-04 | `feat/rag-retriever-context` | Retriever + ContextPacker | ✅ Merged |
+| RAG-05 | `feat/rag-local-pipeline-smoke` | PromptBuilder + LocalGenerator + fake smoke | ✅ Merged |
+| RAG-06 | `feat/rag-cli-smoke` | Synthetic ingest/query CLI + preflight + smoke | ✅ Merged |
+| RAG-07 | `feat/rag-docs-runbook` | Runbook + ADR + shared validation + health tests | ✅ Merged |
+
+### Sprint Gateway-0 — IN PROGRESS
 
 | PR | Branch | Scope | Status |
 |---|---|---|---|
-| RAG-01 | `feat/rag-chunking-*` | Chunking + tests | Merged ✅ |
-| RAG-02 | `feat/rag-embeddings` | Ollama embeddings + tests | Merged ✅ |
-| RAG-03 | `feat/rag-qdrant-store` | Qdrant store + integration tests | Merged ✅ |
-| RAG-04 | `feat/rag-retriever-context` | Retriever + ContextPacker | Merged ✅ |
-| RAG-05 | `feat/rag-local-pipeline-smoke` | PromptBuilder + LocalGenerator + fake smoke | Merged ✅ |
-| RAG-06 | `feat/rag-cli-smoke` | Synthetic ingest/query CLI + smoke | Merged ✅ |
-| RAG-07 | `feat/rag-docs-runbook` | Runbook + ADR + validation cleanup | Active PR prep |
+| GW-01 | `feat/gateway-prep-contracts` | ADR, Blueprint V3.0, config schema, semantic health checks | User-reported merged; GitHub normalization pending |
+| GW-02 | `feat/gateway-install-health` | infra/litellm/, start/healthcheck/test scripts, regression tests | User-reported merged; GitHub normalization pending |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | `GatewayChatClient`, route `LocalGenerator` → LiteLLM | User-reported merged; GitHub normalization pending |
+| GW-04 | `feat/gateway-runtime-smoke` | Optional live smoke + observability + validation cleanup | Local changes present; PR workflow pending |
 
-Before starting a PR, confirm actual state with:
+**ATENÇÃO — estado do working tree:** the local checkout contains mixed Gateway
+PR1-PR4 changes. Preserve or split the work before branch switching, syncing, or
+replaying PRs.
+
+### Acceptance criteria pendentes para GW-04
+
+- Optional smoke tests are skipped by default and enabled with `RUN_LITELLM_SMOKE=1`.
+- Script smoke covers `local_chat`, `local_think`, `local_rag`, and `local_json`.
+- `_validate_messages` duplication is consolidated without broad refactors.
+- Embeddings, RAG retrieval, Qdrant, FastAPI, MCP, remote providers, and quant
+  tools remain unchanged.
+
+Before starting a new PR:
 
 ```bash
 git status --short --branch
@@ -174,10 +208,23 @@ Do not read `.env`, `.env.*`, `.claude/`, or large generated directories.
 ## 6. Branch and PR Discipline
 
 - Use one branch per issue.
-- Prefer clean worktrees based on `origin/main`.
+- GitHub is the source of truth for issue, branch, PR, review, and merge state.
+- Start every tracked task by syncing `main` with GitHub:
+
+```bash
+cd /Users/fas/projetos/OPENCLAW
+git checkout main
+git pull --ff-only origin main
+```
+
+- Open or update a GitHub Issue before implementation.
+- Create the feature branch only after `main` is updated.
 - Keep diffs small enough to review in one pass.
-- Do not commit or push unless explicitly instructed.
-- Do not merge unless explicitly instructed.
+- Commit locally, push the feature branch, and open a GitHub PR before review.
+- Do not push directly to `main`.
+- Do not merge locally into `main` as the final integration step.
+- Final merge happens in GitHub after approval.
+- After GitHub merge, sync local `main` with `git pull --ff-only origin main`.
 - If a branch depends on an open PR, say so before implementing.
 
 Recommended branch shape:
@@ -187,6 +234,22 @@ feat/rag-<small-scope>
 docs/<small-scope>
 fix/<small-scope>
 ```
+
+Required deliverables per tracked PR:
+
+1. Issue title and issue description.
+2. Branch name.
+3. PR title and PR description.
+4. Validation commands and results.
+5. Merge readiness status.
+
+### Current Gateway Workflow Warning
+
+As of 2026-04-26, the local checkout contains combined, uncommitted Gateway
+PR1-PR4 changes on `feat/gateway-runtime-smoke`. Do not reset, clean, rebase, or
+checkout away from this state until the changes are intentionally preserved or
+split. The next cycle should read `docs/sprints/GATEWAY_SPRINT_HANDOFF.md`
+before touching Git.
 
 ---
 
@@ -406,3 +469,81 @@ Append or paste this at the end of substantial sessions:
 
 ### Risks
 - Current `.venv` lacks pytest, mypy, and pyright after manual environment sync, so full validation is pending.
+
+---
+
+## Handoff — 2026-04-26
+
+**Agent:** Claude (Cowork)
+**Branch:** `feat/gateway-route-opencraw-litellm` (GW-03) + `feat/gateway-install-health` (GW-02) + `feat/gateway-prep-contracts` (GW-01)
+**Issue/PR:** GW-01 / GW-02 / GW-03 — all pending commit via user terminal (git index.lock held by Claude Code process)
+**Task:** Gateway-0 — architectural review, risk resolution, and all corrections for GW-01/02/03.
+
+### Changed
+
+**GW-01 — `feat/gateway-prep-contracts`**
+- `backend/gateway/config.py`: Pydantic v2 schema for `litellm_config.yaml`; `LiteLLMParams.must_be_local` rejects non-localhost `api_base`; `GatewayConfig.required_aliases_present` enforces all 5 aliases at load time; `load_gateway_config()` wraps failures in `GatewayConfigurationError`; `get_alias()` raises `GatewayModelAliasError`.
+- `backend/gateway/health.py`: `check_gateway_services()` fetches Ollama `/api/tags`, verifies `qwen3:14b` and `nomic-embed-text` loaded (base-name matching for quantised variants); exits status 1 with actionable `ollama pull` hint on failure.
+- `tests/unit/test_gateway_config.py`: 25 tests — schema validation, alias enforcement, contract tests against real `config/litellm_config.yaml`.
+- `tests/unit/test_gateway_health.py`: 10 tests — mocked httpx, quantised variant acceptance, connect error, missing models, 503 response.
+- `backend/gateway/errors.py`: stable 8-error taxonomy; all subclass `GatewayError` with `alias`/`provider` kwargs and `to_log_context()`; added `GatewayConnectionError` and `GatewayAuthenticationError`.
+
+**GW-02 — `feat/gateway-install-health`**
+- `infra/litellm/litellm_config.yaml`: operational runtime config using `os.environ/OLLAMA_API_BASE` (not hardcoded); 5 aliases; `general_settings.master_key: os.environ/LITELLM_MASTER_KEY`.
+- `infra/litellm/start_litellm.sh`: refuses missing `LITELLM_MASTER_KEY`, `LITELLM_HOST != 127.0.0.1`, remote `OLLAMA_API_BASE`, remote model override; `set -euo pipefail`.
+- `infra/litellm/requirements.txt`: `litellm[proxy]>=1.83.0,<2.0.0,!=1.82.7,!=1.82.8` (supply-chain exclusions).
+- `infra/litellm/README.md`: added "Future Directions" section documenting MCP integration sequence.
+
+**GW-03 — `feat/gateway-route-opencraw-litellm`**
+- `backend/gateway/client.py`: `GatewayRuntimeConfig` (frozen dataclass, `.from_env()`, `.validated()` rejects non-localhost and empty api_key); `GatewayChatClient` (async httpx, maps errors to domain exceptions; api_key NOT in exception messages).
+- `backend/rag/generator.py`: routes through `GatewayChatClient`; **critical fix applied** — `.validated()` called before `httpx.AsyncClient` creation to prevent resource leaks on bad config.
+- `config/rag_config.yaml`: `generation.endpoint` → `http://127.0.0.1:4000/v1`; `generation.model` → `local_rag` (semantic alias); `api_key_env` field converted to comment (key set via shell export only).
+- `docs/guides/OPENCLAW_LITELLM_RUNTIME.md`: all 6 env vars, start sequence, troubleshooting guide.
+- `tests/unit/test_gateway_client.py`: 4 tests — alias/constant purity, rag_config.yaml contract, auth failure without key leak.
+- `backend/gateway/__init__.py`: exports all public symbols (client, config, health, all 8 errors).
+- `.gitignore`: added `.claude/worktrees/`.
+- `docs/04_MEM/AGENT_CONTEXT.md`: sections 3 and 4 updated (LiteLLM gateway assumptions, env vars table, complete sprint history).
+
+### Validation
+- `uv run pytest` — **98/98 passed** (all unit + integration + smoke).
+- `uv run mypy backend/ --strict --explicit-package-bases` — **0 errors** (35 files checked).
+- `uv run pyright backend/` — **0 errors**.
+- `git diff --check` — passed.
+- No LangChain, sentence-transformers, remote AI, real data, or forbidden files touched.
+
+### Not Changed
+- `CLAUDE.md`, `.claude/`, `.env`, `uv.lock`, real portfolio data untouched.
+- Embeddings still use direct Ollama (`http://localhost:11434`) — gateway routing for embeddings is GW-04.
+- `_validate_messages` duplication between `generator.py` and `GatewayChatClient` intentionally deferred to GW-04.
+- FastAPI, Redis, multi-agent production workflows, brokerage integrations: untouched.
+
+### Next Action
+- **User must commit via terminal** (git index.lock prevents sandbox git operations):
+  ```bash
+  # GW-01
+  git checkout feat/gateway-prep-contracts
+  git add backend/gateway/config.py backend/gateway/health.py backend/gateway/errors.py \
+          tests/unit/test_gateway_config.py tests/unit/test_gateway_health.py \
+          backend/gateway/__init__.py .gitignore
+  git commit -m "feat(gateway): GW-01 — schema validation, health checks, stable error taxonomy"
+
+  # GW-02
+  git checkout feat/gateway-install-health
+  git add infra/litellm/litellm_config.yaml infra/litellm/start_litellm.sh \
+          infra/litellm/requirements.txt infra/litellm/README.md
+  git commit -m "feat(gateway): GW-02 — LiteLLM operational config and startup scripts"
+
+  # GW-03
+  git checkout feat/gateway-route-opencraw-litellm
+  git add backend/gateway/client.py backend/rag/generator.py config/rag_config.yaml \
+          docs/guides/OPENCLAW_LITELLM_RUNTIME.md tests/unit/test_gateway_client.py \
+          docs/04_MEM/AGENT_CONTEXT.md
+  git commit -m "feat(gateway): GW-03 — route OpenClaw runtime through LiteLLM gateway"
+  ```
+- Open PRs for GW-01, GW-02, GW-03 via `gh pr create`.
+- Plan GW-04: consolidate `_validate_messages`, per-alias timeout config, embed routing via `local_embed`.
+
+### Risks
+- All git operations pending user terminal execution (index.lock).
+- `local_think` timeout (120s) is in litellm_config.yaml but `GatewayChatClient` uses global timeout — per-alias timeout is GW-04 scope.
+- Real Ollama + Docker Qdrant E2E with live LiteLLM not yet smoke-tested in this environment.

--- a/docs/04_MEM/GATEWAY0_STATUS.md
+++ b/docs/04_MEM/GATEWAY0_STATUS.md
@@ -1,0 +1,234 @@
+# Gateway-0 Sprint — Status para Retomada
+
+> Arquivo gerado ao fim da sessão 2026-04-26.
+> Leia este arquivo antes de qualquer operação git amanhã.
+
+---
+
+## Estado atual do repositório (crítico)
+
+**Todos os branches apontam para o mesmo commit:** `e0ac81a` — RAG-07.
+**Nenhum dos commits Gateway-0 foi gravado ainda.**
+O trabalho existe no working tree como arquivos modificados/untracked mas **zero commits**.
+
+### Por que?
+
+`git index.lock` — Claude Code mantém o lock do git index durante sessões ativas.
+O lock impede operações de staging e commit.
+
+### Primeiro comando de amanhã (obrigatório)
+
+```bash
+rm /Users/fas/projetos/OPENCLAW/.git/index.lock
+git status --short --branch   # confirmar que está limpo
+```
+
+---
+
+## Todos os arquivos pendentes de commit (working tree atual)
+
+### Modificados (M) — alterações sobre arquivos já commitados em RAG-07
+
+| Arquivo | Pertence a |
+|---|---|
+| `.gitignore` | GW-03 |
+| `backend/rag/generator.py` | GW-03 (routing + fix crítico) |
+| `backend/rag/prompt_builder.py` | RAG-07 (shared validation import) |
+| `config/rag_config.yaml` | GW-03 (endpoint + alias semântico) |
+| `docs/04_MEM/AGENT_CONTEXT.md` | GW-03 (handoff session) |
+| `docs/04_MEM/current_state.md` | GW-03 |
+| `docs/04_MEM/decisions.md` | GW-03 |
+| `docs/04_MEM/next_actions.md` | GW-03 |
+| `scripts/rag_ask_local.py` | RAG-07 (shared validation) |
+| `tests/unit/test_generator.py` | GW-03 (gateway client mocks) |
+
+### Untracked (??) — arquivos novos, nunca commitados
+
+| Arquivo/Dir | Pertence a |
+|---|---|
+| `backend/__init__.py` | GW-01 |
+| `backend/gateway/` | GW-01 (config, health, errors, __init__) + GW-03 (client) + GW-04 (messages) |
+| `config/litellm_config.yaml` | GW-01 |
+| `docs/ADR/0001-litellm-as-initial-model-gateway.md` | GW-01 |
+| `docs/GATEWAY_SETUP.md` | GW-03 |
+| `docs/architecture/` | GW-01 |
+| `docs/guides/` | GW-03 (OPENCLAW_LITELLM_RUNTIME.md) |
+| `docs/sprints/` | GW-01 |
+| `infra/` | GW-02 (litellm_config.yaml, start_litellm.sh, requirements.txt, README.md) |
+| `scripts/__init__.py` | GW-01 |
+| `scripts/check_litellm_gateway.sh` | GW-02 |
+| `scripts/test_opencraw_litellm_runtime.sh` | GW-02/GW-04 (expandido) |
+| `tests/smoke/test_gateway_runtime_smoke.py` | GW-04 |
+| `tests/unit/test_gateway_client.py` | GW-03 |
+| `tests/unit/test_gateway_config.py` | GW-01 |
+| `tests/unit/test_gateway_errors.py` | GW-01 |
+| `tests/unit/test_gateway_health.py` | GW-01 |
+| `tests/unit/test_litellm_infra_scripts.py` | GW-02 |
+| `uv.lock` | GW-01 (uv sync com dev deps PEP 735) |
+
+---
+
+## Sequência de commits para amanhã
+
+```bash
+cd ~/projetos/OPENCLAW
+rm .git/index.lock   # ← obrigatório primeiro
+
+# Confirmar branch
+git checkout feat/gateway-route-opencraw-litellm
+git status --short --branch
+
+# ── COMMIT 1: GW-01 ──────────────────────────────────────────────────────────
+git add \
+  backend/__init__.py \
+  scripts/__init__.py \
+  backend/gateway/config.py \
+  backend/gateway/health.py \
+  backend/gateway/errors.py \
+  backend/gateway/__init__.py \
+  config/litellm_config.yaml \
+  tests/unit/test_gateway_config.py \
+  tests/unit/test_gateway_health.py \
+  tests/unit/test_gateway_errors.py \
+  docs/ADR/0001-litellm-as-initial-model-gateway.md \
+  docs/architecture/ \
+  docs/sprints/ \
+  uv.lock
+
+git commit -m "feat(gateway): GW-01 — Pydantic schema, semantic health checks, stable error taxonomy (closes #20)"
+
+# ── COMMIT 2: GW-02 ──────────────────────────────────────────────────────────
+git add \
+  infra/ \
+  scripts/check_litellm_gateway.sh
+
+git commit -m "feat(gateway): GW-02 — LiteLLM operational config, start script, supply-chain guards (closes #21)"
+
+# ── COMMIT 3: GW-03 ──────────────────────────────────────────────────────────
+git add \
+  backend/gateway/client.py \
+  backend/rag/generator.py \
+  backend/rag/prompt_builder.py \
+  config/rag_config.yaml \
+  .gitignore \
+  docs/GATEWAY_SETUP.md \
+  docs/guides/ \
+  tests/unit/test_gateway_client.py \
+  tests/unit/test_generator.py \
+  scripts/rag_ask_local.py \
+  docs/04_MEM/AGENT_CONTEXT.md \
+  docs/04_MEM/current_state.md \
+  docs/04_MEM/decisions.md \
+  docs/04_MEM/next_actions.md
+
+git commit -m "feat(gateway): GW-03 — route OpenClaw runtime through LiteLLM, validation-before-resource fix (closes #22)"
+
+# ── COMMIT 4: GW-04 ──────────────────────────────────────────────────────────
+git add \
+  backend/gateway/messages.py \
+  scripts/test_opencraw_litellm_runtime.sh \
+  tests/smoke/test_gateway_runtime_smoke.py \
+  docs/04_MEM/GATEWAY0_STATUS.md
+
+git commit -m "feat(gateway): GW-04 — validate_chat_messages consolidation, observability, optional smoke tests"
+
+# ── Push e PR ────────────────────────────────────────────────────────────────
+git push origin feat/gateway-route-opencraw-litellm
+
+gh pr create \
+  --base main \
+  --title "feat(gateway): Gateway-0 — LiteLLM routing, validation, infra, smoke tests (GW-01–04)" \
+  --body "Implements full Gateway-0 sprint (GW-01 through GW-04).
+Closes #20, #21, #22.
+
+## Commits
+- GW-01: Pydantic schema, health checks, stable error taxonomy
+- GW-02: LiteLLM operational config, start script, supply-chain exclusions
+- GW-03: GatewayChatClient + routing + validation-before-resource fix
+- GW-04: validate_chat_messages consolidation + observability + smoke tests
+
+## Validação
+- 115/115 tests pass (2 skipped — smoke, expected)
+- mypy --strict: 0 erros (40 files)
+- pyright: 0 erros
+- rg '_validate_messages': 0 resultados
+
+## Pendente (GW-05)
+- Per-alias timeout (local_think 120s vs local_chat)
+- Embed routing via local_embed"
+
+gh pr merge --merge --delete-branch
+
+git checkout main
+git pull --ff-only origin main
+git log --oneline --decorate -5
+```
+
+---
+
+## Resumo de cada PR (GW-01 a GW-04)
+
+### GW-01 — Contratos e base do gateway
+**Issue:** #20 | **Branch:** `feat/gateway-prep-contracts`
+
+Cria os contratos de base antes de qualquer infraestrutura:
+- `backend/gateway/config.py`: schema Pydantic v2 para `litellm_config.yaml`. Rejeita URLs não-localhost, exige 5 aliases obrigatórios (`local_chat`, `local_think`, `local_rag`, `local_json`, `local_embed`).
+- `backend/gateway/health.py`: `check_gateway_services()` verifica Ollama rodando + modelos carregados (base-name matching para variantes quantizadas como `qwen3:14b-instruct-q4_K_M`).
+- `backend/gateway/errors.py`: taxonomia estável de 8 exceções, todas subclasses de `GatewayError`, com `alias`/`provider` kwargs e `to_log_context()`.
+- 35 testes (25 config + 10 health).
+- `config/litellm_config.yaml`: config de referência com 5 aliases, URLs localhost hardcoded.
+
+**Validação local:** 98/98 testes, mypy 0, pyright 0.
+
+---
+
+### GW-02 — Infraestrutura operacional LiteLLM
+**Issue:** #21 | **Branch:** `feat/gateway-install-health`
+
+Cria a camada operacional local do LiteLLM com guards de segurança:
+- `infra/litellm/litellm_config.yaml`: usa `os.environ/OLLAMA_API_BASE` (não hardcoded). 5 aliases. `master_key` via env.
+- `infra/litellm/start_litellm.sh`: recusa `LITELLM_HOST=0.0.0.0`, `OLLAMA_API_BASE` remoto, `LITELLM_MASTER_KEY` ausente. `set -euo pipefail`.
+- `infra/litellm/requirements.txt`: `litellm[proxy]>=1.83.0,<2.0.0,!=1.82.7,!=1.82.8` (exclusões de supply chain — versões comprometidas no PyPI em março/2026).
+- `infra/litellm/README.md`: inclui seção "Future Directions" documentando sequência de integração MCP.
+
+---
+
+### GW-03 — Routing do runtime OpenClaw → LiteLLM
+**Issue:** #22 | **Branch:** `feat/gateway-route-opencraw-litellm`
+
+Roteia todas as chamadas de geração pelo gateway:
+- `backend/gateway/client.py`: `GatewayRuntimeConfig` (frozen dataclass com `.from_env()` e `.validated()`); `GatewayChatClient` (async httpx, mapeia erros para domain exceptions, api_key nunca aparece em exceções).
+- `backend/rag/generator.py`: **fix crítico** — `.validated()` chamado antes de `httpx.AsyncClient()`. Sem o fix, ambientes com `ALL_PROXY=socks5h://` crashavam antes da validação da api_key.
+- `config/rag_config.yaml`: `generation.endpoint` → gateway; `generation.model` → `local_rag`.
+- `docs/guides/OPENCLAW_LITELLM_RUNTIME.md`: todos os 6 env vars, startup, troubleshooting.
+- 4 testes com `MockTransport` — sem dependência de LiteLLM real.
+
+---
+
+### GW-04 — Consolidação, observabilidade e smoke tests opcionais
+**Issue:** parte de #20 | **Branch:** `feat/gateway-runtime-smoke`
+
+Fecha as pendências técnicas do sprint:
+- `backend/gateway/messages.py`: `validate_chat_messages()` — função compartilhada. Elimina duplicação entre `client.py` e `generator.py`.
+- `backend/gateway/client.py`: `_log_gateway_call()` emite `logger.debug` com alias, host (netloc only), latência, status, categoria de erro. Sem prompt, sem api_key.
+- `scripts/test_opencraw_litellm_runtime.sh`: expandido para testar os 4 aliases com prompts sintéticos. Output truncado + comentário de dado sintético.
+- `tests/smoke/test_gateway_runtime_smoke.py`: skipado por default; `RUN_LITELLM_SMOKE=1` para ativar. Testa 4 aliases + endpoint `/models`. Sem Qdrant, sem embeddings, sem dados reais.
+
+**Validação:** 115/115 tests, 2 skipped (smoke, esperado). mypy 0, pyright 0.
+
+---
+
+## Issues criados hoje
+
+| Issue | Título | Estado |
+|---|---|---|
+| #20 | [GW-01] Gateway contracts | open |
+| #21 | [GW-02] Gateway infra | open |
+| #22 | [GW-03] Gateway routing | open |
+
+## Próximo sprint: GW-05
+
+Pendências registradas:
+1. Per-alias timeout: `local_think` (120s) vs `local_chat` (30s) — mesmo `timeout_seconds` global hoje.
+2. Routing de embeddings via `local_embed`.
+3. Integration test `LocalGenerator → GatewayChatClient` sem mocks.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -1,92 +1,124 @@
 # current_state.md — OPENCLAW Operational Memory
 
-> Volatile project state for Codex, Claude Code, ChatGPT Thinking, and human review.
-> Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of meaningful sessions.
+> Volatile project state for Codex, Claude Code, ChatGPT Thinking, and human
+> review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
+> meaningful sessions.
 
 **Last updated:** 2026-04-26
-**Updated by:** Codex — RAG-07 runbook/validation prep
+**Updated by:** Codex — Gateway workflow normalization handoff
 
 ---
 
-## Active Sprint: RAG-0
+## Active Sprint: Gateway-0 / LiteLLM
 
-**Goal:** Full local pipeline: chunk -> embed -> Qdrant -> retrieve -> pack context -> prompt -> Qwen3 answer with citations.
+**Goal:** make LiteLLM the local-only model gateway for OpenClaw runtime model
+calls while preserving existing RAG/Qdrant behavior.
 
 **Hard constraints:**
-- Local only for RAG-0.
-- Ollama only for embeddings/generation.
-- Qdrant local for vector storage.
-- No LiteLLM, remote providers, FastAPI, LangChain, sentence-transformers, Redis, real portfolio data, or private documents.
+
+- Local only.
+- No remote providers.
+- No FastAPI.
+- No MCP.
+- No quant tools.
+- No secrets or real portfolio data.
+- No final local merge into `main`; GitHub PR approval is the integration path.
 
 ---
 
-## GitHub State
+## Mandatory GitHub Workflow
 
-| RAG step | Branch | State | Scope |
-|---|---|---|---|
-| RAG-01 | `feat/rag-chunking-*` | Merged | Chunking + unit tests |
-| RAG-02 | `feat/rag-embeddings` | Merged | Ollama embeddings + mocked unit tests |
-| RAG-03 | `feat/rag-qdrant-store` | Merged | Qdrant store + integration tests |
-| RAG-04 | `feat/rag-retriever-context` | Merged | Retriever + ContextPacker |
-| RAG-05 | `feat/rag-local-pipeline-smoke` | Merged | PromptBuilder + LocalGenerator + LocalRagPipeline |
-| RAG-06 | `feat/rag-cli-smoke` | Merged | Synthetic ingest/query scripts + smoke |
-| RAG-07 | `feat/rag-docs-runbook` | Active PR prep | Runbook + ADR + validation cleanup |
+For every tracked task:
 
-Current issue for active work: <https://github.com/franciscosalido/OPENCLAW/issues/18>
+1. Sync local `main` with GitHub.
+2. Open or update a GitHub Issue before implementation.
+3. Create a feature branch from updated `main`.
+4. Implement locally.
+5. Run validation locally.
+6. Commit atomic changes.
+7. Push the feature branch.
+8. Open a GitHub PR to `main`.
+9. Link the PR to the issue.
+10. Address review on the same branch.
+11. Merge only in GitHub after approval.
+12. After merge, pull `main` with `--ff-only` and delete branches only when safe.
+
+Do not push directly to `main`. Do not use `git push --force`; if a rebase is
+unavoidable, use `git push --force-with-lease`.
 
 ---
 
-## Active Branch: `feat/rag-docs-runbook`
+## Current Local State Warning
 
-Planned files:
+Current observed branch:
 
 ```text
-backend/rag/_validation.py
-backend/rag/prompt_builder.py
-backend/rag/pipeline.py
-backend/rag/retriever.py
-tests/unit/test_validation.py
-tests/unit/test_health.py
-docs/RAG_RUNBOOK.md
-docs/ADR/001-rag-local-only.md
-docs/04_MEM/AGENT_CONTEXT.md
-docs/04_MEM/current_state.md
+feat/gateway-runtime-smoke
 ```
 
-Current implementation summary:
+Current observed risk:
 
-- `_validate_question` duplication was removed.
-- `validate_question` now lives in `backend/rag/_validation.py`.
-- PromptBuilder, LocalRagPipeline, and Retriever use the shared helper.
-- `health.py` has mocked unit coverage for healthy services, missing Qdrant, missing embedding model, and skipped checks.
-- `docs/RAG_RUNBOOK.md` documents local setup, ingest, query, validation, troubleshooting, and thinking-mode policy.
-- `docs/ADR/001-rag-local-only.md` records the local-only RAG decision.
+- The working tree contains mixed Gateway PR1-PR4 modifications and untracked
+  files.
+- Local `main`/`origin/main` may not reflect the user-reported manual Gateway
+  merges yet.
+- Do not run `git reset`, `git clean`, destructive checkout, or broad stash
+  commands until the Gateway changes are intentionally preserved or split.
+- `uv.lock` is untracked; decide deliberately whether dependency lock changes
+  belong in a PR.
+- `.gitignore` is modified; decide deliberately whether the `.claude/worktrees/`
+  ignore rule belongs in a PR.
+
+Read `docs/sprints/GATEWAY_SPRINT_HANDOFF.md` before the next Gateway action.
 
 ---
 
-## Validation Status
+## Gateway PR Tracking
 
-Passed in current environment:
+| PR | Branch | User-reported state | Local verification state | Next action |
+|---|---|---|---|---|
+| GW-01 | `feat/gateway-prep-contracts` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
+| GW-02 | `feat/gateway-install-health` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
+| GW-04 | `feat/gateway-runtime-smoke` | In progress | Local changes present | Preserve/split, then open PR |
 
-```bash
-.venv/bin/python -m unittest tests.unit.test_validation tests.unit.test_health -v
-.venv/bin/python -m py_compile backend/rag/*.py scripts/*.py tests/unit/*.py tests/integration/*.py tests/smoke/*.py
-git diff --check
-```
+Proposed issue and PR titles are recorded in
+`docs/sprints/GATEWAY_SPRINT_HANDOFF.md`.
 
-Pending because current `.venv` lacks dev tools after manual sync:
+---
+
+## Last Known Validation
+
+Before this documentation handoff, the Gateway PR4 local work had passed:
 
 ```bash
 uv run pytest -v
-uv run mypy --explicit-package-bases --strict backend/rag scripts tests/unit tests/integration tests/smoke
-uv run pyright backend/rag scripts tests/unit tests/integration tests/smoke
+uv run mypy --strict . || true
+uv run pyright || true
+uv run python -m compileall backend scripts infra tests || true
+git diff --check
 ```
 
-Do not install dependencies without explicit human approval.
+Observed result from the prior local run:
+
+```text
+115 passed, 2 skipped, 35 subtests passed
+mypy: success
+pyright: 0 errors
+compileall: success
+git diff --check: success
+```
+
+Live LiteLLM smoke was attempted with a fake local key and failed clearly because
+LiteLLM was not running at `127.0.0.1:4000`. No secrets were printed.
 
 ---
 
-## Remaining Risks
+## Next Recommended Move
 
-- Full pytest/mypy/pyright validation is pending until dev tools are restored.
-- No real data has been used or accessed.
+1. Preserve the current Gateway work before any branch switch.
+2. Backfill GitHub issues for GW-01 through GW-04.
+3. Verify whether the manual merges are actually present on GitHub `main`.
+4. If not, split or replay the local Gateway changes into the required PR chain.
+5. Do not begin a new feature PR until GW-01 through GW-03 are represented in
+   GitHub and local `main` is synchronized.

--- a/docs/04_MEM/decisions.md
+++ b/docs/04_MEM/decisions.md
@@ -93,3 +93,23 @@
 **Decision:** Level 0 = local only (never remote). Level 1 = sanitized before remote. Level 2 = blocked (credentials, real portfolio).
 
 **Why:** Previous 3-level taxonomy had "Level 2 = remote sensitive" which created a dangerous ambiguity. Renamed: blocked = never leaves machine under any circumstance.
+
+---
+
+## ADR-010 — GitHub Issue/PR Workflow Is Mandatory
+
+**Date:** 2026-04-26 | **Status:** Accepted
+
+**Decision:** GitHub is the operational source of truth for tracked work. Every
+PR-sized task must start from synced `main`, have a GitHub Issue before
+implementation, use a feature branch from updated `main`, push that branch, open
+a GitHub PR, link the PR to the issue, and merge only through GitHub after
+approval.
+
+**Why:** Local-only integration created ambiguity around Gateway PR1-PR3 status.
+The project needs durable issue/PR history, review state, and merge tracking
+that survives agent handoffs and local worktree drift.
+
+**Consequence:** Agents must not treat the local project directory as the final
+integration point. If local state is dirty or contains unsplit work, preserve it
+first, then normalize GitHub records before starting the next feature.

--- a/docs/04_MEM/next_actions.md
+++ b/docs/04_MEM/next_actions.md
@@ -2,103 +2,50 @@
 
 > This file drives the next session. Check it off as you complete items.
 
-**Last updated:** 2026-04-25
+**Last updated:** 2026-04-26
 
 ---
 
-## Right Now — Merge ops/memory-foundation
+## Right Now — Normalize Gateway GitHub Workflow
 
-- [ ] Review PR: https://github.com/franciscosalido/OPENCLAW/pull/new/ops/memory-foundation
-- [ ] Merge to main
-- [ ] Locally: `git checkout main && git pull && uv sync`
-- [ ] Start Qdrant: `docker compose -f docker/docker-compose.qdrant.yml up -d`
-- [ ] Verify: `curl localhost:6333/healthz` → OK
+- [ ] Read `docs/sprints/GATEWAY_SPRINT_HANDOFF.md`.
+- [ ] Run `git status --short --branch`.
+- [ ] Verify GitHub issues and PRs for GW-01, GW-02, GW-03, and GW-04.
+- [ ] Backfill missing issues before implementation or PR work.
+- [ ] Preserve current local Gateway work before switching branches.
+- [ ] Sync local `main` with `git pull --ff-only origin main` only after the
+      current work is preserved or intentionally split.
 
 ---
 
-## PR#3 — feat/rag-ollama-embeddings
+## Required Issue Records
 
-### Step 1 — Create branch and open issue
+| PR | Issue title | Branch |
+|---|---|---|
+| GW-01 | `[Gateway-01] LiteLLM gateway contracts and semantic aliases` | `feat/gateway-prep-contracts` |
+| GW-02 | `[Gateway-02] Local-only LiteLLM install and health scripts` | `feat/gateway-install-health` |
+| GW-03 | `[Gateway-03] Route OpenClaw runtime chat through LiteLLM` | `feat/gateway-route-opencraw-litellm` |
+| GW-04 | `[Gateway-04] Optional LiteLLM runtime smoke and observability` | `feat/gateway-runtime-smoke` |
+
+---
+
+## Mandatory Workflow Reminder
+
 ```bash
-gh issue create --title "[RAG-03] OllamaEmbedder — embeddings.py" \
-  --body "Implement OllamaEmbedder class per docs/04_MEM/current_state.md PR#3 contract"
-git checkout -b feat/rag-ollama-embeddings
+cd /Users/fas/projetos/OPENCLAW
+git checkout main
+git pull --ff-only origin main
+gh issue create ...
+git checkout -b <feature-branch>
+# implement
+# validate
+git commit -m "<atomic message>"
+git push -u origin <feature-branch>
+gh pr create --base main --head <feature-branch> ...
 ```
 
-### Step 2 — Claude Code implements these exact files
+Do not merge locally into `main` as the final integration step. Final merge
+belongs in GitHub after review approval.
 
-**`backend/rag/embeddings.py`**
-```python
-"""Embedding client for OPENCLAW RAG pipeline.
-
-Calls Ollama /api/embed endpoint. No sentence-transformers.
-All config from rag_config.yaml via RAGConfig.
-"""
-from __future__ import annotations
-import asyncio
-from dataclasses import dataclass
-import httpx
-from loguru import logger
-
-
-class EmbeddingError(Exception):
-    """Raised when embedding fails after all retries or dimensions mismatch."""
-
-
-class OllamaEmbedder:
-    """Async embedding client backed by Ollama /api/embed."""
-    # POST {endpoint}/api/embed
-    # body: {"model": model, "input": [text, ...]}
-    # response: {"embeddings": [[float, ...], ...]}
-    # validate: len(each_vector) == expected_dimensions
-    # retry: up to 3 times, backoff 1s → 2s → 4s
-    # always call close() or use as async context manager
-    ...
-```
-
-**`tests/unit/test_embeddings.py`** — 5 tests, ALL mocked, no Ollama
-1. `test_embed_returns_correct_dimensions` — mock → 768d vector ✓
-2. `test_embed_batch_multiple_texts` — 3 texts → 3 vectors ✓
-3. `test_embed_retry_on_timeout` — 1st call timeout, 2nd succeeds ✓
-4. `test_embed_raises_on_wrong_dimensions` — 512d response → EmbeddingError ✓
-5. `test_embed_empty_text` — empty string → EmbeddingError ✓
-
-### Step 3 — Verify before PR
-```bash
-uv run pytest tests/unit/test_embeddings.py -v
-uv run mypy backend/rag/embeddings.py --strict
-grep -r 'sentence_transformers' backend/  # must return nothing
-```
-
-### Step 4 — PR
-```bash
-gh pr create \
-  --title "[RAG-03] feat/rag-ollama-embeddings: OllamaEmbedder + 5 unit tests" \
-  --body "Adds OllamaEmbedder (httpx async, retry, dimension validation). 5 mocked unit tests. No Ollama required to run tests."
-```
-
----
-
-## PR#4 (queue — do not start until PR#3 merged)
-
-**Branch:** `feat/rag-qdrant-store`
-
-`backend/rag/qdrant_store.py` — `QdrantVectorStore`:
-- `ensure_collection()` — idempotent
-- `upsert(chunks, vectors)` — payload: doc_id, chunk_index, text, ingested_at, security_level
-- `delete_document(document_id)` — filter delete
-- `search(vector, top_k, score_threshold, filters)` → `list[dict]`
-- `count()` → `int`
-
-`tests/integration/test_qdrant_store.py` — 6 tests, temp collection, cleanup on teardown.
-
----
-
-## Workflow Reminder
-
-```
-gh issue create → git checkout -b branch → implement → pytest → mypy → gh pr create → review → merge → update current_state.md
-```
-
-Use `/compact` in Claude Code after each PR.
-Use `/cost` periodically to monitor token usage.
+Use `/compact` in Claude Code after each PR. Use `/cost` periodically to monitor
+token usage.

--- a/docs/ADR/0001-litellm-as-initial-model-gateway.md
+++ b/docs/ADR/0001-litellm-as-initial-model-gateway.md
@@ -1,0 +1,63 @@
+# ADR-0001: LiteLLM as Initial Model Gateway
+
+**Status:** Accepted
+**Date:** 2026-04-26
+
+## Context
+
+Quimera/OpenClaw is a local-first, security-first, multi-agent assistant. RAG-0
+proved local retrieval with Qdrant, Ollama, Qwen, and synthetic documents.
+Gateway-0 prepares the next boundary: all model calls should eventually pass
+through one configurable gateway instead of each agent or module choosing
+providers directly.
+
+## Decision
+
+Use LiteLLM as the initial model gateway contract for Quimera/OpenClaw.
+
+Gateway-0 defines semantic aliases:
+
+- `local_chat`
+- `local_think`
+- `local_rag`
+- `local_json`
+- `local_embed`
+
+The chat aliases map to local Ollama/Qwen. The embedding alias maps to local
+Ollama/nomic-embed-text. Remote providers are not enabled in this PR.
+
+RAG storage stays in Qdrant. LiteLLM is only the future gateway for model calls:
+chat, reasoning, structured output, and embeddings. Vector CRUD, retrieval,
+chunking, context packing, and prompt construction remain in the existing Python
+RAG modules.
+
+FastAPI is intentionally outside the MVP path. The first gateway steps are
+configuration, contracts, local CLI usage, and tests. HTTP service boundaries can
+be introduced later only with explicit approval.
+
+## Consequences
+
+Positive:
+
+- Agents can request semantic model capabilities instead of hardcoded models.
+- Local-only behavior remains the default.
+- Future remote fallback must be added explicitly behind sanitization and audit.
+- Existing RAG behavior is preserved while the gateway contract is reviewed.
+
+Tradeoffs:
+
+- This PR does not route runtime calls through LiteLLM yet.
+- Thinking/no-thinking behavior is represented as alias metadata until adapter
+  wiring is implemented.
+- Operators must run Ollama locally before the future gateway can serve models.
+
+## Guardrails
+
+- No secrets in repository config.
+- No remote providers enabled by default.
+- No FastAPI in Gateway-0.
+- No quant tools in this sprint.
+- No changes to Claude/Cowork-specific files.
+- Gateway PRs must follow the mandatory GitHub workflow: issue first, branch
+  from updated `main`, push branch, open PR, link issue, and merge only in
+  GitHub after approval.

--- a/docs/GATEWAY_SETUP.md
+++ b/docs/GATEWAY_SETUP.md
@@ -1,0 +1,200 @@
+# Gateway Setup
+
+Gateway-0 prepares LiteLLM as the future single gateway for Quimera/OpenClaw
+model calls. PR 2 makes the local gateway installable and testable, but still
+does not route OpenClaw runtime calls through LiteLLM.
+
+Gateway work must follow the repository GitHub workflow: issue first, branch
+from updated `main`, local validation, pushed branch, GitHub PR, linked issue,
+and merge only in GitHub after approval.
+
+## Local Services
+
+Required local services:
+
+- Ollama at `http://127.0.0.1:11434`
+- Qwen local chat model available in Ollama
+- `nomic-embed-text` available in Ollama
+- Qdrant for RAG vectors
+
+Useful checks:
+
+```bash
+ollama --version
+ollama pull qwen3:14b
+ollama pull nomic-embed-text
+ollama list
+curl -fsS http://127.0.0.1:11434/api/tags
+curl -fsS http://localhost:6333/healthz
+```
+
+## Config Locations
+
+Contract config:
+
+```text
+config/litellm_config.yaml
+```
+
+Operational local gateway config:
+
+```text
+infra/litellm/litellm_config.yaml
+```
+
+Both configs define these semantic aliases:
+
+- `local_chat`
+- `local_think`
+- `local_rag`
+- `local_json`
+- `local_embed`
+
+The operational aliases point only to local Ollama models. No remote provider is
+enabled.
+
+## Install LiteLLM Locally
+
+Use an isolated environment under `infra/litellm`:
+
+```bash
+cd infra/litellm
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Security note: LiteLLM versions `1.82.7` and `1.82.8` were compromised on PyPI
+in March 2026. The local requirements exclude those versions and require the
+post-incident `1.83.x` line.
+
+## Environment
+
+Use shell exports. Do not commit real secrets.
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export QWEN_MODEL="qwen3:14b"
+export EMBED_MODEL="nomic-embed-text"
+export LITELLM_HOST="127.0.0.1"
+export LITELLM_PORT="4000"
+```
+
+LiteLLM supports `os.environ/VAR_NAME` when the whole YAML value is loaded from
+the environment. Because model names need an `ollama/` prefix,
+`start_litellm.sh` derives the full LiteLLM model strings from `QWEN_MODEL` and
+`EMBED_MODEL` before startup.
+
+## Start LiteLLM
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+./start_litellm.sh
+```
+
+The script defaults to `127.0.0.1:4000` and refuses any non-local bind address.
+
+## Validate
+
+In another shell with the same exported environment:
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+./test_models.sh
+./test_local_chat.sh
+./healthcheck.sh
+```
+
+Or from the repository root:
+
+```bash
+scripts/check_litellm_gateway.sh
+scripts/test_opencraw_litellm_runtime.sh
+```
+
+The checks validate:
+
+- `/v1/models` responds;
+- all five aliases are exposed;
+- `local_chat` answers a short synthetic Portuguese prompt;
+- PR4 smoke additionally checks `local_chat`, `local_think`, `local_rag`, and
+  `local_json`;
+- Ollama is reachable;
+- no active remote provider marker appears in the LiteLLM config.
+
+Pytest smoke is opt-in:
+
+```bash
+RUN_LITELLM_SMOKE=1 uv run pytest tests/smoke -v
+```
+
+It is skipped by default because normal unit tests must not require local
+services.
+
+## Stop LiteLLM
+
+If LiteLLM runs in the foreground, stop it with `Ctrl-C`.
+
+If it runs in another shell:
+
+```bash
+ps aux | grep '[l]itellm'
+kill <pid>
+```
+
+## RAG Boundary
+
+Qdrant remains the RAG vector database. LiteLLM is not the vector store and does
+not own chunking, retrieval, context packing, or citation logic.
+
+The intended future path is:
+
+```text
+Python RAG modules -> Qdrant retrieval -> prompt/context -> LiteLLM alias -> Ollama
+```
+
+RAG is not routed directly through LiteLLM in PR 2. Only the standalone gateway
+operation is proven there. PR 3 routes OpenClaw runtime chat generation through
+LiteLLM while preserving Qdrant retrieval and existing embedding behavior.
+PR 4 proves the live route with optional smoke tests and minimal gateway
+observability.
+
+Application runtime environment:
+
+```bash
+export QUIMERA_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+export QUIMERA_LLM_MODEL="local_chat"
+export QUIMERA_LLM_REASONING_MODEL="local_think"
+export QUIMERA_LLM_RAG_MODEL="local_rag"
+export QUIMERA_LLM_JSON_MODEL="local_json"
+```
+
+See `docs/guides/OPENCLAW_LITELLM_RUNTIME.md` for runtime troubleshooting.
+
+## MVP Exclusions
+
+FastAPI is intentionally out of the MVP path. Gateway-0 focuses on local config,
+contracts, and reviewable boundaries before any service layer is introduced.
+
+Also excluded:
+
+- remote AI fallback;
+- Redis;
+- quant tools;
+- MCP;
+- embeddings-through-gateway;
+- real portfolio data;
+- secrets in repository files.
+
+## Security Notes
+
+Do not commit `.env`, API keys, tokens, passwords, private endpoints, broker
+exports, real portfolio data, or private documents.
+
+Do not put private financial data in prompts or logs. Remote providers must be
+introduced only in a later approved sprint with sanitization, audit logging, and
+budget controls.

--- a/docs/architecture/QUIMERA_OPENCLAW_BLUEPRINT_V3_0.md
+++ b/docs/architecture/QUIMERA_OPENCLAW_BLUEPRINT_V3_0.md
@@ -1,0 +1,81 @@
+# Quimera/OpenClaw Blueprint V3.0
+
+## Product Identity
+
+Quimera is the product. OpenClaw is the repository.
+
+The platform is local-first, security-first, and multi-agent. Local services are
+the default path for model calls, retrieval, and deterministic computation.
+
+## Target MVP Architecture
+
+- Ollama runs local models.
+- Qwen 3.0 14B is the primary local chat/reasoning model.
+- `nomic-embed-text` provides local embeddings.
+- Qdrant stores local RAG vectors.
+- Python owns deterministic orchestration, validation, retrieval, prompt
+  construction, and mathematical co-processing.
+- LiteLLM becomes the single model gateway for model calls.
+- GitHub remains the source of truth for issues, branches, and pull requests.
+
+## Operational Source Of Truth
+
+GitHub is the final integration surface for OpenClaw work. Local branches are
+work areas, not the source of merge truth.
+
+For every tracked change:
+
+- sync local `main` from GitHub with `git pull --ff-only origin main`;
+- open or update a GitHub Issue before implementation;
+- create a feature branch from updated `main`;
+- validate locally;
+- commit and push the feature branch;
+- open a GitHub PR to `main`;
+- link the PR to the issue;
+- merge only in GitHub after approval.
+
+Local merges into `main` are not considered final integration.
+
+## Gateway Boundary
+
+LiteLLM is introduced as a model-call gateway, not as the owner of RAG state.
+
+Gateway aliases:
+
+| Alias | Purpose | Initial mapping |
+| --- | --- | --- |
+| `local_chat` | Default local chat | Ollama/Qwen |
+| `local_think` | Local reasoning calls | Ollama/Qwen |
+| `local_rag` | RAG answer synthesis | Ollama/Qwen |
+| `local_json` | Structured local responses | Ollama/Qwen |
+| `local_embed` | Embeddings for retrieval | Ollama/nomic-embed-text |
+
+RAG remains in Qdrant:
+
+- documents are chunked in Python;
+- embeddings are generated locally;
+- vectors are written to Qdrant;
+- retrieval and context packing remain Python responsibilities;
+- only model calls move behind the gateway in a later PR.
+
+## Explicit Non-Goals for Gateway-0
+
+- No remote provider routing.
+- No FastAPI service.
+- No quant tools.
+- No real portfolio data.
+- No secret handling beyond documenting that secrets must not be committed.
+- No change to existing RAG runtime behavior.
+
+## Security Levels
+
+Level 0 never leaves the machine: real portfolio data, balances, credentials,
+personal data, private documents, and sensitive logs.
+
+Level 1 can leave only after sanitization: abstracted scenarios, anonymized
+errors, synthetic examples, and generic architecture questions.
+
+Level 2 is safe for remote: public documentation, generic code structure, toy
+examples, and non-sensitive educational material.
+
+Gateway-0 enables only the local path.

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -1,0 +1,137 @@
+# OpenClaw LiteLLM Runtime
+
+PR 3 routes OpenClaw runtime chat generation through the local LiteLLM gateway.
+PR 4 adds optional live smoke tests for that route.
+The default runtime path is:
+
+```text
+OpenClaw -> http://127.0.0.1:4000/v1 -> LiteLLM -> Ollama/Qwen local
+```
+
+## Environment Variables
+
+```bash
+export QUIMERA_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+export QUIMERA_LLM_API_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_MODEL="local_chat"
+export QUIMERA_LLM_REASONING_MODEL="local_think"
+export QUIMERA_LLM_RAG_MODEL="local_rag"
+export QUIMERA_LLM_JSON_MODEL="local_json"
+```
+
+`QUIMERA_LLM_API_KEY` should match the local `LITELLM_MASTER_KEY` used to start
+LiteLLM. Do not commit either value.
+
+## Start LiteLLM
+
+Use the local-only operational scripts from PR 2:
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export QWEN_MODEL="qwen3:14b"
+export EMBED_MODEL="nomic-embed-text"
+./start_litellm.sh
+```
+
+In another shell:
+
+```bash
+export QUIMERA_LLM_API_KEY="dev-local-key-change-me"
+scripts/test_opencraw_litellm_runtime.sh
+```
+
+## Optional Live Smoke Tests
+
+Smoke tests are skipped by default so normal CI and local unit runs do not
+require LiteLLM or Ollama.
+
+Run the script smoke:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_opencraw_litellm_runtime.sh
+```
+
+Run the pytest smoke:
+
+```bash
+RUN_LITELLM_SMOKE=1 uv run pytest tests/smoke -v
+```
+
+The live smoke tests exercise only synthetic prompts and these local aliases:
+
+- `local_chat`
+- `local_think`
+- `local_rag`
+- `local_json`
+
+They do not require Qdrant, embeddings, real portfolio data, or remote
+providers.
+
+## What Changed
+
+- `backend.rag.generator.LocalGenerator` now sends OpenAI-compatible
+  `/chat/completions` requests to LiteLLM.
+- The default base URL is `http://127.0.0.1:4000/v1`.
+- The default chat alias is `local_chat`.
+- RAG CLI calls use `local_rag` by default and `local_think` when `--thinking`
+  is selected.
+- Gateway calls emit minimal debug observability: alias, base URL host, latency,
+  success/failure status, and error category. API keys and prompt text are not
+  logged.
+
+## What Did Not Change
+
+- Qdrant remains the vector store.
+- RAG chunking, embeddings, retrieval, context packing, and citation logic are
+  unchanged.
+- Embeddings still use the existing local Ollama embedder until a separate,
+  tested embedding-gateway PR is approved.
+- Remote providers remain disabled.
+- FastAPI remains postponed.
+- MCP and tooling integration are not implemented in PR 3 or PR 4.
+
+## Troubleshooting
+
+LiteLLM is not running:
+
+```bash
+cd infra/litellm
+./start_litellm.sh
+```
+
+Ollama is not running:
+
+```bash
+ollama serve
+curl -fsS http://127.0.0.1:11434/api/tags
+```
+
+Wrong API key:
+
+- Ensure `QUIMERA_LLM_API_KEY` matches `LITELLM_MASTER_KEY`.
+- Do not print either value in logs or terminal captures.
+
+Missing model alias:
+
+```bash
+cd infra/litellm
+./test_models.sh
+```
+
+Model not pulled:
+
+```bash
+ollama pull qwen3:14b
+ollama pull nomic-embed-text
+ollama list
+```
+
+Direct Ollama call accidentally configured:
+
+- Runtime chat defaults should use semantic aliases only.
+- Vendor model names such as Qwen, GPT, Claude, Gemini, or Ollama provider
+  strings belong in LiteLLM configuration, not application-facing defaults.

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -1,0 +1,277 @@
+# Gateway Sprint Handoff
+
+> Start the next Gateway cycle by reading this file before touching Git.
+
+**Last updated:** 2026-04-26  
+**Repository:** OpenClaw  
+**Product:** Quimera  
+**Sprint:** Gateway-0 / LiteLLM  
+
+---
+
+## Mandatory GitHub Workflow
+
+The local project directory is not the final integration point. GitHub is the
+source of truth for issues, branches, pull requests, review status, and merge
+state.
+
+For every tracked PR:
+
+1. Sync local `main`:
+
+```bash
+cd /Users/fas/projetos/OPENCLAW
+git checkout main
+git pull --ff-only origin main
+```
+
+2. Open or update a GitHub Issue before implementation.
+3. Create the feature branch from updated `main`.
+4. Implement locally.
+5. Run relevant validations locally.
+6. Commit with clear atomic messages.
+7. Push the feature branch.
+8. Open a GitHub PR from the feature branch to `main`.
+9. Link the PR to the issue.
+10. Address review comments on the same branch.
+11. Merge only in GitHub after approval.
+12. After GitHub merge, sync local `main` with `--ff-only`.
+
+Never push directly to `main`. Never use `git push --force`; if unavoidable
+after a rebase, use `git push --force-with-lease`.
+
+---
+
+## Current Local Risk
+
+Current observed branch:
+
+```text
+feat/gateway-runtime-smoke
+```
+
+The working tree currently contains combined Gateway PR1-PR4 changes. This is
+valuable work, but it is not yet cleanly represented in GitHub from this local
+checkout.
+
+Do not run:
+
+```bash
+git reset --hard
+git clean -fd
+git checkout -- .
+```
+
+Do not switch away from the branch until the current work is preserved, split,
+or intentionally committed.
+
+Known local risks:
+
+- `origin/main` in this checkout may still point to the older RAG-07 state.
+- Gateway PR1-PR3 are user-reported as merged manually, but this checkout still
+  needs GitHub verification.
+- Many Gateway files are untracked.
+- `.gitignore` is modified.
+- `uv.lock` is untracked and should not be staged unless intentionally part of
+  dependency policy.
+
+---
+
+## Proposed GitHub Records
+
+| PR | Issue title | Branch | PR title |
+|---|---|---|---|
+| GW-01 | `[Gateway-01] LiteLLM gateway contracts and semantic aliases` | `feat/gateway-prep-contracts` | `feat(gateway): add LiteLLM prep contracts` |
+| GW-02 | `[Gateway-02] Local-only LiteLLM install and health scripts` | `feat/gateway-install-health` | `feat(gateway): add local LiteLLM install and health scripts` |
+| GW-03 | `[Gateway-03] Route OpenClaw runtime chat through LiteLLM` | `feat/gateway-route-opencraw-litellm` | `feat(gateway): route runtime chat through local LiteLLM` |
+| GW-04 | `[Gateway-04] Optional LiteLLM runtime smoke and observability` | `feat/gateway-runtime-smoke` | `feat(gateway): add optional runtime smoke for local LiteLLM` |
+
+---
+
+## Issue Body Templates
+
+### GW-01
+
+Context: Gateway-0 introduces LiteLLM as the local-only model gateway contract.
+
+Objective: add ADR, Blueprint V3.0, semantic aliases, config validation,
+gateway exceptions, and contract tests without changing runtime behavior.
+
+Scope: docs, config, `backend/gateway` contracts, unit tests.
+
+Out of scope: remote providers, FastAPI, MCP, quant tools, OpenClaw runtime
+routing, RAG behavior changes.
+
+Acceptance criteria: aliases exist, remote providers absent, schema validation
+passes, tests pass, no secrets committed.
+
+Risks/follow-ups: keep runtime wiring for later PRs; maintain small Gateway
+exception taxonomy.
+
+### GW-02
+
+Context: PR1 created the Gateway contract; PR2 makes local LiteLLM installable
+and testable.
+
+Objective: add `infra/litellm` operational scripts and documentation for
+starting and checking LiteLLM bound to `127.0.0.1`.
+
+Scope: local config, `.env.example`, start script, healthcheck scripts, setup
+docs, script tests.
+
+Out of scope: runtime integration, remote providers, FastAPI, MCP, quant tools,
+real portfolio data.
+
+Acceptance criteria: LiteLLM can start locally, `/v1/models` responds,
+`local_chat` works through local Qwen, scripts fail clearly, no secrets
+committed.
+
+Risks/follow-ups: live checks require local Ollama/LiteLLM; docs must keep MCP
+and tooling direction explicitly out of scope.
+
+### GW-03
+
+Context: PR2 made the gateway operational; PR3 routes OpenClaw runtime chat
+generation through LiteLLM.
+
+Objective: make application-facing model calls use OpenAI-compatible
+`/chat/completions` at `http://127.0.0.1:4000/v1` with semantic aliases.
+
+Scope: gateway client, runtime generation adapter, config defaults, docs, mocked
+unit tests.
+
+Out of scope: embeddings-through-gateway, Qdrant changes, retrieval changes,
+remote providers, FastAPI, MCP, quant tools.
+
+Acceptance criteria: default route is LiteLLM local, default alias is
+`local_chat`, reasoning/RAG/JSON aliases are available, vendor model names stay
+out of application-facing defaults, tests pass.
+
+Risks/follow-ups: `_validate_messages` duplication was intentionally temporary
+and should be consolidated in GW-04.
+
+### GW-04
+
+Context: PR3 routes runtime calls; PR4 proves the live route with optional smoke
+tests and minimal observability.
+
+Objective: add opt-in runtime smoke coverage for
+`OpenClaw -> LiteLLM -> Ollama/Qwen` and resolve the temporary message
+validation duplication.
+
+Scope: optional smoke script/test, LiteLLM health helper if narrow, minimal
+debug observability, docs, validation cleanup.
+
+Out of scope: embeddings-through-gateway, Qdrant/retrieval/chunking changes,
+remote providers, FastAPI, MCP, quant tools, real portfolio prompts.
+
+Acceptance criteria: normal tests skip live smoke by default, `RUN_LITELLM_SMOKE=1`
+enables live checks, smoke uses only synthetic prompts and local aliases, no
+secrets are printed, existing tests pass.
+
+Risks/follow-ups: live smoke requires local LiteLLM and Ollama; if services are
+down, failures must be clear and secret-safe.
+
+---
+
+## Exact Command Plan For Normalization
+
+First inspect without changing history:
+
+```bash
+cd /Users/fas/projetos/OPENCLAW
+git status --short --branch
+git branch -vv
+gh auth status
+gh issue list --state open
+gh pr list --state all --limit 20
+```
+
+Create issue body files in `/tmp` manually from the templates above, then:
+
+```bash
+gh issue create --title "[Gateway-01] LiteLLM gateway contracts and semantic aliases" --body-file /tmp/gateway-01-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-02] Local-only LiteLLM install and health scripts" --body-file /tmp/gateway-02-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-03] Route OpenClaw runtime chat through LiteLLM" --body-file /tmp/gateway-03-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-04] Optional LiteLLM runtime smoke and observability" --body-file /tmp/gateway-04-issue.md --label codex-task --label local-only
+```
+
+If PR1-PR3 are already present on GitHub, link or comment on those issues with
+the existing PR URLs instead of recreating duplicate PRs.
+
+If PR1-PR3 are not present on GitHub, preserve current work before syncing:
+
+```bash
+git status --short --branch
+git diff --stat
+git diff --check
+```
+
+Then decide one of these safe paths:
+
+- commit a temporary preservation branch with explicit files;
+- split patches into the four target branches;
+- create a worktree backup before replaying from `main`.
+
+After preservation:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+Then replay each branch from updated `main`, validate, push, and open the PR:
+
+```bash
+git checkout -b feat/gateway-prep-contracts
+# apply GW-01 files
+uv run pytest tests/unit/test_gateway_config.py tests/unit/test_gateway_health.py tests/unit/test_gateway_errors.py -v
+git status --short --branch
+git add <gw-01-files>
+git commit -m "feat(gateway): add LiteLLM prep contracts"
+git push -u origin feat/gateway-prep-contracts
+gh pr create --base main --head feat/gateway-prep-contracts --title "feat(gateway): add LiteLLM prep contracts" --body-file /tmp/gateway-01-pr.md
+```
+
+Repeat the same pattern for GW-02, GW-03, and GW-04.
+
+---
+
+## Last Known PR4 Validation
+
+The PR4 local bundle previously passed:
+
+```bash
+uv run pytest -v
+uv run mypy --strict . || true
+uv run pyright || true
+uv run python -m compileall backend scripts infra tests || true
+git diff --check
+```
+
+Observed result:
+
+```text
+115 passed, 2 skipped, 35 subtests passed
+mypy: success
+pyright: 0 errors
+compileall: success
+git diff --check: success
+```
+
+Live smoke with a fake local key failed clearly because LiteLLM was not running
+at `127.0.0.1:4000`. No secrets were printed.
+
+---
+
+## Next Cycle Start
+
+Start with:
+
+```bash
+cd /Users/fas/projetos/OPENCLAW
+git status --short --branch
+sed -n '1,260p' docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+```
+
+Then normalize GitHub records before doing new Gateway implementation work.

--- a/docs/sprints/QUIMERA_LITELLM_PR_PROMPTS_V3.md
+++ b/docs/sprints/QUIMERA_LITELLM_PR_PROMPTS_V3.md
@@ -1,0 +1,51 @@
+# Quimera/OpenClaw LiteLLM Sprint PR Prompts V3
+
+## Sprint Intent
+
+Prepare LiteLLM as the single model gateway while preserving the local-only RAG
+pipeline and avoiding runtime behavior changes until the contract is reviewed.
+
+## Mandatory GitHub Workflow
+
+Every PR prompt in this sprint must be executed through GitHub:
+
+1. Sync local `main` with `git pull --ff-only origin main`.
+2. Open or update a GitHub Issue before implementation.
+3. Create the feature branch from updated `main`.
+4. Validate locally.
+5. Commit, push, open a GitHub PR, and link the issue.
+6. Merge only through GitHub after approval.
+
+Do not treat local `main` as the final integration point. If the working tree is
+dirty, preserve or split the work before syncing or replaying branches.
+
+## PR 1: Gateway Prep Contracts
+
+Branch: `feat/gateway-prep-contracts`
+
+Goal: add the gateway decision record, blueprint, setup guide, LiteLLM local
+alias config, and domain exceptions without wiring runtime calls yet.
+
+Acceptance:
+
+- `config/litellm_config.yaml` defines `local_chat`, `local_think`,
+  `local_rag`, `local_json`, and `local_embed`.
+- Chat aliases map to local Ollama/Qwen.
+- Embedding alias maps to local Ollama/nomic-embed-text.
+- Remote providers are absent or documented only as future placeholders.
+- FastAPI is documented as intentionally out of the MVP path.
+- RAG remains in Qdrant; only future model calls pass through LiteLLM.
+- Gateway domain exceptions do not depend on LiteLLM internals.
+- Existing tests still pass.
+
+## Follow-Up PRs
+
+Future PRs should stay small:
+
+- load and validate gateway configuration;
+- add a local LiteLLM smoke command;
+- route embeddings through the gateway only after RAG behavior is covered;
+- route local chat generation through the gateway;
+- add sanitization and audit contracts before any remote fallback.
+
+Remote providers remain out of scope until explicit approval.

--- a/docs/sprints/SPRINT-LLM-01-litellm-gateway.md
+++ b/docs/sprints/SPRINT-LLM-01-litellm-gateway.md
@@ -1,0 +1,140 @@
+# Sprint LLM-01: LiteLLM Gateway
+
+## Mandatory Workflow
+
+All Gateway PRs use GitHub as the source of truth:
+
+1. Sync `main` with `git pull --ff-only origin main`.
+2. Open or update a GitHub Issue before implementation.
+3. Branch from updated `main`.
+4. Implement, validate, commit, push.
+5. Open a GitHub PR and link it to the issue.
+6. Merge only through GitHub after approval.
+
+The current local checkout contains combined PR1-PR4 work. Normalize GitHub
+issues/PRs and preserve local work before starting PR4 review or PR5 planning.
+
+## Goal
+
+Introduce LiteLLM as a local-only model gateway for Quimera/OpenClaw.
+
+## PR 1: Gateway Prep Contracts
+
+Branch: `feat/gateway-prep-contracts`  
+Issue title: `[Gateway-01] LiteLLM gateway contracts and semantic aliases`  
+PR title: `feat(gateway): add LiteLLM prep contracts`  
+Status: user-reported merged manually; GitHub issue/PR tracking must be
+backfilled or verified.
+
+Delivered:
+
+- ADR and Blueprint V3.0.
+- Semantic aliases: `local_chat`, `local_think`, `local_rag`, `local_json`,
+  `local_embed`.
+- Gateway exception taxonomy.
+- Pydantic config validation and contract tests.
+- Semantic gateway health check contracts.
+
+Risk posture after PR 1:
+
+- Missing aliases are caught by tests.
+- Remote provider config is rejected by validation.
+- `thinking_mode` is a tested contract.
+- Gateway exceptions are local domain exceptions, not LiteLLM internals.
+
+## PR 2: Gateway Install And Health
+
+Branch: `feat/gateway-install-health`  
+Issue title: `[Gateway-02] Local-only LiteLLM install and health scripts`  
+PR title: `feat(gateway): add local LiteLLM install and health scripts`  
+Status: user-reported merged manually; GitHub issue/PR tracking must be
+backfilled or verified.
+
+Scope:
+
+- Add `infra/litellm/` operational directory.
+- Install LiteLLM in an isolated venv.
+- Start LiteLLM on `127.0.0.1:4000`.
+- Validate `/v1/models`.
+- Validate a short `local_chat` call through Qwen/Ollama.
+- Add local healthcheck scripts.
+
+Out of scope:
+
+- OpenClaw runtime wiring to LiteLLM.
+- Remote providers.
+- FastAPI.
+- Redis.
+- Quant tools.
+- Real portfolio data.
+
+Merge criteria:
+
+- Shell scripts fail clearly when dependencies or services are missing.
+- LiteLLM config contains only local Ollama aliases.
+- Existing tests pass.
+- `python -m compileall` or equivalent compile check is clean.
+- Health scripts pass when Ollama and LiteLLM are running locally.
+
+## PR 3: Runtime Route Through LiteLLM
+
+Branch: `feat/gateway-route-opencraw-litellm`  
+Issue title: `[Gateway-03] Route OpenClaw runtime chat through LiteLLM`  
+PR title: `feat(gateway): route runtime chat through local LiteLLM`  
+Status: user-reported merged manually; GitHub issue/PR tracking must be
+backfilled or verified.
+
+Delivered:
+
+- Runtime chat/generation calls route through LiteLLM `/v1/chat/completions`.
+- Default base URL is `http://127.0.0.1:4000/v1`.
+- Application-facing defaults use semantic aliases, not vendor model names.
+- Qdrant, retrieval, chunking, embeddings, and prompt construction remain
+  unchanged.
+
+## PR 4: Runtime Smoke
+
+Branch: `feat/gateway-runtime-smoke`  
+Issue title: `[Gateway-04] Optional LiteLLM runtime smoke and observability`  
+PR title: `feat(gateway): add optional runtime smoke for local LiteLLM`  
+Status: current / in progress; local changes present and must be preserved
+before branch operations.
+
+Scope:
+
+- Optional live smoke tests guarded by `RUN_LITELLM_SMOKE=1`.
+- Script smoke for `local_chat`, `local_think`, `local_rag`, and `local_json`.
+- Minimal gateway observability: alias, local endpoint host, latency, status,
+  and error category.
+- No Qdrant, embeddings, remote providers, FastAPI, MCP, or quant tools.
+
+## Normalization Commands
+
+Do not run destructive commands while the current worktree is dirty. First
+inspect and preserve the local Gateway work:
+
+```bash
+cd /Users/fas/projetos/OPENCLAW
+git status --short --branch
+git branch -vv
+gh issue list --state open
+gh pr list --state all --limit 20
+```
+
+Create or backfill issues:
+
+```bash
+gh issue create --title "[Gateway-01] LiteLLM gateway contracts and semantic aliases" --body-file /tmp/gateway-01-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-02] Local-only LiteLLM install and health scripts" --body-file /tmp/gateway-02-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-03] Route OpenClaw runtime chat through LiteLLM" --body-file /tmp/gateway-03-issue.md --label codex-task --label local-only
+gh issue create --title "[Gateway-04] Optional LiteLLM runtime smoke and observability" --body-file /tmp/gateway-04-issue.md --label codex-task --label local-only
+```
+
+Only after local Gateway work is preserved or intentionally split:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+Then replay each PR from updated `main` if GitHub does not already contain it.

--- a/infra/litellm/.env.example
+++ b/infra/litellm/.env.example
@@ -1,0 +1,9 @@
+# Local development placeholders only.
+# Do not commit real secrets or private endpoints.
+
+LITELLM_MASTER_KEY=dev-local-key-change-me
+OLLAMA_API_BASE=http://127.0.0.1:11434
+QWEN_MODEL=qwen3:14b
+EMBED_MODEL=nomic-embed-text
+LITELLM_HOST=127.0.0.1
+LITELLM_PORT=4000

--- a/infra/litellm/README.md
+++ b/infra/litellm/README.md
@@ -1,0 +1,119 @@
+# LiteLLM Local Gateway
+
+This directory contains the operational Gateway-0 layer for Quimera/OpenClaw.
+It starts LiteLLM as a local-only proxy in front of Ollama. OpenClaw runtime
+calls are not routed through LiteLLM yet.
+
+## Security Contract
+
+- Bind only to `127.0.0.1`.
+- Do not commit real secrets.
+- Do not enable OpenAI, Anthropic, Gemini, or any remote provider.
+- Do not use real portfolio data, private financial data, or private documents
+  in test prompts.
+- Do not print `LITELLM_MASTER_KEY`.
+- Keep RAG data in Qdrant. LiteLLM handles model calls only.
+
+## Install
+
+```bash
+cd infra/litellm
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Supply-chain note: LiteLLM versions `1.82.7` and `1.82.8` were compromised on
+PyPI in March 2026. This directory excludes those versions and requires a
+post-incident `1.83.x` release line.
+
+## Prepare Ollama
+
+```bash
+ollama --version
+ollama pull qwen3:14b
+ollama pull nomic-embed-text
+ollama list
+```
+
+## Configure Environment
+
+Use shell exports. Do not copy real secrets into Git.
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export QWEN_MODEL="qwen3:14b"
+export EMBED_MODEL="nomic-embed-text"
+export LITELLM_HOST="127.0.0.1"
+export LITELLM_PORT="4000"
+```
+
+LiteLLM supports `os.environ/VAR_NAME` when the whole YAML value comes from the
+environment. Because model names need an `ollama/` prefix, `start_litellm.sh`
+derives `LITELLM_LOCAL_CHAT_MODEL` and `LITELLM_LOCAL_EMBED_MODEL` from
+`QWEN_MODEL` and `EMBED_MODEL`.
+
+## Start
+
+```bash
+./start_litellm.sh
+```
+
+The script refuses to bind to anything other than `127.0.0.1`.
+
+## Validate
+
+In another shell with the same environment variables:
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+./test_models.sh
+./test_local_chat.sh
+./healthcheck.sh
+```
+
+Expected checks:
+
+- `/v1/models` responds.
+- All five local aliases are visible.
+- `local_chat` returns a compact answer through LiteLLM.
+- Ollama is reachable.
+- No active remote provider appears in the LiteLLM config.
+
+## Stop
+
+If LiteLLM runs in the foreground, stop it with `Ctrl-C`.
+
+If you started it in a background shell, find and stop that process manually:
+
+```bash
+ps aux | grep '[l]itellm'
+kill <pid>
+```
+
+## MVP Boundary
+
+FastAPI is intentionally not used in this PR. Gateway-0 should prove the local
+LiteLLM operational path before adding any service layer.
+
+RAG is not routed directly through LiteLLM yet. Qdrant remains the vector store,
+and the Python RAG modules still own chunking, retrieval, context packing, and
+prompt construction.
+
+## Future Directions
+
+Multi-agent and MCP integration will be introduced only after the local gateway
+path is validated end-to-end. The intended sequence is:
+
+1. Route OpenClaw runtime model calls through the LiteLLM gateway (PR3).
+2. Validate the full RAG → LiteLLM → Ollama path in a smoke test.
+3. Introduce multi-agent coordination contracts once the single-agent path is stable.
+4. Add MCP tool bindings as an explicit sprint after agent contracts are defined.
+
+Remote providers and external API access remain out of scope until a dedicated
+sanitisation and audit sprint is approved.
+
+MCP and broader tooling integration remain explicitly out of scope until the
+local LiteLLM runtime path is stable and reviewed.

--- a/infra/litellm/healthcheck.sh
+++ b/infra/litellm/healthcheck.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/litellm_config.yaml"
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required." 127
+
+[ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required."
+
+LITELLM_HOST="${LITELLM_HOST:-127.0.0.1}"
+LITELLM_PORT="${LITELLM_PORT:-4000}"
+OLLAMA_API_BASE="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+
+[ "${LITELLM_HOST}" = "127.0.0.1" ] || fail "Refusing non-local LiteLLM host '${LITELLM_HOST}'."
+
+case "${OLLAMA_API_BASE}" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *) fail "OLLAMA_API_BASE must be local-only. Got '${OLLAMA_API_BASE}'." ;;
+esac
+
+if grep -v '^[[:space:]]*#' "${CONFIG_FILE}" | grep -Eiq 'openai|anthropic|gemini|api[_.-]?key'; then
+  fail "Remote provider or provider API key marker found in active LiteLLM config."
+fi
+
+if ! curl -fsS --max-time 5 "${OLLAMA_API_BASE%/}/api/tags" >/dev/null; then
+  fail "Ollama is not reachable at ${OLLAMA_API_BASE}. Start Ollama and pull local models."
+fi
+
+"${SCRIPT_DIR}/test_models.sh"
+"${SCRIPT_DIR}/test_local_chat.sh"
+
+printf 'OK: LiteLLM local gateway healthcheck passed.\n'

--- a/infra/litellm/litellm_config.yaml
+++ b/infra/litellm/litellm_config.yaml
@@ -1,0 +1,73 @@
+# Quimera/OpenClaw LiteLLM local gateway config.
+#
+# This operational config is local-only. It intentionally does not define
+# OpenAI, Anthropic, Gemini, or any remote provider.
+#
+# LiteLLM supports os.environ/VAR_NAME for whole config values. Because model
+# names need an "ollama/" prefix, start_litellm.sh derives:
+# - LITELLM_LOCAL_CHAT_MODEL=ollama/${QWEN_MODEL}
+# - LITELLM_LOCAL_EMBED_MODEL=ollama/${EMBED_MODEL}
+
+model_list:
+  - model_name: local_chat
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_API_BASE
+      timeout: 60
+      temperature: 0.2
+    model_info:
+      provider: ollama
+      purpose: default local chat
+      thinking_mode: false
+
+  - model_name: local_think
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_API_BASE
+      timeout: 120
+      temperature: 0.2
+    model_info:
+      provider: ollama
+      purpose: local reasoning calls
+      thinking_mode: true
+
+  - model_name: local_rag
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_API_BASE
+      timeout: 60
+      temperature: 0.1
+    model_info:
+      provider: ollama
+      purpose: RAG answer synthesis from Qdrant context
+      thinking_mode: false
+
+  - model_name: local_json
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_API_BASE
+      timeout: 60
+      temperature: 0.0
+    model_info:
+      provider: ollama
+      purpose: structured local JSON responses
+      response_contract: json
+      thinking_mode: false
+
+  - model_name: local_embed
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_EMBED_MODEL
+      api_base: os.environ/OLLAMA_API_BASE
+      timeout: 30
+    model_info:
+      provider: ollama
+      purpose: local embeddings for Qdrant RAG
+      output_dimensions: 768
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  disable_spend_logs: true

--- a/infra/litellm/requirements.txt
+++ b/infra/litellm/requirements.txt
@@ -1,0 +1,3 @@
+# Keep LiteLLM isolated from the main OpenClaw runtime.
+# Security note: 1.82.7 and 1.82.8 were compromised on PyPI in March 2026.
+litellm[proxy]>=1.83.0,<2.0.0,!=1.82.7,!=1.82.8

--- a/infra/litellm/start_litellm.sh
+++ b/infra/litellm/start_litellm.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/litellm_config.yaml"
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+[ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required. Export a local dev key before starting LiteLLM."
+
+export OLLAMA_API_BASE="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+export QWEN_MODEL="${QWEN_MODEL:-qwen3:14b}"
+export EMBED_MODEL="${EMBED_MODEL:-nomic-embed-text}"
+export LITELLM_HOST="${LITELLM_HOST:-127.0.0.1}"
+export LITELLM_PORT="${LITELLM_PORT:-4000}"
+
+[ "${LITELLM_HOST}" = "127.0.0.1" ] || fail "Refusing to bind LiteLLM to '${LITELLM_HOST}'. Gateway-0 must bind only to 127.0.0.1."
+
+case "${OLLAMA_API_BASE}" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *) fail "OLLAMA_API_BASE must be local-only. Got '${OLLAMA_API_BASE}'." ;;
+esac
+
+export LITELLM_LOCAL_CHAT_MODEL="${LITELLM_LOCAL_CHAT_MODEL:-ollama/${QWEN_MODEL}}"
+export LITELLM_LOCAL_EMBED_MODEL="${LITELLM_LOCAL_EMBED_MODEL:-ollama/${EMBED_MODEL}}"
+
+case "${LITELLM_LOCAL_CHAT_MODEL}" in
+  ollama/*|ollama_chat/*) ;;
+  *) fail "LITELLM_LOCAL_CHAT_MODEL must use the local Ollama provider. Got '${LITELLM_LOCAL_CHAT_MODEL}'." ;;
+esac
+
+case "${LITELLM_LOCAL_EMBED_MODEL}" in
+  ollama/*) ;;
+  *) fail "LITELLM_LOCAL_EMBED_MODEL must use the local Ollama provider. Got '${LITELLM_LOCAL_EMBED_MODEL}'." ;;
+esac
+
+command -v litellm >/dev/null 2>&1 || fail "litellm command not found. Run: cd infra/litellm && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt" 127
+
+printf 'Starting LiteLLM on http://%s:%s using local Ollama at %s\n' "${LITELLM_HOST}" "${LITELLM_PORT}" "${OLLAMA_API_BASE}"
+printf 'Config: %s\n' "${CONFIG_FILE}"
+
+exec litellm --config "${CONFIG_FILE}" --host "${LITELLM_HOST}" --port "${LITELLM_PORT}"

--- a/infra/litellm/test_local_chat.sh
+++ b/infra/litellm/test_local_chat.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required." 127
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for response validation." 127
+
+[ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required."
+
+LITELLM_HOST="${LITELLM_HOST:-127.0.0.1}"
+LITELLM_PORT="${LITELLM_PORT:-4000}"
+[ "${LITELLM_HOST}" = "127.0.0.1" ] || fail "Refusing non-local LiteLLM host '${LITELLM_HOST}'."
+
+URL="http://${LITELLM_HOST}:${LITELLM_PORT}/v1/chat/completions"
+PAYLOAD='{"model":"local_chat","messages":[{"role":"user","content":"Responda em uma frase curta: o que e um teste local?"}],"temperature":0,"max_tokens":64}'
+
+if ! RESPONSE="$(curl -fsS --max-time 60 -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" -H "Content-Type: application/json" -d "${PAYLOAD}" "${URL}")"; then
+  fail "LiteLLM chat completion failed at ${URL}. Check LiteLLM and Ollama/Qwen."
+fi
+
+python3 -c '
+import json
+import sys
+
+raw = sys.stdin.read()
+try:
+    body = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"ERROR: chat completion did not return valid JSON: {exc}") from exc
+
+choices = body.get("choices")
+if not isinstance(choices, list) or not choices:
+    raise SystemExit("ERROR: chat completion response has no choices.")
+
+message = choices[0].get("message") if isinstance(choices[0], dict) else None
+content = message.get("content") if isinstance(message, dict) else None
+if not isinstance(content, str) or not content.strip():
+    raise SystemExit("ERROR: chat completion returned empty content.")
+
+compact = " ".join(content.split())
+print(f"OK: local_chat responded: {compact[:180]}")
+' <<< "${RESPONSE}"

--- a/infra/litellm/test_models.sh
+++ b/infra/litellm/test_models.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required." 127
+command -v python3 >/dev/null 2>&1 || fail "python3 is required for response validation." 127
+
+[ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required."
+
+LITELLM_HOST="${LITELLM_HOST:-127.0.0.1}"
+LITELLM_PORT="${LITELLM_PORT:-4000}"
+[ "${LITELLM_HOST}" = "127.0.0.1" ] || fail "Refusing non-local LiteLLM host '${LITELLM_HOST}'."
+
+URL="http://${LITELLM_HOST}:${LITELLM_PORT}/v1/models"
+
+if ! RESPONSE="$(curl -fsS --max-time 10 -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" "${URL}")"; then
+  fail "LiteLLM /v1/models is not reachable at ${URL}. Is start_litellm.sh running?"
+fi
+
+python3 -c '
+import json
+import sys
+
+expected = {"local_chat", "local_think", "local_rag", "local_json", "local_embed"}
+raw = sys.stdin.read()
+try:
+    body = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"ERROR: /v1/models did not return valid JSON: {exc}") from exc
+
+data = body.get("data")
+if not isinstance(data, list):
+    raise SystemExit("ERROR: /v1/models response is missing a data list.")
+
+seen = {
+    str(item.get("id") or item.get("model_name") or item.get("model") or "")
+    for item in data
+    if isinstance(item, dict)
+}
+missing = sorted(expected - seen)
+if missing:
+    raise SystemExit(f"ERROR: Missing LiteLLM aliases: {missing}. Seen: {sorted(seen)}")
+
+print("OK: /v1/models exposes local gateway aliases.")
+' <<< "${RESPONSE}"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Executable helper scripts for OpenClaw local workflows."""

--- a/scripts/check_litellm_gateway.sh
+++ b/scripts/check_litellm_gateway.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec "${REPO_ROOT}/infra/litellm/healthcheck.sh"

--- a/scripts/rag_ask_local.py
+++ b/scripts/rag_ask_local.py
@@ -16,7 +16,8 @@ from typing import Any
 
 from backend.rag.context_packer import ContextPacker
 from backend.rag.embeddings import OllamaEmbedder
-from backend.rag.generator import DEFAULT_GENERATION_MODEL, LocalGenerator
+from backend.gateway.client import DEFAULT_LLM_RAG_MODEL, DEFAULT_LLM_REASONING_MODEL
+from backend.rag.generator import LocalGenerator
 from backend.rag.health import check_local_services
 from backend.rag.pipeline import LocalRagPipeline, RagPipelineResult
 from backend.rag.prompt_builder import PromptBuilder
@@ -28,12 +29,15 @@ async def ask_local(
     question: str,
     top_k: int = 5,
     thinking_mode: bool = False,
-    model: str = DEFAULT_GENERATION_MODEL,
+    model: str | None = None,
     filters: Mapping[str, Any] | None = None,
 ) -> RagPipelineResult:
-    """Run one local RAG question with default Ollama + Qdrant components."""
+    """Run one local RAG question with Qdrant retrieval and LiteLLM generation."""
 
-    async with OllamaEmbedder() as embedder, LocalGenerator(model=model) as generator:
+    effective_model = model or (
+        DEFAULT_LLM_REASONING_MODEL if thinking_mode else DEFAULT_LLM_RAG_MODEL
+    )
+    async with OllamaEmbedder() as embedder, LocalGenerator(model=effective_model) as generator:
         store = QdrantVectorStore()
         try:
             retriever = Retriever(
@@ -83,7 +87,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("question", help="Pergunta em linguagem natural.")
     parser.add_argument("--top-k", type=int, default=5)
     parser.add_argument("--thinking", action="store_true")
-    parser.add_argument("--model", default=DEFAULT_GENERATION_MODEL)
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "LiteLLM semantic alias. Defaults to local_rag, or local_think "
+            "when --thinking is set."
+        ),
+    )
     parser.add_argument("--verbose", action="store_true")
     return parser.parse_args()
 

--- a/scripts/test_opencraw_litellm_runtime.sh
+++ b/scripts/test_opencraw_litellm_runtime.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+[ -n "${QUIMERA_LLM_API_KEY:-}" ] || fail "QUIMERA_LLM_API_KEY is required and should match LITELLM_MASTER_KEY."
+
+QUIMERA_LLM_BASE_URL="${QUIMERA_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+QUIMERA_LLM_MODEL="${QUIMERA_LLM_MODEL:-local_chat}"
+QUIMERA_LLM_REASONING_MODEL="${QUIMERA_LLM_REASONING_MODEL:-local_think}"
+QUIMERA_LLM_RAG_MODEL="${QUIMERA_LLM_RAG_MODEL:-local_rag}"
+QUIMERA_LLM_JSON_MODEL="${QUIMERA_LLM_JSON_MODEL:-local_json}"
+
+case "${QUIMERA_LLM_BASE_URL}" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *) fail "QUIMERA_LLM_BASE_URL must point to the local LiteLLM gateway. Got '${QUIMERA_LLM_BASE_URL}'." ;;
+esac
+
+command -v curl >/dev/null 2>&1 || fail "curl is required." 127
+
+if [ -x ".venv/bin/python" ]; then
+  PYTHON_BIN=".venv/bin/python"
+else
+  PYTHON_BIN="${PYTHON:-python3}"
+fi
+command -v "${PYTHON_BIN}" >/dev/null 2>&1 || fail "python is required." 127
+
+MODELS_BODY="$(mktemp)"
+trap 'rm -f "${MODELS_BODY}"' EXIT
+HTTP_STATUS="$(
+  curl -sS --max-time 10 \
+    -o "${MODELS_BODY}" \
+    -w "%{http_code}" \
+    -H "Authorization: Bearer ${QUIMERA_LLM_API_KEY}" \
+    "${QUIMERA_LLM_BASE_URL%/}/models" || true
+)"
+
+case "${HTTP_STATUS}" in
+  200) ;;
+  401|403)
+    fail "LiteLLM authentication failed. QUIMERA_LLM_API_KEY should match LITELLM_MASTER_KEY."
+    ;;
+  000)
+    fail "LiteLLM /v1/models is not reachable. Start infra/litellm/start_litellm.sh."
+    ;;
+  *)
+    fail "LiteLLM /v1/models returned HTTP ${HTTP_STATUS}."
+    ;;
+esac
+
+printf 'OK: LiteLLM /models reachable at %s\n' "${QUIMERA_LLM_BASE_URL%/}/models"
+
+"${PYTHON_BIN}" - <<'PY'
+import asyncio
+import json
+import os
+import time
+
+import httpx
+
+from backend.gateway.client import GatewayChatClient, GatewayRuntimeConfig
+
+
+ALIASES = [
+    (
+        os.environ.get("QUIMERA_LLM_MODEL", "local_chat"),
+        "Explique em uma frase o que e risco de concentracao.",
+        None,
+    ),
+    (
+        os.environ.get("QUIMERA_LLM_REASONING_MODEL", "local_think"),
+        "Planeje em uma frase como revisar uma hipotese sintetica.",
+        None,
+    ),
+    (
+        os.environ.get("QUIMERA_LLM_RAG_MODEL", "local_rag"),
+        "Classifique esta pergunta sintetica: carteira hipotetica com 50% em FIIs.",
+        None,
+    ),
+    (
+        os.environ.get("QUIMERA_LLM_JSON_MODEL", "local_json"),
+        (
+            "Responda somente JSON valido, sem markdown: "
+            '{"classe":"alocacao_sintetica","fiis":50,"renda_fixa":30,"acoes":20}'
+        ),
+        {"type": "json_object"},
+    ),
+]
+
+
+async def main() -> None:
+    config = GatewayRuntimeConfig.from_env().validated()
+    async with GatewayChatClient(config=config) as client:
+        for alias, prompt, response_format in ALIASES:
+            start = time.perf_counter()
+            try:
+                answer = await client.chat_completion(
+                    [{"role": "user", "content": prompt}],
+                    model=alias,
+                    temperature=0.0,
+                    max_tokens=96,
+                    response_format=response_format,
+                )
+                if alias == os.environ.get("QUIMERA_LLM_JSON_MODEL", "local_json"):
+                    json.loads(answer)
+            except httpx.HTTPStatusError as exc:
+                raise SystemExit(
+                    f"ERROR: alias {alias} failed with HTTP {exc.response.status_code}"
+                ) from exc
+            except Exception as exc:
+                raise SystemExit(f"ERROR: alias {alias} failed: {exc}") from exc
+
+            latency_ms = (time.perf_counter() - start) * 1000
+            # Print truncated response (synthetic output only — no real portfolio data)
+            compact = " ".join(answer.split())[:120]
+            print(f"OK: {alias} responded in {latency_ms:.1f}ms: {compact}")
+
+
+asyncio.run(main())
+PY

--- a/tests/smoke/test_gateway_runtime_smoke.py
+++ b/tests/smoke/test_gateway_runtime_smoke.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import httpx
+import pytest
+
+from backend.gateway.client import (
+    DEFAULT_LLM_JSON_MODEL,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_RAG_MODEL,
+    DEFAULT_LLM_REASONING_MODEL,
+    ENV_LLM_API_KEY,
+    GatewayChatClient,
+    GatewayRuntimeConfig,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_LITELLM_SMOKE") != "1",
+    reason="LiteLLM runtime smoke skipped; set RUN_LITELLM_SMOKE=1 to enable.",
+)
+
+
+def _runtime_config() -> GatewayRuntimeConfig:
+    if not os.environ.get(ENV_LLM_API_KEY):
+        pytest.skip(f"{ENV_LLM_API_KEY} is required for LiteLLM runtime smoke.")
+    return GatewayRuntimeConfig.from_env().validated()
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_litellm_runtime_aliases_respond() -> None:
+    config = _runtime_config()
+    cases = [
+        (
+            os.environ.get("QUIMERA_LLM_MODEL", DEFAULT_LLM_MODEL),
+            "Explique em uma frase o que e risco de concentracao.",
+            None,
+        ),
+        (
+            os.environ.get("QUIMERA_LLM_REASONING_MODEL", DEFAULT_LLM_REASONING_MODEL),
+            "Planeje em uma frase como revisar uma hipotese sintetica.",
+            None,
+        ),
+        (
+            os.environ.get("QUIMERA_LLM_RAG_MODEL", DEFAULT_LLM_RAG_MODEL),
+            "Classifique esta pergunta sintetica: carteira hipotetica com 50% em FIIs.",
+            None,
+        ),
+        (
+            os.environ.get("QUIMERA_LLM_JSON_MODEL", DEFAULT_LLM_JSON_MODEL),
+            (
+                "Responda somente JSON valido, sem markdown: "
+                '{"classe":"alocacao_sintetica","fiis":50,"renda_fixa":30,"acoes":20}'
+            ),
+            {"type": "json_object"},
+        ),
+    ]
+
+    async with GatewayChatClient(config=config) as client:
+        for alias, prompt, response_format in cases:
+            start = time.perf_counter()
+            try:
+                answer = await client.chat_completion(
+                    [{"role": "user", "content": prompt}],
+                    model=alias,
+                    temperature=0.0,
+                    max_tokens=96,
+                    response_format=response_format,
+                )
+            except Exception as exc:
+                raise AssertionError(
+                    f"LiteLLM alias {alias!r} failed. Check LiteLLM, Ollama, "
+                    "QUIMERA_LLM_API_KEY, and configured aliases."
+                ) from exc
+
+            assert answer.strip(), f"LiteLLM alias {alias!r} returned an empty answer"
+            assert (time.perf_counter() - start) < 120, (
+                f"LiteLLM alias {alias!r} exceeded the smoke timeout"
+            )
+            if alias == os.environ.get("QUIMERA_LLM_JSON_MODEL", DEFAULT_LLM_JSON_MODEL):
+                try:
+                    json.loads(answer)
+                except json.JSONDecodeError as exc:
+                    raise AssertionError(
+                        f"LiteLLM JSON alias {alias!r} did not return parseable JSON: "
+                        f"{answer[:120]!r}"
+                    ) from exc
+
+
+@pytest.mark.smoke
+def test_litellm_models_endpoint_exposes_runtime_aliases() -> None:
+    config = _runtime_config()
+    models_url = f"{config.base_url.rstrip('/')}/models"
+    try:
+        response = httpx.get(
+            models_url,
+            headers={"Authorization": f"Bearer {config.api_key}"},
+            timeout=10,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in {401, 403}:
+            raise AssertionError(
+                "LiteLLM authentication failed. QUIMERA_LLM_API_KEY should match "
+                "LITELLM_MASTER_KEY."
+            ) from exc
+        raise AssertionError(f"LiteLLM /models returned HTTP {exc.response.status_code}") from exc
+    except httpx.RequestError as exc:
+        raise AssertionError(
+            f"LiteLLM /models is not reachable at {models_url}. "
+            "Start infra/litellm/start_litellm.sh."
+        ) from exc
+
+    body = response.json()
+    data = body.get("data")
+    assert isinstance(data, list), "LiteLLM /models response is missing a data list"
+    seen = {
+        str(item.get("id") or item.get("model_name") or item.get("model") or "")
+        for item in data
+        if isinstance(item, dict)
+    }
+    expected = {
+        os.environ.get("QUIMERA_LLM_MODEL", DEFAULT_LLM_MODEL),
+        os.environ.get("QUIMERA_LLM_REASONING_MODEL", DEFAULT_LLM_REASONING_MODEL),
+        os.environ.get("QUIMERA_LLM_RAG_MODEL", DEFAULT_LLM_RAG_MODEL),
+        os.environ.get("QUIMERA_LLM_JSON_MODEL", DEFAULT_LLM_JSON_MODEL),
+    }
+    missing = sorted(expected - seen)
+    assert not missing, f"LiteLLM /models is missing aliases: {missing}"

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+import httpx
+import yaml
+
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_JSON_MODEL,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_RAG_MODEL,
+    DEFAULT_LLM_REASONING_MODEL,
+    GatewayChatClient,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConfigurationError,
+    GatewayConnectionError,
+    GatewayResponseError,
+)
+
+
+class GatewayRuntimeConfigTests(unittest.TestCase):
+    def test_defaults_point_to_local_litellm_aliases(self) -> None:
+        config = GatewayRuntimeConfig(api_key="dev-key").validated()
+
+        self.assertEqual(config.base_url, "http://127.0.0.1:4000/v1")
+        self.assertEqual(config.default_model, "local_chat")
+        self.assertEqual(config.reasoning_model, "local_think")
+        self.assertEqual(config.rag_model, "local_rag")
+        self.assertEqual(config.json_model, "local_json")
+
+    def test_default_constants_do_not_include_vendor_model_names(self) -> None:
+        defaults = [
+            DEFAULT_LLM_BASE_URL,
+            DEFAULT_LLM_MODEL,
+            DEFAULT_LLM_REASONING_MODEL,
+            DEFAULT_LLM_RAG_MODEL,
+            DEFAULT_LLM_JSON_MODEL,
+        ]
+
+        forbidden = ("qwen", "qwen3", "llama", "ollama/", "gpt", "claude", "gemini")
+        for value in defaults:
+            with self.subTest(value=value):
+                lowered = value.lower()
+                self.assertFalse(any(name in lowered for name in forbidden))
+
+    def test_rag_generation_config_uses_semantic_aliases(self) -> None:
+        config_path = Path(__file__).resolve().parents[2] / "config" / "rag_config.yaml"
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        generation = raw["rag"]["generation"]
+
+        self.assertEqual(generation["endpoint"], DEFAULT_LLM_BASE_URL)
+        self.assertEqual(generation["model"], DEFAULT_LLM_RAG_MODEL)
+        self.assertEqual(generation["reasoning_model"], DEFAULT_LLM_REASONING_MODEL)
+        self.assertEqual(generation["json_model"], DEFAULT_LLM_JSON_MODEL)
+        for key in ("model", "reasoning_model", "json_model", "endpoint"):
+            value = str(generation[key]).lower()
+            self.assertNotIn("qwen", value)
+            self.assertNotIn("ollama/", value)
+
+    def test_remote_base_url_is_rejected(self) -> None:
+        with self.assertRaises(GatewayConfigurationError):
+            GatewayRuntimeConfig(
+                base_url="https://api.openai.com/v1",
+                api_key="dev-key",
+            ).validated()
+
+    def test_missing_api_key_raises_authentication_error_without_secret(self) -> None:
+        with self.assertRaises(GatewayAuthenticationError) as ctx:
+            GatewayRuntimeConfig(api_key=None).validated()
+
+        self.assertNotIn("dev-key", str(ctx.exception))
+        self.assertIn("QUIMERA_LLM_API_KEY", str(ctx.exception))
+
+
+class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_chat_completion_posts_openai_compatible_payload(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+        seen_auth_headers: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            seen_auth_headers.append(request.headers.get("authorization"))
+            self.assertEqual(request.url.path, "/v1/chat/completions")
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta compacta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            answer = await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                temperature=0.1,
+                max_tokens=64,
+            )
+
+        self.assertEqual(answer, "Resposta compacta.")
+        self.assertEqual(seen_auth_headers, ["Bearer secret-test-key"])
+        self.assertEqual(
+            seen_payloads,
+            [
+                {
+                    "model": "local_chat",
+                    "messages": [{"role": "user", "content": "pergunta"}],
+                    "temperature": 0.1,
+                    "max_tokens": 64,
+                }
+            ],
+        )
+
+    async def test_authentication_failure_does_not_print_api_key(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(lambda _request: httpx.Response(401)),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayAuthenticationError) as ctx:
+                await gateway.chat_completion([{"role": "user", "content": "pergunta"}])
+
+        self.assertNotIn("secret-test-key", str(ctx.exception))
+        self.assertIn("authentication failed", str(ctx.exception))
+
+    async def test_connection_failure_raises_domain_exception(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayConnectionError) as ctx:
+                await gateway.chat_completion([{"role": "user", "content": "pergunta"}])
+
+        self.assertIn("local LiteLLM gateway", str(ctx.exception))
+
+    async def test_invalid_response_raises_domain_exception(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(200, json={"choices": []})
+            ),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayResponseError):
+                await gateway.chat_completion([{"role": "user", "content": "pergunta"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_config.py
+++ b/tests/unit/test_gateway_config.py
@@ -1,0 +1,285 @@
+"""Contract and schema tests for backend.gateway.config.
+
+Two test classes:
+
+* ``TestGatewaySchema`` — pure schema-level unit tests; no filesystem access.
+* ``TestActualGatewayConfig`` — contract tests that load the real
+  ``config/litellm_config.yaml`` and assert the structural invariants that
+  the runtime wiring adapter will depend on.
+
+If any test in ``TestActualGatewayConfig`` fails, the YAML was changed in a
+way that breaks the gateway contract and the PR must not merge.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from backend.gateway.config import (
+    REQUIRED_ALIASES,
+    GatewayConfig,
+    LiteLLMParams,
+    LiteLLMSettings,
+    load_gateway_config,
+)
+from backend.gateway.errors import GatewayConfigurationError, GatewayModelAliasError
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+_YAML_PATH = Path(__file__).parent.parent.parent / "config" / "litellm_config.yaml"
+
+_LOCALHOST = "http://localhost:11434"
+_LOOPBACK = "http://127.0.0.1:11434"
+_REMOTE = "https://api.openai.com"
+
+GatewayAliasRaw = dict[str, Any]
+
+
+def _alias(
+    name: str,
+    *,
+    api_base: str = _LOCALHOST,
+    model: str = "ollama_chat/qwen3:14b",
+    timeout: int = 60,
+    thinking_mode: bool = False,
+) -> GatewayAliasRaw:
+    return {
+        "model_name": name,
+        "litellm_params": {"model": model, "api_base": api_base, "timeout": timeout},
+        "model_info": {
+            "provider": "ollama",
+            "purpose": "test",
+            "thinking_mode": thinking_mode,
+        },
+    }
+
+
+def _all_required_aliases(**overrides: Any) -> list[GatewayAliasRaw]:
+    """Return one dict per required alias, applying *overrides* to every entry."""
+    return [_alias(name, **overrides) for name in sorted(REQUIRED_ALIASES)]
+
+
+# ─── Schema unit tests ────────────────────────────────────────────────────────
+
+
+class TestLiteLLMParamsValidator(unittest.TestCase):
+    """Unit tests for the LiteLLMParams field validator."""
+
+    def test_localhost_api_base_accepted(self) -> None:
+        params = LiteLLMParams(
+            model="ollama_chat/qwen3:14b", api_base=_LOCALHOST, timeout=60
+        )
+        self.assertEqual(params.api_base, _LOCALHOST)
+
+    def test_loopback_ip_accepted(self) -> None:
+        params = LiteLLMParams(
+            model="ollama_chat/qwen3:14b", api_base=_LOOPBACK, timeout=60
+        )
+        self.assertEqual(params.api_base, _LOOPBACK)
+
+    def test_remote_api_base_rejected(self) -> None:
+        with self.assertRaises(ValidationError) as ctx:
+            LiteLLMParams(model="gpt-4", api_base=_REMOTE, timeout=60)
+        self.assertIn("remote host", str(ctx.exception))
+
+    def test_https_localhost_rejected(self) -> None:
+        """TLS termination proxy on localhost is also out of Gateway-0 scope."""
+        with self.assertRaises(ValidationError):
+            LiteLLMParams(
+                model="local", api_base="https://localhost:11434", timeout=60
+            )
+
+
+class TestGatewayConfigValidator(unittest.TestCase):
+    """Unit tests for GatewayConfig model-level validation."""
+
+    def test_all_required_aliases_accepted(self) -> None:
+        raw = {"model_list": _all_required_aliases()}
+        config = GatewayConfig.model_validate(raw)
+        self.assertEqual(config.alias_names, REQUIRED_ALIASES)
+
+    def test_missing_single_alias_rejected(self) -> None:
+        aliases = [
+            _alias(name)
+            for name in REQUIRED_ALIASES
+            if name != "local_embed"
+        ]
+        with self.assertRaises(ValidationError) as ctx:
+            GatewayConfig.model_validate({"model_list": aliases})
+        self.assertIn("local_embed", str(ctx.exception))
+
+    def test_missing_multiple_aliases_rejected(self) -> None:
+        raw = {"model_list": [_alias("local_chat")]}
+        with self.assertRaises(ValidationError) as ctx:
+            GatewayConfig.model_validate(raw)
+        self.assertIn("missing required aliases", str(ctx.exception))
+
+    def test_extra_alias_permitted(self) -> None:
+        """Additional aliases beyond the required five must not cause failures."""
+        aliases = _all_required_aliases() + [_alias("local_extra")]
+        config = GatewayConfig.model_validate({"model_list": aliases})
+        self.assertIn("local_extra", config.alias_names)
+
+    def test_get_alias_returns_correct_entry(self) -> None:
+        config = GatewayConfig.model_validate({"model_list": _all_required_aliases()})
+        alias = config.get_alias("local_chat")
+        self.assertEqual(alias.model_name, "local_chat")
+
+    def test_get_alias_raises_for_unknown_name(self) -> None:
+        config = GatewayConfig.model_validate({"model_list": _all_required_aliases()})
+        with self.assertRaises(GatewayModelAliasError):
+            config.get_alias("does_not_exist")
+
+    def test_default_litellm_settings_applied(self) -> None:
+        config = GatewayConfig.model_validate({"model_list": _all_required_aliases()})
+        self.assertTrue(config.litellm_settings.drop_params)
+        self.assertFalse(config.litellm_settings.set_verbose)
+
+    def test_remote_api_base_in_any_alias_rejected(self) -> None:
+        aliases = _all_required_aliases()
+        aliases[0]["litellm_params"]["api_base"] = _REMOTE
+        with self.assertRaises(ValidationError) as ctx:
+            GatewayConfig.model_validate({"model_list": aliases})
+        self.assertIn("remote host", str(ctx.exception))
+
+
+class TestLoadGatewayConfigErrors(unittest.TestCase):
+    """Unit tests for load_gateway_config error handling."""
+
+    def test_missing_file_raises_gateway_config_error(self) -> None:
+        with self.assertRaises(GatewayConfigurationError) as ctx:
+            load_gateway_config("/nonexistent/path/litellm_config.yaml")
+        self.assertIn("not found", str(ctx.exception))
+
+    def test_invalid_yaml_raises_gateway_config_error(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write("model_list: [\n  - broken yaml: [")
+            tmp = f.name
+        with self.assertRaises(GatewayConfigurationError) as ctx:
+            load_gateway_config(tmp)
+        self.assertIn("YAML parse error", str(ctx.exception))
+
+    def test_non_mapping_yaml_raises_gateway_config_error(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            f.write("- just\n- a list\n")
+            tmp = f.name
+        with self.assertRaises(GatewayConfigurationError) as ctx:
+            load_gateway_config(tmp)
+        self.assertIn("not a YAML mapping", str(ctx.exception))
+
+
+# ─── Contract tests against real litellm_config.yaml ─────────────────────────
+
+
+class TestActualGatewayConfig(unittest.TestCase):
+    """Contract tests that load the real config/litellm_config.yaml.
+
+    These tests define the invariants the wiring adapter will rely on.
+    A failing test here means the YAML change broke a gateway contract.
+    """
+
+    def setUp(self) -> None:
+        self.config = load_gateway_config(_YAML_PATH)
+
+    def test_all_five_required_aliases_present(self) -> None:
+        self.assertEqual(
+            self.config.alias_names,
+            REQUIRED_ALIASES,
+            "All five required aliases must be defined in litellm_config.yaml",
+        )
+
+    def test_all_aliases_use_local_api_base(self) -> None:
+        for alias in self.config.model_list:
+            with self.subTest(alias=alias.model_name):
+                self.assertTrue(
+                    alias.litellm_params.api_base.startswith("http://localhost:"),
+                    f"Alias '{alias.model_name}' has non-local api_base: "
+                    f"{alias.litellm_params.api_base}",
+                )
+
+    def test_local_think_has_thinking_mode_true(self) -> None:
+        """Adapter contract: local_think must signal thinking_mode so /think is injected."""
+        think = self.config.get_alias("local_think")
+        self.assertTrue(
+            think.model_info.thinking_mode,
+            "local_think.model_info.thinking_mode must be true — "
+            "the future wiring adapter reads this field to inject /think",
+        )
+
+    def test_non_thinking_aliases_have_thinking_mode_false(self) -> None:
+        """Adapter contract: default aliases must NOT inject /think."""
+        for name in ("local_chat", "local_rag", "local_json"):
+            with self.subTest(alias=name):
+                alias = self.config.get_alias(name)
+                self.assertFalse(
+                    alias.model_info.thinking_mode,
+                    f"'{name}' must have thinking_mode=false",
+                )
+
+    def test_local_embed_maps_to_nomic_embed_text(self) -> None:
+        embed = self.config.get_alias("local_embed")
+        self.assertIn(
+            "nomic-embed-text",
+            embed.litellm_params.model,
+            "local_embed must map to the nomic-embed-text model",
+        )
+
+    def test_local_chat_maps_to_qwen(self) -> None:
+        chat = self.config.get_alias("local_chat")
+        self.assertIn(
+            "qwen",
+            chat.litellm_params.model.lower(),
+            "local_chat must map to a Qwen model",
+        )
+
+    def test_local_think_uses_longer_timeout(self) -> None:
+        """Thinking calls need more wall time than default chat calls."""
+        think = self.config.get_alias("local_think")
+        chat = self.config.get_alias("local_chat")
+        self.assertGreater(
+            think.litellm_params.timeout,
+            chat.litellm_params.timeout,
+            "local_think timeout must exceed local_chat timeout",
+        )
+
+    def test_drop_params_enabled(self) -> None:
+        self.assertTrue(
+            self.config.litellm_settings.drop_params,
+            "drop_params must be enabled to suppress unsupported params silently",
+        )
+
+    def test_verbose_disabled(self) -> None:
+        self.assertFalse(
+            self.config.litellm_settings.set_verbose,
+            "set_verbose must be false to keep logs clean in production",
+        )
+
+    def test_no_alias_points_to_remote_provider(self) -> None:
+        """Security contract: no remote provider may slip into the config."""
+        for alias in self.config.model_list:
+            with self.subTest(alias=alias.model_name):
+                self.assertFalse(
+                    alias.litellm_params.api_base.startswith("https://"),
+                    f"Alias '{alias.model_name}' unexpectedly points to HTTPS endpoint",
+                )
+                self.assertNotIn(
+                    "openai",
+                    alias.litellm_params.api_base.lower(),
+                    f"Alias '{alias.model_name}' api_base contains 'openai'",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_errors.py
+++ b/tests/unit/test_gateway_errors.py
@@ -1,0 +1,51 @@
+import unittest
+
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConnectionError,
+    GatewayConfigurationError,
+    GatewayError,
+    GatewayModelAliasError,
+    GatewayProviderUnavailableError,
+    GatewayRequestRejectedError,
+    GatewayResponseError,
+    GatewayTimeoutError,
+)
+
+
+class GatewayErrorTests(unittest.TestCase):
+    def test_gateway_error_preserves_message_and_context(self) -> None:
+        error = GatewayError(
+            "provider unavailable",
+            alias="local_chat",
+            provider="ollama",
+        )
+
+        self.assertEqual(str(error), "provider unavailable")
+        self.assertEqual(
+            error.to_log_context(),
+            {"alias": "local_chat", "provider": "ollama"},
+        )
+
+    def test_gateway_error_omits_empty_context(self) -> None:
+        error = GatewayError("unsafe request")
+
+        self.assertEqual(error.to_log_context(), {})
+
+    def test_domain_errors_share_base_type(self) -> None:
+        for error_type in (
+            GatewayConfigurationError,
+            GatewayConnectionError,
+            GatewayAuthenticationError,
+            GatewayModelAliasError,
+            GatewayProviderUnavailableError,
+            GatewayRequestRejectedError,
+            GatewayResponseError,
+            GatewayTimeoutError,
+        ):
+            with self.subTest(error_type=error_type):
+                self.assertIsInstance(error_type("failure"), GatewayError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_health.py
+++ b/tests/unit/test_gateway_health.py
@@ -1,0 +1,220 @@
+"""Unit tests for backend.gateway.health semantic checks.
+
+All Ollama network calls are mocked via unittest.mock.patch so these tests
+run without any local service running.
+
+The key invariant under test: check_gateway_services() must exit with
+status 1 and a human-readable message whenever:
+  - Ollama is not reachable;
+  - a required model is missing from the model list;
+  - Ollama returns a non-200 status.
+
+It must NOT exit when all required models are present.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from backend.gateway.health import (
+    OLLAMA_TAGS_URL,
+    REQUIRED_CHAT_MODEL,
+    REQUIRED_EMBED_MODEL,
+    REQUIRED_GATEWAY_ALIASES,
+    check_gateway_services,
+    check_litellm_gateway,
+)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _tags_ok(*model_names: str) -> httpx.Response:
+    """Return a 200 /api/tags response listing *model_names*."""
+    return httpx.Response(
+        200,
+        json={"models": [{"name": name} for name in model_names]},
+        request=httpx.Request("GET", OLLAMA_TAGS_URL),
+    )
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code,
+        request=httpx.Request("GET", OLLAMA_TAGS_URL),
+    )
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=response.request, response=response
+    )
+
+
+def _models_ok(*model_names: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"data": [{"id": name} for name in model_names]},
+        request=httpx.Request("GET", "http://127.0.0.1:4000/v1/models"),
+    )
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestCheckGatewayServices(unittest.TestCase):
+    def test_passes_when_both_models_available(self) -> None:
+        """No exit when both chat and embed models are present."""
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(REQUIRED_CHAT_MODEL, REQUIRED_EMBED_MODEL),
+        ):
+            # Must not raise or call sys.exit.
+            check_gateway_services()
+
+    def test_exits_1_when_ollama_unreachable(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_exits_1_when_chat_model_missing(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(REQUIRED_EMBED_MODEL),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services(require_chat=True, require_embed=False)
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_exits_1_when_embed_model_missing(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(REQUIRED_CHAT_MODEL),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services(require_chat=False, require_embed=True)
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_skips_chat_check_when_not_required(self) -> None:
+        """Only embed model present — should not exit if require_chat=False."""
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(REQUIRED_EMBED_MODEL),
+        ):
+            check_gateway_services(require_chat=False, require_embed=True)
+
+    def test_skips_embed_check_when_not_required(self) -> None:
+        """Only chat model present — should not exit if require_embed=False."""
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(REQUIRED_CHAT_MODEL),
+        ):
+            check_gateway_services(require_chat=True, require_embed=False)
+
+    def test_exits_1_on_http_503(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            side_effect=_http_error(503),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_accepts_quantised_model_variant(self) -> None:
+        """qwen3:14b-instruct-q4_K_M should satisfy REQUIRED_CHAT_MODEL via base match."""
+        quantised = f"{REQUIRED_CHAT_MODEL.split(':')[0]}:14b-instruct-q4_K_M"
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=_tags_ok(quantised, REQUIRED_EMBED_MODEL),
+        ):
+            # Base name 'qwen3' matches the quantised variant — must not exit.
+            check_gateway_services()
+
+    def test_exits_when_models_key_is_empty_list(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=httpx.Response(
+                200,
+                json={"models": []},
+                request=httpx.Request("GET", OLLAMA_TAGS_URL),
+            ),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_exits_when_response_is_not_a_dict(self) -> None:
+        with patch(
+            "backend.gateway.health.httpx.get",
+            return_value=httpx.Response(
+                200,
+                json=["unexpected", "list"],
+                request=httpx.Request("GET", OLLAMA_TAGS_URL),
+            ),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_gateway_services()
+            self.assertEqual(ctx.exception.code, 1)
+
+
+class TestCheckLiteLLMGateway(unittest.TestCase):
+    def test_litellm_gateway_passes_when_aliases_available(self) -> None:
+        with (
+            patch.dict(
+                "os.environ",
+                {"QUIMERA_LLM_API_KEY": "dev-key"},
+                clear=False,
+            ),
+            patch(
+                "backend.gateway.health.httpx.get",
+                return_value=_models_ok(*REQUIRED_GATEWAY_ALIASES),
+            ),
+        ):
+            check_litellm_gateway()
+
+    def test_litellm_gateway_exits_when_api_key_missing(self) -> None:
+        with patch.dict("os.environ", {"QUIMERA_LLM_API_KEY": ""}, clear=False):
+            with self.assertRaises(SystemExit) as ctx:
+                check_litellm_gateway()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_litellm_gateway_exits_when_alias_missing(self) -> None:
+        aliases = sorted(REQUIRED_GATEWAY_ALIASES - {"local_json"})
+        with (
+            patch.dict(
+                "os.environ",
+                {"QUIMERA_LLM_API_KEY": "dev-key"},
+                clear=False,
+            ),
+            patch(
+                "backend.gateway.health.httpx.get",
+                return_value=_models_ok(*aliases),
+            ),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_litellm_gateway()
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_litellm_gateway_exits_on_auth_failure(self) -> None:
+        response = httpx.Response(
+            401,
+            request=httpx.Request("GET", "http://127.0.0.1:4000/v1/models"),
+        )
+        with (
+            patch.dict(
+                "os.environ",
+                {"QUIMERA_LLM_API_KEY": "dev-key"},
+                clear=False,
+            ),
+            patch("backend.gateway.health.httpx.get", return_value=response),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                check_litellm_gateway()
+            self.assertEqual(ctx.exception.code, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -1,32 +1,37 @@
 from __future__ import annotations
 
 import json
+import os
 import unittest
+from unittest.mock import patch
 
 import httpx
 
-from backend.rag.generator import GenerationError, LocalGenerator
+from backend.gateway.client import DEFAULT_LLM_BASE_URL
+from backend.gateway.errors import GatewayAuthenticationError, GatewayResponseError
+from backend.rag.generator import LocalGenerator
 
 
 class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
-    async def test_chat_posts_to_ollama_chat_endpoint(self) -> None:
+    async def test_chat_posts_to_litellm_chat_completions_endpoint(self) -> None:
         seen_payloads: list[dict[str, object]] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
             seen_payloads.append(json.loads(request.content.decode("utf-8")))
-            self.assertEqual(request.url.path, "/api/chat")
+            self.assertEqual(request.url.path, "/v1/chat/completions")
             return httpx.Response(
                 200,
-                json={"message": {"content": "Resposta com [doc-a#0]."}},
+                json={"choices": [{"message": {"content": "Resposta com [doc-a#0]."}}]},
             )
 
         async with httpx.AsyncClient(
-            base_url="http://ollama.test",
+            base_url=DEFAULT_LLM_BASE_URL,
             transport=httpx.MockTransport(handler),
         ) as client:
             generator = LocalGenerator(
                 client=client,
-                model="qwen3:14b",
+                api_key="dev-key",
+                model="local_rag",
                 max_tokens=128,
             )
             answer = await generator.chat(
@@ -37,25 +42,32 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(answer, "Resposta com [doc-a#0].")
-        self.assertEqual(seen_payloads[0]["model"], "qwen3:14b")
-        self.assertEqual(seen_payloads[0]["stream"], False)
-        self.assertEqual(seen_payloads[0]["options"], {"temperature": 0.2, "num_predict": 128})
+        self.assertEqual(seen_payloads[0]["model"], "local_rag")
+        self.assertEqual(seen_payloads[0]["temperature"], 0.2)
+        self.assertEqual(seen_payloads[0]["max_tokens"], 128)
 
     async def test_chat_strips_thinking_blocks_when_disabled(self) -> None:
         async with httpx.AsyncClient(
-            base_url="http://ollama.test",
+            base_url=DEFAULT_LLM_BASE_URL,
             transport=httpx.MockTransport(
                 lambda _request: httpx.Response(
                     200,
                     json={
-                        "message": {
-                            "content": "<think>rascunho interno</think>Resposta final [doc-a#0]."
-                        }
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": (
+                                        "<think>rascunho interno</think>"
+                                        "Resposta final [doc-a#0]."
+                                    )
+                                }
+                            }
+                        ]
                     },
                 )
             ),
         ) as client:
-            generator = LocalGenerator(client=client)
+            generator = LocalGenerator(client=client, api_key="dev-key")
             answer = await generator.chat(
                 [{"role": "user", "content": "pergunta sintetica"}],
                 thinking_mode=False,
@@ -65,19 +77,26 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_chat_keeps_thinking_blocks_when_enabled(self) -> None:
         async with httpx.AsyncClient(
-            base_url="http://ollama.test",
+            base_url=DEFAULT_LLM_BASE_URL,
             transport=httpx.MockTransport(
                 lambda _request: httpx.Response(
                     200,
                     json={
-                        "message": {
-                            "content": "<think>rascunho</think>Resposta final [doc-a#0]."
-                        }
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": (
+                                        "<think>rascunho</think>"
+                                        "Resposta final [doc-a#0]."
+                                    )
+                                }
+                            }
+                        ]
                     },
                 )
             ),
         ) as client:
-            generator = LocalGenerator(client=client)
+            generator = LocalGenerator(client=client, api_key="dev-key")
             answer = await generator.chat(
                 [{"role": "user", "content": "pergunta sintetica"}],
                 thinking_mode=True,
@@ -87,14 +106,46 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_invalid_response_raises_generation_error(self) -> None:
         async with httpx.AsyncClient(
-            base_url="http://ollama.test",
+            base_url=DEFAULT_LLM_BASE_URL,
             transport=httpx.MockTransport(
-                lambda _request: httpx.Response(200, json={"message": {}})
+                lambda _request: httpx.Response(200, json={"choices": []})
             ),
         ) as client:
-            generator = LocalGenerator(client=client)
-            with self.assertRaises(GenerationError):
+            generator = LocalGenerator(client=client, api_key="dev-key")
+            with self.assertRaises(GatewayResponseError):
                 await generator.chat([{"role": "user", "content": "pergunta"}])
+
+    async def test_missing_gateway_api_key_fails_clearly(self) -> None:
+        with self.assertRaises(GatewayAuthenticationError) as ctx:
+            LocalGenerator(api_key="")
+
+        self.assertIn("QUIMERA_LLM_API_KEY", str(ctx.exception))
+
+    async def test_defaults_can_be_controlled_by_environment(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "ok"}}]},
+            )
+
+        env = {
+            "QUIMERA_LLM_BASE_URL": DEFAULT_LLM_BASE_URL,
+            "QUIMERA_LLM_API_KEY": "dev-key",
+            "QUIMERA_LLM_MODEL": "local_json",
+        }
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with patch.dict(os.environ, env, clear=False):
+                generator = LocalGenerator(client=client)
+                answer = await generator.chat([{"role": "user", "content": "pergunta"}])
+
+        self.assertEqual(answer, "ok")
+        self.assertEqual(seen_payloads[0]["model"], "local_json")
 
     async def test_validation_errors(self) -> None:
         with self.assertRaises(ValueError):
@@ -107,10 +158,10 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
             LocalGenerator(max_tokens=0)
 
         async with httpx.AsyncClient(
-            base_url="http://ollama.test",
+            base_url=DEFAULT_LLM_BASE_URL,
             transport=httpx.MockTransport(lambda _request: httpx.Response(200)),
         ) as client:
-            generator = LocalGenerator(client=client)
+            generator = LocalGenerator(client=client, api_key="dev-key")
             with self.assertRaises(ValueError):
                 await generator.chat([])
             with self.assertRaises(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,815 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-tools"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/c8/1223f29c84a143ae9a56c084fc96894de0ba84b6e8d60a26241abd81d278/grpcio_tools-1.80.0.tar.gz", hash = "sha256:26052b19c6ce0dcf52d1024496aea3e2bdfa864159f06dc7b97b22d041a94b26", size = 6133212, upload-time = "2026-03-30T08:52:39.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/b9/65929df8c9614792db900a8e45d4997fadbd1734c827da3f0eb1f2fe4866/grpcio_tools-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:d19d5a8244311947b96f749c417b32d144641c6953f1164824579e1f0a51d040", size = 2550856, upload-time = "2026-03-30T08:50:57.3Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/af1557544d68d1aeca9d9ea53ed16524022d521fec6ba334ab3530e9c1a6/grpcio_tools-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fb599a3dc89ed1bb24489a2724b2f6dd4cddbbf0f7bdd69c073477bab0dc7554", size = 5710883, upload-time = "2026-03-30T08:51:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/aa9b4f7519ca972bc40d315d5c28f05ca28fa08de13d4e8b69f551b798ab/grpcio_tools-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:623ee31fc2ff7df9a987b4f3d139c30af17ce46a861ae0e25fb8c112daa32dd8", size = 2598004, upload-time = "2026-03-30T08:51:02.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b8/b01371c119924b3beca1fe3f047b1bc2cdc66b3d37f0f3acc9d10c567a43/grpcio_tools-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b46570a68378539ee2b75a5a43202561f8d753c832798b1047099e3c551cf5d6", size = 2909568, upload-time = "2026-03-30T08:51:04.159Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7c/1108f7bdb58475a7e701ec89b55eb494538b6e76acd211ba0d4cc5fd28e8/grpcio_tools-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51caf99c28999e7e0f97e9cea190c1405b7681a57bb2e0631205accd92b43fa4", size = 2660938, upload-time = "2026-03-30T08:51:06.126Z" },
+    { url = "https://files.pythonhosted.org/packages/67/59/d1c0063d4cd3b85363c7044ff3e5159d6d5df96e2692a9a5312d9c8cb290/grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cdaa1c9aa8d3a87891a96700cadd29beec214711d6522818d207277f6452567c", size = 3113814, upload-time = "2026-03-30T08:51:08.834Z" },
+    { url = "https://files.pythonhosted.org/packages/76/21/18d34a4efe524c903cf66b0cfa5260d81f277b6ae668b647edf795df9ce5/grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3399b5fd7b59bcffd59c6b9975a969d9f37a3c87f3e3d63c3a09c147907acb0d", size = 3662793, upload-time = "2026-03-30T08:51:11.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/cf2d9295a6bd593244ea703858f8fc2efd315046ca3ef7c6f9ebc5b810fa/grpcio_tools-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9c6abc08d3485b2aac99bb58afcd31dc6cd4316ce36cf263ff09cb6df15f287f", size = 3329149, upload-time = "2026-03-30T08:51:13.066Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1d/fc34b32167966df20d69429b71dfca83c48434b047a5ac4fd6cd91ca4eed/grpcio_tools-1.80.0-cp312-cp312-win32.whl", hash = "sha256:18c51e07652ac7386fcdbd11866f8d55a795de073337c12447b5805575339f74", size = 997519, upload-time = "2026-03-30T08:51:14.87Z" },
+    { url = "https://files.pythonhosted.org/packages/91/98/6d6563cdf51085b75f8ec24605c6f2ce84197571878ca8ab4af949c6be2d/grpcio_tools-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:ac6fdd42d5bb18f0d903a067e2825be172deff70cf197164b6f65676cb506c9b", size = 1162407, upload-time = "2026-03-30T08:51:16.793Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d9/f7887a4805939e9a85d03744b66fc02575dc1df3c3e8b4d9ec000ee7a33d/grpcio_tools-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e7046837859bbfd10b01786056145480155c16b222c9e209215b68d3be13060e", size = 2550319, upload-time = "2026-03-30T08:51:19.117Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5a/c8a05b32bd7203f1b9f4c0151090a2d6179d6c97692d32f2066dc29c67a6/grpcio_tools-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a447f28958a8fe84ff0d9d3d9473868feb27ee4a9c9c805e66f5b670121cec59", size = 5709681, upload-time = "2026-03-30T08:51:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6b/794350ed645c12c310008f97068f6a6fd927150b0d0d08aad1d909e880b1/grpcio_tools-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:75f00450e08fe648ad8a1eeb25bc52219679d54cdd02f04dfdddc747309d83f6", size = 2596820, upload-time = "2026-03-30T08:51:24.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b2/b39e7b79f7c878135e0784a53cd7260ee77260c8c7f2c9e46bca8e05d017/grpcio_tools-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3db830eaff1f2c2797328f2fa86c9dcdbd7d81af573a68db81e27afa2182a611", size = 2909193, upload-time = "2026-03-30T08:51:27.025Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f3/abe089b058f87f9910c9a458409505cbeb0b3e1c2d993a79721d02ee6a32/grpcio_tools-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7982b5fe42f012686b667dda12916884de95c4b1c65ff64371fb7232a1474b23", size = 2660197, upload-time = "2026-03-30T08:51:29.392Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c3/3f7806ad8b731d8a89fe3c6ed496473abd1ef4c9c42c9e9a8836ce96e377/grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6451b3f4eb52d12c7f32d04bf8e0185f80521f3f088ad04b8d222b3a4819c71e", size = 3113144, upload-time = "2026-03-30T08:51:31.671Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f5/415ef205e0b7e75d2a2005df6120145c4f02fda28d7b3715b55d924fe1a4/grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:258bc30654a9a2236be4ca8e2ad443e2ac6db7c8cc20454d34cce60265922726", size = 3661897, upload-time = "2026-03-30T08:51:34.849Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d3/2ad54764c2a9547080dd8518f4a4dc7899c7e6e747a1b1de542ce6a12066/grpcio_tools-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:865a2b8e6334c838976ab02a322cbd55c863d2eaf3c1e1a0255883c63996772a", size = 3328786, upload-time = "2026-03-30T08:51:37.265Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/63/23ab7db01f9630ab4f3742a2fc9fbff38b0cfc30c976114f913950664a75/grpcio_tools-1.80.0-cp313-cp313-win32.whl", hash = "sha256:f760ac1722f33e774814c37b6aa0444143f612e85088ead7447a0e9cd306a1f1", size = 997087, upload-time = "2026-03-30T08:51:39.137Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/af/b1c1c4423fb49cb7c8e9d2c02196b038c44160b7028b425466743c6c81fa/grpcio_tools-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:7843b9ac6ff8ca508424d0dd968bd9a1a4559967e4a290f26be5bd6f04af2234", size = 1162167, upload-time = "2026-03-30T08:51:41.498Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/44/7beeee2348f9f412804f5bf80b7d13b81d522bf926a338ae3da46b2213b7/grpcio_tools-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:12f950470449dbeec78317dbc090add7a00eb6ca812af7b0538ab7441e0a42c3", size = 2550303, upload-time = "2026-03-30T08:51:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/aa/f77dd85409a1855f8c6319ffc69d81e8c3ffe122ee3a7136653e1991d8b6/grpcio_tools-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d3f9a376a29c9adf62bb56f7ff5bc81eb4abeaf53d1e7dde5015564832901a51", size = 5709778, upload-time = "2026-03-30T08:51:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/7c/ab7af4883ebdfdc228b853de89fed409703955e8d47285b321a5794856bd/grpcio_tools-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ba1ffbf2cff71533615e2c5a138ed5569611eec9ae7f9c67b8898e127b54ac0", size = 2597928, upload-time = "2026-03-30T08:51:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/4381a963d472e3ab6690ba067ed2b1f1abf8518b10f402678bd2dcb79a54/grpcio_tools-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:13f60f8d9397c514c6745a967d22b5c8c698347e88deebca1ff2e1b94555e450", size = 2909333, upload-time = "2026-03-30T08:51:52.124Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cb/356b5fdf79dd99455b425fb16302fe60995554ceb721afbf3cf770a19208/grpcio_tools-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:88d77bad5dd3cd5e6f952c4ecdd0ee33e0c02ecfc2e4b0cbee3391ac19e0a431", size = 2660217, upload-time = "2026-03-30T08:51:55.066Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/1752018cc2c36b2c5612051379e2e5f59f2dbe612de23e817d2f066a9487/grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:017945c3e98a4ed1c4e21399781b4137fc08dfc1f802c8ace2e64ef52d32b142", size = 3113896, upload-time = "2026-03-30T08:51:57.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/17/695bbe454f70df35c03e22b48c5314683b913d3e6ed35ec90d065418c1ab/grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a33e265d4db803495007a6c623eafb0f6b9bb123ff4a0af89e44567dad809b88", size = 3661950, upload-time = "2026-03-30T08:51:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d0/533d87629ec823c02c9169ee20228f734c264b209dcdf55268b5a14cde0a/grpcio_tools-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c129da370c5f85f569be2e545317dda786a60dd51d7deea29b03b0c05f6aac3", size = 3328755, upload-time = "2026-03-30T08:52:02.942Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a1/504d7838770c73a9761e8a8ff4869dba1146b44f297ff0ac6641481942d3/grpcio_tools-1.80.0-cp314-cp314-win32.whl", hash = "sha256:25742de5958ae4325249a37e724e7c0e5120f8e302a24a977ebd1737b48a5e97", size = 1019620, upload-time = "2026-03-30T08:52:05.342Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/8b7cd281c5cdfb4ca2c308f7e9b2799bab2be6e7a9e9212ea5a82e2aecd4/grpcio_tools-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:bbf8eeef78fda1966f732f79c1c802fadd5cfd203d845d2af4d314d18569069c", size = 1194210, upload-time = "2026-03-30T08:52:08.105Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "openclaw"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "loguru" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "qdrant-client" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "types-pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "qdrant-client", specifier = "==1.13.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.13.0" },
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891, upload-time = "2024-07-13T23:15:34.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf", size = 18423, upload-time = "2024-07-13T23:15:32.602Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "grpcio-tools" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/07/3eaf3777d524d555ba14e56a30c3e393ad78ed93f6c87c6a3ddc70ec2e49/qdrant_client-1.13.2.tar.gz", hash = "sha256:c8cce87ce67b006f49430a050a35c85b78e3b896c0c756dafc13bdeca543ec13", size = 266257, upload-time = "2025-01-22T16:06:07.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/26/89ebaee5fcbd99bf1c0a627a9447b440118b2d31dea423d074cb0481be5c/qdrant_client-1.13.2-py3-none-any.whl", hash = "sha256:db97e759bd3f8d483a383984ba4c2a158eef56f2188d83df7771591d43de2201", size = 306637, upload-time = "2025-01-22T16:06:05.334Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]


### PR DESCRIPTION
## Sprint Gateway-0 — completo

Roteia o runtime OpenClaw pelo gateway LiteLLM local com contratos validados, infraestrutura de startup segura, observabilidade mínima e smoke tests opcionais.

Closes #20, #21, #22

---

## Commits

### GW-01 — Contratos e base
- Pydantic v2 schema para `litellm_config.yaml` com rejeição de URLs remotas e exigência dos 5 aliases obrigatórios
- `check_gateway_services()`: verifica Ollama rodando + modelos carregados (base-name matching para variantes quantizadas)
- Taxonomia estável de 8 exceções com `to_log_context()`
- 35 testes unitários (25 config + 10 health)

### GW-02 — Infraestrutura LiteLLM
- Config operacional com `os.environ/OLLAMA_API_BASE` (não hardcoded)
- `start_litellm.sh` recusa `LITELLM_HOST=0.0.0.0`, OLLAMA remoto e master_key ausente
- `requirements.txt` com exclusões supply-chain `!=1.82.7,!=1.82.8` (PyPI comprometido março/2026)

### GW-03 — Routing runtime
- `GatewayChatClient` + `GatewayRuntimeConfig` com `.validated()` rejeitando URLs não-localhost
- **Fix crítico**: `.validated()` chamado antes de `httpx.AsyncClient()` — evita resource leak e mascaramento de erro em ambientes com SOCKS proxy (`ALL_PROXY`)
- api_key nunca aparece em mensagens de exceção (verificado por teste)
- `config/rag_config.yaml` atualizado para endpoint gateway e alias semântico

### GW-04 — Consolidação e observabilidade
- `backend/gateway/messages.py`: elimina duplicação `_validate_messages` entre `client.py` e `generator.py`
- Observabilidade: `logger.debug` com alias, host local, latência, status, categoria de erro — sem prompt, sem api_key
- Smoke tests opcionais (`RUN_LITELLM_SMOKE=1`): 4 aliases + `/models` endpoint, dados sintéticos apenas

---

## Validação
- `uv run pytest`: **115/115 passed**, 2 skipped (smoke — esperado e correto)
- `uv run mypy --strict .`: **0 erros** (40 source files)
- `uv run pyright`: **0 erros**
- `rg '_validate_messages'`: **0 resultados**
- Smoke live com LiteLLM down: **falha clara e acionável**

## Não mudou
- Embeddings, Qdrant, retrieval, chunking, prompt builder: sem alteração funcional
- FastAPI, MCP, remote providers: fora de escopo
- `.env`, `.claude/`, `CLAUDE.md`: não tocados

## Pendente — GW-05
- Per-alias timeout (`local_think` 120s vs `local_chat` 30s no mesmo `timeout_seconds` global)
- Routing de embeddings via `local_embed`
- Integration test `LocalGenerator → GatewayChatClient` sem mocks