### PR TITLE
feat(gateway): add per-alias timeout configuration

### DIFF
--- a/backend/gateway/client.py
+++ b/backend/gateway/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import isfinite
 import os
 import time
 from collections.abc import Mapping, Sequence
@@ -28,6 +29,14 @@ DEFAULT_LLM_REASONING_MODEL = "local_think"
 DEFAULT_LLM_RAG_MODEL = "local_rag"
 DEFAULT_LLM_JSON_MODEL = "local_json"
 DEFAULT_LLM_TIMEOUT_SECONDS = 120.0
+DEFAULT_LLM_EMBED_MODEL = "local_embed"
+DEFAULT_LLM_ALIAS_TIMEOUTS: Mapping[str, float] = {
+    DEFAULT_LLM_MODEL: 30.0,
+    DEFAULT_LLM_REASONING_MODEL: 120.0,
+    DEFAULT_LLM_RAG_MODEL: 60.0,
+    DEFAULT_LLM_JSON_MODEL: 30.0,
+    DEFAULT_LLM_EMBED_MODEL: 30.0,
+}
 
 ENV_LLM_BASE_URL = "QUIMERA_LLM_BASE_URL"
 ENV_LLM_API_KEY = "QUIMERA_LLM_API_KEY"
@@ -50,6 +59,9 @@ class GatewayRuntimeConfig:
     rag_model: str = DEFAULT_LLM_RAG_MODEL
     json_model: str = DEFAULT_LLM_JSON_MODEL
     timeout_seconds: float = DEFAULT_LLM_TIMEOUT_SECONDS
+    per_alias_timeouts: Mapping[str, float] = field(
+        default_factory=lambda: dict(DEFAULT_LLM_ALIAS_TIMEOUTS)
+    )
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> GatewayRuntimeConfig:
@@ -70,6 +82,16 @@ class GatewayRuntimeConfig:
     def validated(self) -> GatewayRuntimeConfig:
         """Return a normalized config or raise a clear setup error."""
         base_url = self.base_url.rstrip("/")
+        global_timeout = _validate_timeout(
+            self.timeout_seconds,
+            label="timeout_seconds",
+        )
+        validated_alias_timeouts = {
+            alias.strip(): _validate_timeout(timeout, label=f"timeout for {alias!r}")
+            for alias, timeout in self.per_alias_timeouts.items()
+        }
+        if any(not alias for alias in validated_alias_timeouts):
+            raise GatewayConfigurationError("Gateway timeout alias cannot be empty")
         if not any(base_url.startswith(prefix) for prefix in _LOCAL_BASE_PREFIXES):
             raise GatewayConfigurationError(
                 "QUIMERA_LLM_BASE_URL must point to the local LiteLLM gateway "
@@ -96,8 +118,16 @@ class GatewayRuntimeConfig:
             reasoning_model=self.reasoning_model.strip(),
             rag_model=self.rag_model.strip(),
             json_model=self.json_model.strip(),
-            timeout_seconds=self.timeout_seconds,
+            timeout_seconds=global_timeout,
+            per_alias_timeouts=validated_alias_timeouts,
         )
+
+    def resolve_timeout(self, model_alias: str | None) -> float:
+        """Return the request timeout for *model_alias* or the global fallback."""
+        if model_alias is None:
+            return self.timeout_seconds
+        alias = model_alias.strip()
+        return self.per_alias_timeouts.get(alias, self.timeout_seconds)
 
 
 @dataclass
@@ -166,11 +196,13 @@ class GatewayChatClient:
 
         start = time.perf_counter()
         base_url_host = _base_url_host(self.config.base_url)
+        request_timeout = self.config.resolve_timeout(model_alias)
         try:
             response = await self.client.post(
                 "/chat/completions",
                 json=payload,
                 headers={"Authorization": f"Bearer {self.config.api_key}"},
+                timeout=request_timeout,
             )
         except httpx.TimeoutException as exc:
             _log_gateway_call(
@@ -270,6 +302,19 @@ def _extract_assistant_text(body: dict[str, Any], *, alias: str) -> str:
 def _base_url_host(base_url: str) -> str:
     parsed = urlparse(base_url)
     return parsed.netloc or "unknown"
+
+
+def _validate_timeout(value: float, *, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise GatewayConfigurationError(
+            f"Gateway {label} must be a finite number greater than zero"
+        )
+    timeout = float(value)
+    if not isfinite(timeout) or timeout <= 0:
+        raise GatewayConfigurationError(
+            f"Gateway {label} must be a finite number greater than zero"
+        )
+    return timeout
 
 
 def _log_gateway_call(

--- a/backend/gateway/client.py
+++ b/backend/gateway/client.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from math import isfinite
 import os
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import Any, cast
 from urllib.parse import urlparse
 
@@ -30,6 +30,8 @@ DEFAULT_LLM_RAG_MODEL = "local_rag"
 DEFAULT_LLM_JSON_MODEL = "local_json"
 DEFAULT_LLM_TIMEOUT_SECONDS = 120.0
 DEFAULT_LLM_EMBED_MODEL = "local_embed"
+# Python-side HTTPX timeouts are the first line of defense. LiteLLM-side
+# timeouts in config/litellm_config.yaml may differ intentionally.
 DEFAULT_LLM_ALIAS_TIMEOUTS: Mapping[str, float] = {
     DEFAULT_LLM_MODEL: 30.0,
     DEFAULT_LLM_REASONING_MODEL: 120.0,
@@ -142,8 +144,6 @@ class GatewayChatClient:
 
     def __post_init__(self) -> None:
         self.config = self.config.validated()
-        if self.config.timeout_seconds <= 0:
-            raise GatewayConfigurationError("Gateway timeout must be greater than zero")
         if self.client is None:
             self.client = httpx.AsyncClient(
                 base_url=self.config.base_url,

--- a/backend/gateway/config.py
+++ b/backend/gateway/config.py
@@ -65,6 +65,14 @@ class LiteLLMParams(BaseModel):
             )
         return v
 
+    @field_validator("timeout")
+    @classmethod
+    def timeout_must_be_positive(cls, v: int) -> int:
+        """Reject invalid LiteLLM alias timeout values."""
+        if v <= 0:
+            raise ValueError("timeout must be greater than zero")
+        return v
+
 
 class ModelInfo(BaseModel):
     """Semantic metadata attached to a gateway alias.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,8 +4,8 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-04-26
-**Updated by:** Codex — Gateway workflow normalization handoff
+**Last updated:** 2026-04-27
+**Updated by:** Codex — Gateway GW-05a per-alias timeout prep
 
 ---
 
@@ -14,7 +14,15 @@
 **Goal:** make LiteLLM the local-only model gateway for OpenClaw runtime model
 calls while preserving existing RAG/Qdrant behavior.
 
-**Hard constraints:**
+Current runtime path:
+
+```text
+OpenClaw / runtime generation
+  -> LiteLLM at http://127.0.0.1:4000/v1
+  -> Ollama / Qwen local
+```
+
+Hard constraints remain:
 
 - Local only.
 - No remote providers.
@@ -48,77 +56,72 @@ unavoidable, use `git push --force-with-lease`.
 
 ---
 
-## Current Local State Warning
-
-Current observed branch:
-
-```text
-feat/gateway-runtime-smoke
-```
-
-Current observed risk:
-
-- The working tree contains mixed Gateway PR1-PR4 modifications and untracked
-  files.
-- Local `main`/`origin/main` may not reflect the user-reported manual Gateway
-  merges yet.
-- Do not run `git reset`, `git clean`, destructive checkout, or broad stash
-  commands until the Gateway changes are intentionally preserved or split.
-- `uv.lock` is untracked; decide deliberately whether dependency lock changes
-  belong in a PR.
-- `.gitignore` is modified; decide deliberately whether the `.claude/worktrees/`
-  ignore rule belongs in a PR.
-
-Read `docs/sprints/GATEWAY_SPRINT_HANDOFF.md` before the next Gateway action.
-
----
-
 ## Gateway PR Tracking
 
-| PR | Branch | User-reported state | Local verification state | Next action |
-|---|---|---|---|---|
-| GW-01 | `feat/gateway-prep-contracts` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
-| GW-02 | `feat/gateway-install-health` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
-| GW-03 | `feat/gateway-route-opencraw-litellm` | Merged manually | Backfill issue/PR status in GitHub | Normalize records |
-| GW-04 | `feat/gateway-runtime-smoke` | In progress | Local changes present | Preserve/split, then open PR |
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| GW-01 | `feat/gateway-prep-contracts` | ADR, Blueprint V3.0, semantic aliases, config contracts | Done / merged |
+| GW-02 | `feat/gateway-install-health` | Local-only LiteLLM operational setup | Done / merged |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | Runtime chat/generation through LiteLLM | Done / merged |
+| GW-04 | `feat/gateway-runtime-smoke` | Shared message validation, optional smoke, observability | Done / merged |
+| GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Current |
+| GW-05b | TBD | Expanded live smoke with real local services | Planned |
+| GW-06 | TBD | Evaluate embeddings via `local_embed` | Planned |
+| GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
 
-Proposed issue and PR titles are recorded in
-`docs/sprints/GATEWAY_SPRINT_HANDOFF.md`.
+GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 
 ---
 
-## Last Known Validation
+## GW-05a Timeout Contract
 
-Before this documentation handoff, the Gateway PR4 local work had passed:
+Runtime gateway calls now reserve different timeout budgets per semantic alias:
+
+| Alias | Timeout | Notes |
+|---|---:|---|
+| `local_chat` | 30.0s | Default chat calls |
+| `local_think` | 120.0s | Longer local reasoning calls |
+| `local_rag` | 60.0s | RAG answer synthesis |
+| `local_json` | 30.0s | Structured local responses |
+| `local_embed` | 30.0s | Placeholder only; embeddings are not routed through LiteLLM in GW-05a |
+
+Unknown aliases and `None` fall back to the global `timeout_seconds`.
+
+---
+
+## Next Planned Work
+
+GW-05b:
+
+- Run expanded live smoke with LiteLLM and Ollama actually running.
+- Keep smoke opt-in and synthetic-only.
+- Do not introduce remote providers or real data.
+
+GW-06:
+
+- Evaluate whether embeddings should route through `local_embed`.
+- Keep existing direct/local embedding behavior until a tested PR changes it.
+
+GW-07:
+
+- Prove a synthetic RAG end-to-end flow against the gateway path.
+- Keep Qdrant data synthetic and local.
+
+---
+
+## Validation Expectations For GW-05a
+
+Before opening PR:
 
 ```bash
-uv run pytest -v
-uv run mypy --strict . || true
-uv run pyright || true
-uv run python -m compileall backend scripts infra tests || true
 git diff --check
+uv run pytest -v
+uv run mypy --strict .
+uv run pyright
+uv run python -m compileall backend tests scripts infra
+uv run pytest tests/unit/test_gateway_config.py -v
+uv run pytest tests/unit/test_gateway_client.py -v
+uv run pytest tests/smoke/ -v
 ```
 
-Observed result from the prior local run:
-
-```text
-115 passed, 2 skipped, 35 subtests passed
-mypy: success
-pyright: 0 errors
-compileall: success
-git diff --check: success
-```
-
-Live LiteLLM smoke was attempted with a fake local key and failed clearly because
-LiteLLM was not running at `127.0.0.1:4000`. No secrets were printed.
-
----
-
-## Next Recommended Move
-
-1. Preserve the current Gateway work before any branch switch.
-2. Backfill GitHub issues for GW-01 through GW-04.
-3. Verify whether the manual merges are actually present on GitHub `main`.
-4. If not, split or replay the local Gateway changes into the required PR chain.
-5. Do not begin a new feature PR until GW-01 through GW-03 are represented in
-   GitHub and local `main` is synchronized.
+Smoke tests should skip by default unless `RUN_LITELLM_SMOKE=1` is set.

--- a/docs/GATEWAY_SETUP.md
+++ b/docs/GATEWAY_SETUP.md
@@ -161,6 +161,8 @@ operation is proven there. PR 3 routes OpenClaw runtime chat generation through
 LiteLLM while preserving Qdrant retrieval and existing embedding behavior.
 PR 4 proves the live route with optional smoke tests and minimal gateway
 observability.
+GW-05a adds runtime request timeout budgets per semantic alias without changing
+RAG, Qdrant, embeddings, or prompt construction.
 
 Application runtime environment:
 
@@ -172,6 +174,16 @@ export QUIMERA_LLM_REASONING_MODEL="local_think"
 export QUIMERA_LLM_RAG_MODEL="local_rag"
 export QUIMERA_LLM_JSON_MODEL="local_json"
 ```
+
+Runtime timeout contract:
+
+| Alias | Timeout | Notes |
+|---|---:|---|
+| `local_chat` | 30.0s | Default chat calls |
+| `local_think` | 120.0s | Longer local reasoning calls |
+| `local_rag` | 60.0s | RAG answer synthesis |
+| `local_json` | 30.0s | Structured local responses |
+| `local_embed` | 30.0s | Placeholder only; embeddings remain direct/local |
 
 See `docs/guides/OPENCLAW_LITELLM_RUNTIME.md` for runtime troubleshooting.
 

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -100,6 +100,8 @@ providers.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in
   Gateway-0.
+- Live smoke expansion belongs to GW-05b (PR 6). GW-05a does not modify smoke
+  test scope or activation behavior.
 
 ## Troubleshooting
 

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -2,6 +2,7 @@
 
 PR 3 routes OpenClaw runtime chat generation through the local LiteLLM gateway.
 PR 4 adds optional live smoke tests for that route.
+GW-05a adds per-alias request timeout budgets for semantic local aliases.
 The default runtime path is:
 
 ```text
@@ -82,6 +83,9 @@ providers.
 - Gateway calls emit minimal debug observability: alias, base URL host, latency,
   success/failure status, and error category. API keys and prompt text are not
   logged.
+- GW-05a resolves request timeouts per alias: `local_chat` 30s, `local_think`
+  120s, `local_rag` 60s, `local_json` 30s, and `local_embed` 30s placeholder.
+  Unknown aliases and `None` still fall back to the global `timeout_seconds`.
 
 ## What Did Not Change
 
@@ -90,9 +94,12 @@ providers.
   unchanged.
 - Embeddings still use the existing local Ollama embedder until a separate,
   tested embedding-gateway PR is approved.
+- `local_embed` has a reserved timeout value only. GW-05a does not route
+  embeddings through LiteLLM.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
-- MCP and tooling integration are not implemented in PR 3 or PR 4.
+- MCP and tooling integration remain future direction, not implemented in
+  Gateway-0.
 
 ## Troubleshooting
 

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -1,30 +1,23 @@
 # Gateway Sprint Handoff
 
-> Start the next Gateway cycle by reading this file before touching Git.
+> Start each Gateway cycle by reading this file before touching Git.
 
-**Last updated:** 2026-04-26  
-**Repository:** OpenClaw  
-**Product:** Quimera  
-**Sprint:** Gateway-0 / LiteLLM  
+**Last updated:** 2026-04-27
+**Repository:** OpenClaw
+**Product:** Quimera
+**Sprint:** Gateway-0 / LiteLLM
 
 ---
 
 ## Mandatory GitHub Workflow
 
-The local project directory is not the final integration point. GitHub is the
-source of truth for issues, branches, pull requests, review status, and merge
-state.
+GitHub is the source of truth for issues, branches, pull requests, review state,
+and merge state. The local checkout is a work area, not the final integration
+point.
 
 For every tracked PR:
 
-1. Sync local `main`:
-
-```bash
-cd /Users/fas/projetos/OPENCLAW
-git checkout main
-git pull --ff-only origin main
-```
-
+1. Sync local `main`.
 2. Open or update a GitHub Issue before implementation.
 3. Create the feature branch from updated `main`.
 4. Implement locally.
@@ -37,241 +30,122 @@ git pull --ff-only origin main
 11. Merge only in GitHub after approval.
 12. After GitHub merge, sync local `main` with `--ff-only`.
 
-Never push directly to `main`. Never use `git push --force`; if unavoidable
-after a rebase, use `git push --force-with-lease`.
-
----
-
-## Current Local Risk
-
-Current observed branch:
-
-```text
-feat/gateway-runtime-smoke
-```
-
-The working tree currently contains combined Gateway PR1-PR4 changes. This is
-valuable work, but it is not yet cleanly represented in GitHub from this local
-checkout.
-
-Do not run:
-
-```bash
-git reset --hard
-git clean -fd
-git checkout -- .
-```
-
-Do not switch away from the branch until the current work is preserved, split,
-or intentionally committed.
-
-Known local risks:
-
-- `origin/main` in this checkout may still point to the older RAG-07 state.
-- Gateway PR1-PR3 are user-reported as merged manually, but this checkout still
-  needs GitHub verification.
-- Many Gateway files are untracked.
-- `.gitignore` is modified.
-- `uv.lock` is untracked and should not be staged unless intentionally part of
-  dependency policy.
-
----
-
-## Proposed GitHub Records
-
-| PR | Issue title | Branch | PR title |
-|---|---|---|---|
-| GW-01 | `[Gateway-01] LiteLLM gateway contracts and semantic aliases` | `feat/gateway-prep-contracts` | `feat(gateway): add LiteLLM prep contracts` |
-| GW-02 | `[Gateway-02] Local-only LiteLLM install and health scripts` | `feat/gateway-install-health` | `feat(gateway): add local LiteLLM install and health scripts` |
-| GW-03 | `[Gateway-03] Route OpenClaw runtime chat through LiteLLM` | `feat/gateway-route-opencraw-litellm` | `feat(gateway): route runtime chat through local LiteLLM` |
-| GW-04 | `[Gateway-04] Optional LiteLLM runtime smoke and observability` | `feat/gateway-runtime-smoke` | `feat(gateway): add optional runtime smoke for local LiteLLM` |
-
----
-
-## Issue Body Templates
-
-### GW-01
-
-Context: Gateway-0 introduces LiteLLM as the local-only model gateway contract.
-
-Objective: add ADR, Blueprint V3.0, semantic aliases, config validation,
-gateway exceptions, and contract tests without changing runtime behavior.
-
-Scope: docs, config, `backend/gateway` contracts, unit tests.
-
-Out of scope: remote providers, FastAPI, MCP, quant tools, OpenClaw runtime
-routing, RAG behavior changes.
-
-Acceptance criteria: aliases exist, remote providers absent, schema validation
-passes, tests pass, no secrets committed.
-
-Risks/follow-ups: keep runtime wiring for later PRs; maintain small Gateway
-exception taxonomy.
-
-### GW-02
-
-Context: PR1 created the Gateway contract; PR2 makes local LiteLLM installable
-and testable.
-
-Objective: add `infra/litellm` operational scripts and documentation for
-starting and checking LiteLLM bound to `127.0.0.1`.
-
-Scope: local config, `.env.example`, start script, healthcheck scripts, setup
-docs, script tests.
-
-Out of scope: runtime integration, remote providers, FastAPI, MCP, quant tools,
-real portfolio data.
-
-Acceptance criteria: LiteLLM can start locally, `/v1/models` responds,
-`local_chat` works through local Qwen, scripts fail clearly, no secrets
-committed.
-
-Risks/follow-ups: live checks require local Ollama/LiteLLM; docs must keep MCP
-and tooling direction explicitly out of scope.
-
-### GW-03
-
-Context: PR2 made the gateway operational; PR3 routes OpenClaw runtime chat
-generation through LiteLLM.
-
-Objective: make application-facing model calls use OpenAI-compatible
-`/chat/completions` at `http://127.0.0.1:4000/v1` with semantic aliases.
-
-Scope: gateway client, runtime generation adapter, config defaults, docs, mocked
-unit tests.
-
-Out of scope: embeddings-through-gateway, Qdrant changes, retrieval changes,
-remote providers, FastAPI, MCP, quant tools.
-
-Acceptance criteria: default route is LiteLLM local, default alias is
-`local_chat`, reasoning/RAG/JSON aliases are available, vendor model names stay
-out of application-facing defaults, tests pass.
-
-Risks/follow-ups: `_validate_messages` duplication was intentionally temporary
-and should be consolidated in GW-04.
-
-### GW-04
-
-Context: PR3 routes runtime calls; PR4 proves the live route with optional smoke
-tests and minimal observability.
-
-Objective: add opt-in runtime smoke coverage for
-`OpenClaw -> LiteLLM -> Ollama/Qwen` and resolve the temporary message
-validation duplication.
-
-Scope: optional smoke script/test, LiteLLM health helper if narrow, minimal
-debug observability, docs, validation cleanup.
-
-Out of scope: embeddings-through-gateway, Qdrant/retrieval/chunking changes,
-remote providers, FastAPI, MCP, quant tools, real portfolio prompts.
-
-Acceptance criteria: normal tests skip live smoke by default, `RUN_LITELLM_SMOKE=1`
-enables live checks, smoke uses only synthetic prompts and local aliases, no
-secrets are printed, existing tests pass.
-
-Risks/follow-ups: live smoke requires local LiteLLM and Ollama; if services are
-down, failures must be clear and secret-safe.
-
----
-
-## Exact Command Plan For Normalization
-
-First inspect without changing history:
+Canonical start:
 
 ```bash
 cd /Users/fas/projetos/OPENCLAW
-git status --short --branch
-git branch -vv
-gh auth status
-gh issue list --state open
-gh pr list --state all --limit 20
+git checkout main
+git pull --ff-only origin main
 ```
 
-Create issue body files in `/tmp` manually from the templates above, then:
+Never push directly to `main`. Never use `git push --force`; if a rebase is
+unavoidable, use `git push --force-with-lease`.
 
-```bash
-gh issue create --title "[Gateway-01] LiteLLM gateway contracts and semantic aliases" --body-file /tmp/gateway-01-issue.md --label codex-task --label local-only
-gh issue create --title "[Gateway-02] Local-only LiteLLM install and health scripts" --body-file /tmp/gateway-02-issue.md --label codex-task --label local-only
-gh issue create --title "[Gateway-03] Route OpenClaw runtime chat through LiteLLM" --body-file /tmp/gateway-03-issue.md --label codex-task --label local-only
-gh issue create --title "[Gateway-04] Optional LiteLLM runtime smoke and observability" --body-file /tmp/gateway-04-issue.md --label codex-task --label local-only
+---
+
+## Current Status
+
+Current active branch:
+
+```text
+feat/gateway-per-alias-timeouts
 ```
 
-If PR1-PR3 are already present on GitHub, link or comment on those issues with
-the existing PR URLs instead of recreating duplicate PRs.
+Current issue:
 
-If PR1-PR3 are not present on GitHub, preserve current work before syncing:
+```text
+https://github.com/franciscosalido/OPENCLAW/issues/25
+```
+
+Gateway PR state:
+
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| GW-01 | `feat/gateway-prep-contracts` | Gateway contracts, ADR, Blueprint, semantic aliases | Done / merged |
+| GW-02 | `feat/gateway-install-health` | Local-only LiteLLM install and health scripts | Done / merged |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | OpenClaw runtime chat through LiteLLM | Done / merged |
+| GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke, observability | Done / merged |
+| GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Current |
+| GW-05b | TBD | Expanded live smoke with real local services | Planned |
+| GW-06 | TBD | Evaluate embeddings via `local_embed` | Planned |
+| GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
+
+---
+
+## GW-05a Contract
+
+Objective:
+
+Add per-alias timeout configuration for semantic LiteLLM aliases without
+changing the runtime architecture.
+
+Timeout contract:
+
+| Alias | Timeout | Notes |
+|---|---:|---|
+| `local_chat` | 30.0s | Default chat |
+| `local_think` | 120.0s | Longer reasoning/planning calls |
+| `local_rag` | 60.0s | RAG answer synthesis |
+| `local_json` | 30.0s | Structured responses |
+| `local_embed` | 30.0s | Placeholder only; not used for embeddings yet |
+
+Resolution rules:
+
+- If the request alias exists in `per_alias_timeouts`, use that timeout.
+- If the alias is unknown, use global `timeout_seconds`.
+- If the alias is `None`, use global `timeout_seconds`.
+- Reject zero, negative, infinite, or NaN timeout values.
+
+Out of scope:
+
+- Live smoke expansion.
+- FastAPI.
+- MCP.
+- Remote providers.
+- Quant tools.
+- Embeddings through LiteLLM.
+- Qdrant/retrieval/chunking changes.
+- Prompt builder changes.
+- Autoprogramming.
+
+---
+
+## Next Work
+
+GW-05b:
+
+- Run expanded live smoke with LiteLLM and Ollama already running.
+- Keep smoke opt-in with `RUN_LITELLM_SMOKE=1`.
+- Use only synthetic prompts and local aliases.
+
+GW-06:
+
+- Evaluate whether `local_embed` should route embeddings through LiteLLM.
+- Preserve current direct/local embedding path until the PR proves parity.
+
+GW-07:
+
+- Run synthetic RAG E2E over the approved gateway path.
+- Keep all data fictitious and local.
+
+---
+
+## Validation Checklist
+
+Before opening GW-05a PR:
 
 ```bash
 git status --short --branch
 git diff --stat
 git diff --check
-```
-
-Then decide one of these safe paths:
-
-- commit a temporary preservation branch with explicit files;
-- split patches into the four target branches;
-- create a worktree backup before replaying from `main`.
-
-After preservation:
-
-```bash
-git checkout main
-git pull --ff-only origin main
-```
-
-Then replay each branch from updated `main`, validate, push, and open the PR:
-
-```bash
-git checkout -b feat/gateway-prep-contracts
-# apply GW-01 files
-uv run pytest tests/unit/test_gateway_config.py tests/unit/test_gateway_health.py tests/unit/test_gateway_errors.py -v
-git status --short --branch
-git add <gw-01-files>
-git commit -m "feat(gateway): add LiteLLM prep contracts"
-git push -u origin feat/gateway-prep-contracts
-gh pr create --base main --head feat/gateway-prep-contracts --title "feat(gateway): add LiteLLM prep contracts" --body-file /tmp/gateway-01-pr.md
-```
-
-Repeat the same pattern for GW-02, GW-03, and GW-04.
-
----
-
-## Last Known PR4 Validation
-
-The PR4 local bundle previously passed:
-
-```bash
 uv run pytest -v
-uv run mypy --strict . || true
-uv run pyright || true
-uv run python -m compileall backend scripts infra tests || true
-git diff --check
+uv run mypy --strict .
+uv run pyright
+uv run python -m compileall backend tests scripts infra
+uv run pytest tests/unit/test_gateway_config.py -v
+uv run pytest tests/unit/test_gateway_client.py -v
+uv run pytest tests/smoke/ -v
 ```
 
-Observed result:
-
-```text
-115 passed, 2 skipped, 35 subtests passed
-mypy: success
-pyright: 0 errors
-compileall: success
-git diff --check: success
-```
-
-Live smoke with a fake local key failed clearly because LiteLLM was not running
-at `127.0.0.1:4000`. No secrets were printed.
-
----
-
-## Next Cycle Start
-
-Start with:
-
-```bash
-cd /Users/fas/projetos/OPENCLAW
-git status --short --branch
-sed -n '1,260p' docs/sprints/GATEWAY_SPRINT_HANDOFF.md
-```
-
-Then normalize GitHub records before doing new Gateway implementation work.
+Expected smoke behavior without `RUN_LITELLM_SMOKE=1`: smoke tests skip, not
+fail.

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -57,14 +57,20 @@ Current issue:
 https://github.com/franciscosalido/OPENCLAW/issues/25
 ```
 
+Gateway baseline already merged:
+
+```text
+GW-01 through GW-04 are merged in 92c0ec5.
+```
+
 Gateway PR state:
 
 | PR | Branch | Scope | Status |
 |---|---|---|---|
-| GW-01 | `feat/gateway-prep-contracts` | Gateway contracts, ADR, Blueprint, semantic aliases | Done / merged |
-| GW-02 | `feat/gateway-install-health` | Local-only LiteLLM install and health scripts | Done / merged |
-| GW-03 | `feat/gateway-route-opencraw-litellm` | OpenClaw runtime chat through LiteLLM | Done / merged |
-| GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke, observability | Done / merged |
+| GW-01 | `feat/gateway-prep-contracts` | Gateway contracts, ADR, Blueprint, semantic aliases | Merged in `92c0ec5` |
+| GW-02 | `feat/gateway-install-health` | Local-only LiteLLM install and health scripts | Merged in `92c0ec5` |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | OpenClaw runtime chat through LiteLLM | Merged in `92c0ec5` |
+| GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke, observability | Merged in `92c0ec5` |
 | GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Current |
 | GW-05b | TBD | Expanded live smoke with real local services | Planned |
 | GW-06 | TBD | Evaluate embeddings via `local_embed` | Planned |

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import json
 import unittest
+from math import inf, nan
 from pathlib import Path
+from typing import cast
 
 import httpx
 import yaml
 
 from backend.gateway.client import (
+    DEFAULT_LLM_ALIAS_TIMEOUTS,
     DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_EMBED_MODEL,
     DEFAULT_LLM_JSON_MODEL,
     DEFAULT_LLM_MODEL,
     DEFAULT_LLM_RAG_MODEL,
@@ -33,6 +37,80 @@ class GatewayRuntimeConfigTests(unittest.TestCase):
         self.assertEqual(config.reasoning_model, "local_think")
         self.assertEqual(config.rag_model, "local_rag")
         self.assertEqual(config.json_model, "local_json")
+
+    def test_default_alias_timeouts_are_concrete(self) -> None:
+        config = GatewayRuntimeConfig(api_key="dev-key").validated()
+
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_MODEL), 30.0)
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_REASONING_MODEL), 120.0)
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_RAG_MODEL), 60.0)
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_JSON_MODEL), 30.0)
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_EMBED_MODEL), 30.0)
+
+    def test_unknown_alias_and_none_fall_back_to_global_timeout(self) -> None:
+        config = GatewayRuntimeConfig(
+            api_key="dev-key",
+            timeout_seconds=77.0,
+        ).validated()
+
+        self.assertEqual(config.resolve_timeout("local_unknown"), 77.0)
+        self.assertEqual(config.resolve_timeout(None), 77.0)
+
+    def test_empty_per_alias_timeouts_keeps_global_fallback(self) -> None:
+        config = GatewayRuntimeConfig(
+            api_key="dev-key",
+            timeout_seconds=42.0,
+            per_alias_timeouts={},
+        ).validated()
+
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_MODEL), 42.0)
+
+    def test_custom_per_alias_timeout_overrides_default(self) -> None:
+        config = GatewayRuntimeConfig(
+            api_key="dev-key",
+            timeout_seconds=42.0,
+            per_alias_timeouts={DEFAULT_LLM_MODEL: 12.0},
+        ).validated()
+
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_MODEL), 12.0)
+        self.assertEqual(config.resolve_timeout(DEFAULT_LLM_RAG_MODEL), 42.0)
+
+    def test_default_alias_timeout_mapping_matches_contract(self) -> None:
+        self.assertEqual(
+            dict(DEFAULT_LLM_ALIAS_TIMEOUTS),
+            {
+                DEFAULT_LLM_MODEL: 30.0,
+                DEFAULT_LLM_REASONING_MODEL: 120.0,
+                DEFAULT_LLM_RAG_MODEL: 60.0,
+                DEFAULT_LLM_JSON_MODEL: 30.0,
+                DEFAULT_LLM_EMBED_MODEL: 30.0,
+            },
+        )
+
+    def test_global_timeout_must_be_positive_and_finite(self) -> None:
+        for timeout in (0.0, -1.0, inf, nan):
+            with self.subTest(timeout=timeout):
+                with self.assertRaises(GatewayConfigurationError):
+                    GatewayRuntimeConfig(
+                        api_key="dev-key",
+                        timeout_seconds=timeout,
+                    ).validated()
+
+    def test_per_alias_timeout_must_be_positive_and_finite(self) -> None:
+        for timeout in (0.0, -1.0, inf, nan):
+            with self.subTest(timeout=timeout):
+                with self.assertRaises(GatewayConfigurationError):
+                    GatewayRuntimeConfig(
+                        api_key="dev-key",
+                        per_alias_timeouts={DEFAULT_LLM_MODEL: timeout},
+                    ).validated()
+
+    def test_empty_timeout_alias_is_rejected(self) -> None:
+        with self.assertRaises(GatewayConfigurationError):
+            GatewayRuntimeConfig(
+                api_key="dev-key",
+                per_alias_timeouts={" ": 30.0},
+            ).validated()
 
     def test_default_constants_do_not_include_vendor_model_names(self) -> None:
         defaults = [
@@ -82,10 +160,12 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
     async def test_chat_completion_posts_openai_compatible_payload(self) -> None:
         seen_payloads: list[dict[str, object]] = []
         seen_auth_headers: list[str | None] = []
+        seen_timeouts: list[dict[str, float]] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
             seen_payloads.append(json.loads(request.content.decode("utf-8")))
             seen_auth_headers.append(request.headers.get("authorization"))
+            seen_timeouts.append(cast("dict[str, float]", request.extensions["timeout"]))
             self.assertEqual(request.url.path, "/v1/chat/completions")
             return httpx.Response(
                 200,
@@ -108,6 +188,7 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(answer, "Resposta compacta.")
         self.assertEqual(seen_auth_headers, ["Bearer secret-test-key"])
+        self.assertEqual(seen_timeouts[0]["read"], 30.0)
         self.assertEqual(
             seen_payloads,
             [
@@ -119,6 +200,36 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
                 }
             ],
         )
+
+    async def test_chat_completion_uses_alias_specific_timeout(self) -> None:
+        seen_timeouts: list[dict[str, float]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_timeouts.append(cast("dict[str, float]", request.extensions["timeout"]))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "ok"}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                model=DEFAULT_LLM_REASONING_MODEL,
+            )
+            await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                model=DEFAULT_LLM_RAG_MODEL,
+            )
+
+        self.assertEqual(seen_timeouts[0]["read"], 120.0)
+        self.assertEqual(seen_timeouts[1]["read"], 60.0)
 
     async def test_authentication_failure_does_not_print_api_key(self) -> None:
         async with httpx.AsyncClient(

--- a/tests/unit/test_gateway_config.py
+++ b/tests/unit/test_gateway_config.py
@@ -86,6 +86,17 @@ class TestLiteLLMParamsValidator(unittest.TestCase):
             LiteLLMParams(model="gpt-4", api_base=_REMOTE, timeout=60)
         self.assertIn("remote host", str(ctx.exception))
 
+    def test_timeout_must_be_positive(self) -> None:
+        for timeout in (0, -1):
+            with self.subTest(timeout=timeout):
+                with self.assertRaises(ValidationError) as ctx:
+                    LiteLLMParams(
+                        model="ollama_chat/qwen3:14b",
+                        api_base=_LOCALHOST,
+                        timeout=timeout,
+                    )
+                self.assertIn("greater than zero", str(ctx.exception))
+
     def test_https_localhost_rejected(self) -> None:
         """TLS termination proxy on localhost is also out of Gateway-0 scope."""
         with self.assertRaises(ValidationError):
@@ -253,6 +264,11 @@ class TestActualGatewayConfig(unittest.TestCase):
             chat.litellm_params.timeout,
             "local_think timeout must exceed local_chat timeout",
         )
+
+    def test_all_alias_timeouts_are_positive(self) -> None:
+        for alias in self.config.model_list:
+            with self.subTest(alias=alias.model_name):
+                self.assertGreater(alias.litellm_params.timeout, 0)
 
     def test_drop_params_enabled(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
## Summary

Adds per-alias timeout configuration for the local LiteLLM gateway client.

This allows semantic aliases to use different timeout budgets while preserving the existing global `timeout_seconds` fallback.

Implemented timeout contract:

- `local_chat`: 30s
- `local_think`: 120s
- `local_rag`: 60s
- `local_json`: 30s
- `local_embed`: 30s placeholder only

Closes #25

## Scope

Included:

- Per-alias timeout support in gateway config/client
- Backward-compatible global timeout fallback
- Validation for invalid timeout values
- Unit tests for timeout resolution
- Documentation refresh for GW-01 through GW-05a
- Cleanup of stale gateway sprint context docs

Excluded:

- Live smoke expansion
- FastAPI
- MCP
- Remote providers
- Quant tools
- Embeddings through LiteLLM
- Qdrant/retrieval/chunking changes
- Prompt builder changes
- Autoprogramming

## Security

- No secrets committed
- `.env` untouched
- No remote providers enabled
- No Authorization headers logged
- No prompt content logged
- No real portfolio data introduced

## Validation

```bash
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run python -m compileall backend tests scripts infra
uv run pytest tests/unit/test_gateway_config.py -v
uv run pytest tests/unit/test_gateway_client.py -v
uv run pytest tests/smoke/ -v
```

Smoke tests remain skipped by default without `RUN_LITELLM_SMOKE=1`.
