### PR TITLE
test(gateway): evaluate local_embed embeddings through LiteLLM

### DIFF
--- a/backend/gateway/__init__.py
+++ b/backend/gateway/__init__.py
@@ -13,6 +13,7 @@ Runtime chat calls route through the local LiteLLM gateway. Gateway-0 establishe
 
 from backend.gateway.client import (
     DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_EMBED_MODEL,
     DEFAULT_LLM_JSON_MODEL,
     DEFAULT_LLM_MODEL,
     DEFAULT_LLM_RAG_MODEL,
@@ -21,6 +22,11 @@ from backend.gateway.client import (
     GatewayRuntimeConfig,
 )
 from backend.gateway.config import GatewayConfig, load_gateway_config
+from backend.gateway.embed_client import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    ENV_LLM_EMBED_MODEL,
+    GatewayEmbedClient,
+)
 from backend.gateway.errors import (
     GatewayAuthenticationError,
     GatewayConnectionError,
@@ -37,12 +43,16 @@ from backend.gateway.health import check_gateway_services, check_litellm_gateway
 __all__ = [
     # Config
     "DEFAULT_LLM_BASE_URL",
+    "DEFAULT_LLM_EMBED_MODEL",
     "DEFAULT_LLM_JSON_MODEL",
     "DEFAULT_LLM_MODEL",
     "DEFAULT_LLM_RAG_MODEL",
     "DEFAULT_LLM_REASONING_MODEL",
+    "DEFAULT_EMBEDDING_DIMENSIONS",
+    "ENV_LLM_EMBED_MODEL",
     "GatewayChatClient",
     "GatewayConfig",
+    "GatewayEmbedClient",
     "GatewayRuntimeConfig",
     "load_gateway_config",
     # Health

--- a/backend/gateway/embed_client.py
+++ b/backend/gateway/embed_client.py
@@ -1,0 +1,276 @@
+"""Experimental OpenAI-compatible embeddings client for the LiteLLM gateway."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import httpx
+from loguru import logger
+
+from backend.gateway.client import (
+    DEFAULT_LLM_EMBED_MODEL,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConfigurationError,
+    GatewayConnectionError,
+    GatewayResponseError,
+    GatewayTimeoutError,
+)
+
+
+ENV_LLM_EMBED_MODEL = "QUIMERA_LLM_EMBED_MODEL"
+DEFAULT_EMBEDDING_DIMENSIONS = 768
+
+
+@dataclass
+class GatewayEmbedClient:
+    """Small experimental client for LiteLLM ``/embeddings`` calls.
+
+    This client is evaluation-only in GW-06. It is not wired as the default RAG
+    embedder and does not replace ``backend.rag.embeddings.OllamaEmbedder``.
+    """
+
+    config: GatewayRuntimeConfig = field(
+        default_factory=lambda: GatewayRuntimeConfig.from_env().validated()
+    )
+    model: str = field(
+        default_factory=lambda: os.environ.get(
+            ENV_LLM_EMBED_MODEL,
+            DEFAULT_LLM_EMBED_MODEL,
+        )
+    )
+    expected_dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS
+    client: httpx.AsyncClient | None = None
+    _owns_client: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        self.config = self.config.validated()
+        self.model = self.model.strip()
+        if not self.model:
+            raise GatewayConfigurationError(f"{ENV_LLM_EMBED_MODEL} cannot be empty")
+        if self.expected_dimensions <= 0:
+            raise GatewayConfigurationError(
+                "expected_dimensions must be greater than zero"
+            )
+        if self.client is None:
+            self.client = httpx.AsyncClient(
+                base_url=self.config.base_url,
+                timeout=httpx.Timeout(self.config.timeout_seconds),
+            )
+            self._owns_client = True
+
+    async def __aenter__(self) -> GatewayEmbedClient:
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the owned HTTP client."""
+        if self._owns_client and self.client is not None:
+            await self.client.aclose()
+
+    async def embed(self, text: str) -> list[float]:
+        """Embed one synthetic/local text through LiteLLM ``/embeddings``."""
+        clean_text = _validate_text(text)
+        vectors = await self._embed_payload(clean_text)
+        if len(vectors) != 1:
+            raise GatewayResponseError(
+                "LiteLLM embedding response did not contain exactly one vector.",
+                alias=self.model,
+            )
+        return vectors[0]
+
+    async def embed_batch(self, texts: Sequence[str]) -> list[list[float]]:
+        """Embed a small batch through LiteLLM ``/embeddings``."""
+        clean_texts = [_validate_text(text) for text in texts]
+        if not clean_texts:
+            return []
+        vectors = await self._embed_payload(clean_texts)
+        if len(vectors) != len(clean_texts):
+            raise GatewayResponseError(
+                "LiteLLM embedding response count did not match input count.",
+                alias=self.model,
+            )
+        return vectors
+
+    async def _embed_payload(self, input_value: str | list[str]) -> list[list[float]]:
+        if self.client is None:
+            raise GatewayConnectionError("Gateway HTTP client is not initialized")
+
+        request_timeout = self.config.resolve_timeout(self.model)
+        payload: dict[str, object] = {"model": self.model, "input": input_value}
+        start = time.perf_counter()
+
+        try:
+            response = await self.client.post(
+                "/embeddings",
+                json=payload,
+                headers={"Authorization": f"Bearer {self.config.api_key}"},
+                timeout=request_timeout,
+            )
+        except httpx.TimeoutException as exc:
+            _log_embed_call(
+                model_alias=self.model,
+                started_at=start,
+                timeout_s=request_timeout,
+                status="failure",
+                error_category="timeout",
+            )
+            raise GatewayTimeoutError(
+                "Timed out calling local LiteLLM embeddings gateway.",
+                alias=self.model,
+            ) from exc
+        except httpx.RequestError as exc:
+            _log_embed_call(
+                model_alias=self.model,
+                started_at=start,
+                timeout_s=request_timeout,
+                status="failure",
+                error_category="connection",
+            )
+            raise GatewayConnectionError(
+                "Could not reach local LiteLLM embeddings gateway. "
+                "Start infra/litellm/start_litellm.sh and verify /v1/models.",
+                alias=self.model,
+            ) from exc
+
+        if response.status_code in {401, 403}:
+            _log_embed_call(
+                model_alias=self.model,
+                started_at=start,
+                timeout_s=request_timeout,
+                status="failure",
+                error_category="authentication",
+            )
+            raise GatewayAuthenticationError(
+                "LiteLLM embeddings gateway authentication failed. "
+                "QUIMERA_LLM_API_KEY should match LITELLM_MASTER_KEY.",
+                alias=self.model,
+            )
+        if response.status_code >= 400:
+            _log_embed_call(
+                model_alias=self.model,
+                started_at=start,
+                timeout_s=request_timeout,
+                status="failure",
+                error_category=f"http_{response.status_code}",
+            )
+            raise GatewayResponseError(
+                f"LiteLLM embeddings gateway returned HTTP {response.status_code}.",
+                alias=self.model,
+            )
+
+        try:
+            body = cast(dict[str, Any], response.json())
+        except ValueError as exc:
+            raise GatewayResponseError(
+                "LiteLLM embeddings gateway returned invalid JSON.",
+                alias=self.model,
+            ) from exc
+
+        vectors = _extract_embeddings(
+            body,
+            expected_dimensions=self.expected_dimensions,
+            alias=self.model,
+        )
+        _log_embed_call(
+            model_alias=self.model,
+            started_at=start,
+            timeout_s=request_timeout,
+            status="success",
+            error_category=None,
+        )
+        return vectors
+
+
+def _validate_text(text: str) -> str:
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    clean = text.strip()
+    if not clean:
+        raise ValueError("text cannot be empty or whitespace")
+    return clean
+
+
+def _extract_embeddings(
+    body: dict[str, Any],
+    *,
+    expected_dimensions: int,
+    alias: str,
+) -> list[list[float]]:
+    data = body.get("data")
+    if not isinstance(data, list) or not data:
+        raise GatewayResponseError(
+            "LiteLLM embeddings response did not include data.",
+            alias=alias,
+        )
+
+    vectors: list[list[float]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise GatewayResponseError(
+                "LiteLLM embeddings response item is invalid.",
+                alias=alias,
+            )
+        vector = _coerce_embedding_vector(
+            item.get("embedding"),
+            expected_dimensions=expected_dimensions,
+            alias=alias,
+        )
+        vectors.append(vector)
+    return vectors
+
+
+def _coerce_embedding_vector(
+    raw_vector: object,
+    *,
+    expected_dimensions: int,
+    alias: str,
+) -> list[float]:
+    if not isinstance(raw_vector, list) or not raw_vector:
+        raise GatewayResponseError(
+            "LiteLLM embeddings response item did not include a vector.",
+            alias=alias,
+        )
+    if len(raw_vector) != expected_dimensions:
+        raise GatewayResponseError(
+            f"Expected {expected_dimensions} embedding dimensions, "
+            f"got {len(raw_vector)}.",
+            alias=alias,
+        )
+
+    vector: list[float] = []
+    for value in raw_vector:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise GatewayResponseError(
+                "LiteLLM embedding vector contains a non-numeric value.",
+                alias=alias,
+            )
+        vector.append(float(value))
+    return vector
+
+
+def _log_embed_call(
+    *,
+    model_alias: str,
+    started_at: float,
+    timeout_s: float,
+    status: str,
+    error_category: str | None,
+) -> None:
+    logger.debug(
+        "gateway_embed | model_alias={} latency_ms={:.1f} timeout_s={:.1f} "
+        "status={} error_category={}",
+        model_alias,
+        (time.perf_counter() - started_at) * 1000,
+        timeout_s,
+        status,
+        error_category or "none",
+    )

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,7 @@
 > meaningful sessions.
 
 **Last updated:** 2026-04-28
-**Updated by:** Codex — Gateway GW-05b live smoke timeout observability
+**Updated by:** Codex — Gateway GW-06 local_embed evaluation
 
 ---
 
@@ -20,6 +20,21 @@ Current runtime path:
 OpenClaw / runtime generation
   -> LiteLLM at http://127.0.0.1:4000/v1
   -> Ollama / Qwen local
+```
+
+Current embedding path:
+
+```text
+RAG / OllamaEmbedder
+  -> Ollama direct at http://127.0.0.1:11434/api/embed
+```
+
+GW-06 adds an experimental evaluation-only path:
+
+```text
+GatewayEmbedClient
+  -> LiteLLM at http://127.0.0.1:4000/v1/embeddings
+  -> Ollama / nomic-embed-text local
 ```
 
 Hard constraints remain:
@@ -65,12 +80,13 @@ unavoidable, use `git push --force-with-lease`.
 | GW-03 | `feat/gateway-route-opencraw-litellm` | Runtime chat/generation through LiteLLM | Done / merged |
 | GW-04 | `feat/gateway-runtime-smoke` | Shared message validation, optional smoke, observability | Done / merged |
 | GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Done / merged |
-| GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Current |
-| GW-06 | TBD | Evaluate embeddings via `local_embed` | Planned |
+| GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Done / merged |
+| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Current |
 | GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
+GW-06 issue: <https://github.com/franciscosalido/OPENCLAW/issues/30>
 
 ---
 
@@ -122,7 +138,25 @@ Observed latencies (macOS, qwen3:14b Q4_K_M):
 GW-06:
 
 - Evaluate whether embeddings should route through `local_embed`.
-- Keep existing direct/local embedding behavior until a tested PR changes it.
+- Add an experimental `GatewayEmbedClient` for OpenAI-compatible
+  `/embeddings` calls through LiteLLM.
+- Keep existing direct/local embedding behavior as the default RAG path.
+- Do not reindex Qdrant or touch real documents.
+- Use only synthetic smoke inputs.
+- Live evaluation on 2026-04-28 passed against local LiteLLM + Ollama.
+- Decision status: **Approved for future migration**.
+- Migration is still not performed in GW-06; a future PR must preserve or
+  replace the current Ollama embedder's retry/backoff/concurrency behavior.
+
+Observed local_embed results (2026-04-28):
+
+| Check | Result |
+|---|---|
+| LiteLLM single embedding | 768 dimensions, 0.08s |
+| LiteLLM batch embedding | 2 vectors, 768 dimensions each, 0.05s |
+| Direct Ollama parity | 768 dimensions |
+| Cosine similarity | 1.000000 |
+| Script smoke | 768 dimensions, 0.70s |
 
 GW-07:
 
@@ -131,7 +165,7 @@ GW-07:
 
 ---
 
-## Validation Expectations For GW-05b
+## Validation Expectations For GW-06
 
 Before opening PR:
 
@@ -141,18 +175,17 @@ uv run pytest -v
 uv run mypy --strict .
 uv run pyright
 uv run python -m compileall backend tests scripts infra
-uv run pytest tests/unit/test_gateway_config.py -v
-uv run pytest tests/unit/test_gateway_client.py -v
+uv run pytest tests/unit/test_gateway_embed_client.py -v
 uv run pytest tests/smoke/ -v
 ```
 
-Smoke tests should skip by default unless `RUN_LITELLM_SMOKE=1` is set.
+Embedding smoke tests should skip by default unless
+`RUN_LITELLM_EMBED_SMOKE=1` is set.
 
 Optional live validation when local services are already running:
 
 ```bash
-export RUN_LITELLM_SMOKE=1
-scripts/test_opencraw_litellm_runtime.sh
-uv run pytest tests/smoke/ -v
-RUN_LITELLM_SMOKE=1 RUN_LITELLM_SMOKE_REPEAT=3 uv run pytest tests/smoke/ -v
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
+scripts/test_local_embed_litellm.sh
 ```

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -5,6 +5,8 @@ PR 4 adds optional live smoke tests for that route.
 GW-05a adds per-alias request timeout budgets for semantic local aliases.
 GW-05b adds live smoke timing validation and logs the effective timeout budget
 used by each gateway call.
+GW-06 evaluates `local_embed` embeddings through LiteLLM without changing the
+default RAG embedding path.
 The default runtime path is:
 
 ```text
@@ -20,6 +22,7 @@ export QUIMERA_LLM_MODEL="local_chat"
 export QUIMERA_LLM_REASONING_MODEL="local_think"
 export QUIMERA_LLM_RAG_MODEL="local_rag"
 export QUIMERA_LLM_JSON_MODEL="local_json"
+export QUIMERA_LLM_EMBED_MODEL="local_embed"
 ```
 
 `QUIMERA_LLM_API_KEY` should match the local `LITELLM_MASTER_KEY` used to start
@@ -94,6 +97,51 @@ providers.
 Smoke is skipped by default. `RUN_LITELLM_SMOKE=1` is required so normal unit
 test runs do not depend on local services.
 
+## Optional Embedding Evaluation
+
+GW-06 evaluates the reserved `local_embed` alias through LiteLLM. This is an
+evaluation path only:
+
+```text
+GatewayEmbedClient -> LiteLLM /v1/embeddings -> Ollama/nomic-embed-text
+```
+
+The current RAG embedding path remains unchanged:
+
+```text
+RAG / OllamaEmbedder -> Ollama direct /api/embed
+```
+
+Run the guarded pytest smoke when LiteLLM and Ollama are already running:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
+```
+
+Run the compact script smoke:
+
+```bash
+scripts/test_local_embed_litellm.sh
+```
+
+The embedding evaluation uses synthetic text only. It does not require Qdrant,
+does not reindex any collection, does not read real documents, and does not use
+real portfolio data.
+
+Interpretation:
+
+- `dims=768` means the expected `nomic-embed-text` vector shape is present.
+- Batch success means LiteLLM accepts a small list of synthetic inputs.
+- Direct Ollama parity checks compare dimensions and log cosine similarity as
+  evidence; they do not require byte-identical vectors.
+- Latency should be recorded before any future migration decision.
+- GW-06 live evidence recorded 768-dimensional vectors, batch support, and
+  cosine similarity `1.000000` against direct Ollama for the synthetic probe.
+- Decision status is **Approved for future migration**, but the default RAG
+  embedder remains direct Ollama until a future migration PR preserves or
+  replaces retry/backoff/concurrency behavior.
+
 ## What Changed
 
 - `backend.rag.generator.LocalGenerator` now sends OpenAI-compatible
@@ -118,6 +166,7 @@ test runs do not depend on local services.
   tested embedding-gateway PR is approved.
 - `local_embed` has a reserved timeout value only. GW-05a does not route
   embeddings through LiteLLM.
+- GW-06 evaluates `local_embed` but does not wire it into default RAG behavior.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -48,13 +48,13 @@ unavoidable, use `git push --force-with-lease`.
 Current active branch:
 
 ```text
-feat/gateway-live-smoke-timeouts
+feat/gateway-local-embed-evaluation
 ```
 
 Current issue:
 
 ```text
-https://github.com/franciscosalido/OPENCLAW/issues/28
+https://github.com/franciscosalido/OPENCLAW/issues/30
 ```
 
 Gateway baseline already merged:
@@ -62,7 +62,8 @@ Gateway baseline already merged:
 ```text
 GW-01 through GW-04 are merged in 92c0ec5.
 GW-05a is merged in 96278f6.
-GW-05b branches from the post-GW-05a baseline.
+GW-05b live smoke fixes are merged through 5c42547.
+GW-06 branches from the post-GW-05b baseline.
 ```
 
 Gateway PR state:
@@ -74,8 +75,8 @@ Gateway PR state:
 | GW-03 | `feat/gateway-route-opencraw-litellm` | OpenClaw runtime chat through LiteLLM | Merged in `92c0ec5` |
 | GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke, observability | Merged in `92c0ec5` |
 | GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Merged in `96278f6` |
-| GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Current |
-| GW-06 | TBD | Evaluate embeddings via `local_embed` | Planned |
+| GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Merged through `5c42547` |
+| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Current |
 | GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
 
 ---
@@ -118,7 +119,58 @@ Out of scope:
 
 ---
 
-## Next Work
+## GW-06 Current Work
+
+Objective:
+
+Evaluate whether the `local_embed` semantic alias can safely return embeddings
+through LiteLLM without changing the default RAG embedding path.
+
+Scope:
+
+- Add an experimental `GatewayEmbedClient` for OpenAI-compatible
+  `/embeddings` calls.
+- Validate single and small-batch synthetic inputs.
+- Validate 768-dimensional numeric vectors.
+- Add optional live smoke guarded by `RUN_LITELLM_EMBED_SMOKE=1`.
+- Add a local script for one synthetic `local_embed` call.
+- Compare direct Ollama and LiteLLM dimensions when live services are available.
+
+Out of scope:
+
+- Replacing `backend.rag.embeddings.OllamaEmbedder`.
+- Routing production RAG embeddings through LiteLLM.
+- Reindexing Qdrant.
+- Real documents, real portfolio data, or private files.
+- FastAPI, MCP, remote providers, quant tools, and autoprogramming.
+
+Decision status:
+
+- **Approved for future migration** after live local evaluation on 2026-04-28.
+- Current RAG remains direct via Ollama in GW-06.
+- A future migration PR must preserve or replace the current direct embedder's
+  retry/backoff/concurrency behavior before switching defaults.
+
+Live evaluation results:
+
+| Check | Result |
+|---|---|
+| `RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v` | 2/2 passed |
+| `scripts/test_local_embed_litellm.sh` | passed |
+| Single embedding | 768 dimensions, 0.08s pytest / 0.70s script |
+| Batch embedding | 2 vectors, 768 dimensions each, 0.05s |
+| Direct Ollama parity | 768 dimensions |
+| Cosine similarity | 1.000000 |
+
+Environment:
+
+- macOS local development machine.
+- LiteLLM: `127.0.0.1:4000`.
+- Ollama: `127.0.0.1:11434`.
+- Embed alias: `local_embed`.
+- Direct model: `nomic-embed-text`.
+
+## Previous Work
 
 GW-05b:
 
@@ -157,11 +209,6 @@ Config fixes applied in GW-05b to make smoke pass:
   before visible content is produced. `local_think` keeps thinking active.
 - Smoke scripts: `max_tokens=2048` for `local_think`; 96 for other aliases.
 
-GW-06:
-
-- Evaluate whether `local_embed` should route embeddings through LiteLLM.
-- Preserve current direct/local embedding path until the PR proves parity.
-
 GW-07:
 
 - Run synthetic RAG E2E over the approved gateway path.
@@ -171,7 +218,7 @@ GW-07:
 
 ## Validation Checklist
 
-Before opening GW-05b PR:
+Before opening GW-06 PR:
 
 ```bash
 git status --short --branch
@@ -181,19 +228,17 @@ uv run pytest -v
 uv run mypy --strict .
 uv run pyright
 uv run python -m compileall backend tests scripts infra
-uv run pytest tests/unit/test_gateway_config.py -v
-uv run pytest tests/unit/test_gateway_client.py -v
+uv run pytest tests/unit/test_gateway_embed_client.py -v
 uv run pytest tests/smoke/ -v
 ```
 
-Expected smoke behavior without `RUN_LITELLM_SMOKE=1`: smoke tests skip, not
-fail.
+Expected embedding smoke behavior without `RUN_LITELLM_EMBED_SMOKE=1`: smoke
+tests skip, not fail.
 
 Optional live checks when local services and credentials are already available:
 
 ```bash
-export RUN_LITELLM_SMOKE=1
-scripts/test_opencraw_litellm_runtime.sh
-uv run pytest tests/smoke/ -v
-RUN_LITELLM_SMOKE=1 RUN_LITELLM_SMOKE_REPEAT=3 uv run pytest tests/smoke/ -v
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
+scripts/test_local_embed_litellm.sh
 ```

--- a/scripts/test_local_embed_litellm.sh
+++ b/scripts/test_local_embed_litellm.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+[ -n "${QUIMERA_LLM_API_KEY:-}" ] || fail "QUIMERA_LLM_API_KEY is required and should match LITELLM_MASTER_KEY."
+
+QUIMERA_LLM_BASE_URL="${QUIMERA_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+QUIMERA_LLM_EMBED_MODEL="${QUIMERA_LLM_EMBED_MODEL:-local_embed}"
+
+case "${QUIMERA_LLM_BASE_URL}" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *) fail "QUIMERA_LLM_BASE_URL must point to the local LiteLLM gateway. Got '${QUIMERA_LLM_BASE_URL}'." ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [ -x ".venv/bin/python" ]; then
+  PYTHON_BIN=".venv/bin/python"
+else
+  PYTHON_BIN="${PYTHON:-python3}"
+fi
+command -v "${PYTHON_BIN}" >/dev/null 2>&1 || fail "python is required." 127
+
+"${PYTHON_BIN}" - <<'PY'
+import asyncio
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+from backend.gateway.embed_client import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    GatewayEmbedClient,
+)
+
+
+SYNTHETIC_TEXT = "Texto sintetico para validar local_embed."
+
+
+def host(base_url: str) -> str:
+    return urlparse(base_url).netloc or "unknown"
+
+
+async def main() -> None:
+    start = time.perf_counter()
+    try:
+        async with GatewayEmbedClient() as client:
+            vector = await client.embed(SYNTHETIC_TEXT)
+    except Exception as exc:
+        raise SystemExit(f"ERROR: local_embed failed: {exc}") from exc
+
+    elapsed = time.perf_counter() - start
+    if len(vector) != DEFAULT_EMBEDDING_DIMENSIONS:
+        raise SystemExit(
+            "ERROR: local_embed returned "
+            f"{len(vector)} dimensions; expected {DEFAULT_EMBEDDING_DIMENSIONS}"
+        )
+    sys.stdout.write(
+        "OK: alias="
+        f"{os.environ.get('QUIMERA_LLM_EMBED_MODEL', 'local_embed')} "
+        f"host={host(os.environ.get('QUIMERA_LLM_BASE_URL', 'http://127.0.0.1:4000/v1'))} "
+        f"dims={len(vector)} elapsed_s={elapsed:.2f}\n"
+    )
+
+
+asyncio.run(main())
+PY

--- a/tests/smoke/test_gateway_embed_smoke.py
+++ b/tests/smoke/test_gateway_embed_smoke.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import math
+import os
+import time
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from loguru import logger
+
+from backend.gateway.client import (
+    DEFAULT_LLM_EMBED_MODEL,
+    ENV_LLM_API_KEY,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.embed_client import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    GatewayEmbedClient,
+)
+
+
+_SYNTHETIC_TEXT = "Documento sintetico sobre diversificacao educacional."
+_SYNTHETIC_BATCH = [
+    "Cenario sintetico de renda fixa.",
+    "Cenario sintetico de fundos imobiliarios.",
+]
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_LITELLM_EMBED_SMOKE") != "1",
+    reason=(
+        "LiteLLM embedding smoke skipped; set RUN_LITELLM_EMBED_SMOKE=1 "
+        "to enable."
+    ),
+)
+
+
+def _runtime_config() -> GatewayRuntimeConfig:
+    if not os.environ.get(ENV_LLM_API_KEY):
+        pytest.skip(f"{ENV_LLM_API_KEY} is required for LiteLLM embedding smoke.")
+    return GatewayRuntimeConfig.from_env().validated()
+
+
+def _base_url_host(base_url: str) -> str:
+    return urlparse(base_url).netloc or "unknown"
+
+
+def _assert_vector(vector: list[float], *, label: str) -> None:
+    assert len(vector) == DEFAULT_EMBEDDING_DIMENSIONS, (
+        f"{label} returned {len(vector)} dimensions; expected "
+        f"{DEFAULT_EMBEDDING_DIMENSIONS}."
+    )
+    assert all(isinstance(value, float) for value in vector), (
+        f"{label} returned a non-float value."
+    )
+
+
+def _cosine_similarity(left: list[float], right: list[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right, strict=True))
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+async def _direct_ollama_embed(text: str) -> list[float]:
+    base_url = os.environ.get("OLLAMA_API_BASE", "http://127.0.0.1:11434").rstrip("/")
+    model = os.environ.get("EMBED_MODEL", "nomic-embed-text")
+    async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+        response = await client.post("/api/embed", json={"model": model, "input": text})
+        response.raise_for_status()
+    body = response.json()
+    embeddings = body.get("embeddings")
+    assert isinstance(embeddings, list) and embeddings, (
+        "Direct Ollama response did not include embeddings."
+    )
+    first = embeddings[0]
+    assert isinstance(first, list), "Direct Ollama embedding is not a list."
+    return [float(value) for value in first]
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_litellm_local_embed_single_and_batch() -> None:
+    config = _runtime_config()
+    host = _base_url_host(config.base_url)
+    async with GatewayEmbedClient(config=config) as embedder:
+        single_start = time.perf_counter()
+        single = await embedder.embed(_SYNTHETIC_TEXT)
+        single_latency = time.perf_counter() - single_start
+
+        batch_start = time.perf_counter()
+        batch = await embedder.embed_batch(_SYNTHETIC_BATCH)
+        batch_latency = time.perf_counter() - batch_start
+
+    _assert_vector(single, label=DEFAULT_LLM_EMBED_MODEL)
+    assert len(batch) == len(_SYNTHETIC_BATCH)
+    for vector in batch:
+        _assert_vector(vector, label=f"{DEFAULT_LLM_EMBED_MODEL} batch")
+
+    logger.info(
+        "embed_smoke alias={} host={} single_latency_s={:.2f} "
+        "batch_latency_s={:.2f} dims={} batch_count={}",
+        DEFAULT_LLM_EMBED_MODEL,
+        host,
+        single_latency,
+        batch_latency,
+        len(single),
+        len(batch),
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_litellm_local_embed_matches_direct_ollama_dimension() -> None:
+    config = _runtime_config()
+    host = _base_url_host(config.base_url)
+
+    async with GatewayEmbedClient(config=config) as embedder:
+        gateway_start = time.perf_counter()
+        gateway_vector = await embedder.embed(_SYNTHETIC_TEXT)
+        gateway_latency = time.perf_counter() - gateway_start
+
+    direct_start = time.perf_counter()
+    direct_vector = await _direct_ollama_embed(_SYNTHETIC_TEXT)
+    direct_latency = time.perf_counter() - direct_start
+
+    _assert_vector(gateway_vector, label=DEFAULT_LLM_EMBED_MODEL)
+    _assert_vector(direct_vector, label="direct Ollama")
+
+    cosine = _cosine_similarity(gateway_vector, direct_vector)
+    logger.info(
+        "embed_parity alias={} host={} gateway_latency_s={:.2f} "
+        "direct_latency_s={:.2f} cosine_similarity={:.6f}",
+        DEFAULT_LLM_EMBED_MODEL,
+        host,
+        gateway_latency,
+        direct_latency,
+        cosine,
+    )

--- a/tests/unit/test_gateway_embed_client.py
+++ b/tests/unit/test_gateway_embed_client.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import unittest
+from typing import cast
+
+import httpx
+from loguru import logger
+
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_EMBED_MODEL,
+    GatewayRuntimeConfig,
+)
+from backend.gateway.embed_client import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    GatewayEmbedClient,
+)
+from backend.gateway.errors import (
+    GatewayAuthenticationError,
+    GatewayConnectionError,
+    GatewayResponseError,
+    GatewayTimeoutError,
+)
+
+
+def _vector(dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS) -> list[float]:
+    return [float(index) / 1000.0 for index in range(dimensions)]
+
+
+def _embedding_response(count: int = 1) -> dict[str, object]:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": index, "embedding": _vector()}
+            for index in range(count)
+        ],
+    }
+
+
+class GatewayEmbedClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_embed_single_text_returns_vector(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+        seen_auth_headers: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            seen_auth_headers.append(request.headers.get("authorization"))
+            self.assertEqual(request.url.path, "/v1/embeddings")
+            return httpx.Response(200, json=_embedding_response())
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            vector = await gateway.embed("texto sintetico")
+
+        self.assertEqual(len(vector), DEFAULT_EMBEDDING_DIMENSIONS)
+        self.assertEqual(seen_auth_headers, ["Bearer secret-test-key"])
+        self.assertEqual(
+            seen_payloads,
+            [{"model": DEFAULT_LLM_EMBED_MODEL, "input": "texto sintetico"}],
+        )
+
+    async def test_embed_batch_returns_vectors(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(200, json=_embedding_response(count=2))
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            vectors = await gateway.embed_batch(["texto um", "texto dois"])
+
+        self.assertEqual(len(vectors), 2)
+        self.assertTrue(all(len(vector) == DEFAULT_EMBEDDING_DIMENSIONS for vector in vectors))
+        self.assertEqual(
+            seen_payloads,
+            [
+                {
+                    "model": DEFAULT_LLM_EMBED_MODEL,
+                    "input": ["texto um", "texto dois"],
+                }
+            ],
+        )
+
+    async def test_empty_batch_returns_empty_list_without_http_call(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise AssertionError("HTTP call should not happen for an empty batch")
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            vectors = await gateway.embed_batch([])
+
+        self.assertEqual(vectors, [])
+
+    async def test_wrong_dimension_raises_response_error(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "index": 0,
+                                "embedding": _vector(dimensions=767),
+                            }
+                        ]
+                    },
+                )
+            ),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayResponseError):
+                await gateway.embed("texto sintetico")
+
+    async def test_non_numeric_vector_values_are_rejected(self) -> None:
+        bad_vector: list[object] = list(_vector())
+        bad_vector[0] = "not-a-number"
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    json={"data": [{"index": 0, "embedding": bad_vector}]},
+                )
+            ),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayResponseError):
+                await gateway.embed("texto sintetico")
+
+    async def test_missing_api_key_fails_clearly(self) -> None:
+        async with httpx.AsyncClient(base_url=DEFAULT_LLM_BASE_URL) as client:
+            with self.assertRaises(GatewayAuthenticationError) as ctx:
+                GatewayEmbedClient(
+                    config=GatewayRuntimeConfig(api_key=None),
+                    client=client,
+                )
+
+        self.assertIn("QUIMERA_LLM_API_KEY", str(ctx.exception))
+
+    async def test_auth_error_maps_to_gateway_authentication_error(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(lambda _request: httpx.Response(401)),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayAuthenticationError) as ctx:
+                await gateway.embed("texto sintetico")
+
+        self.assertNotIn("secret-test-key", str(ctx.exception))
+
+    async def test_connection_error_maps_to_gateway_connection_error(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayConnectionError):
+                await gateway.embed("texto sintetico")
+
+    async def test_timeout_maps_to_gateway_timeout_error(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("timeout")
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayTimeoutError):
+                await gateway.embed("texto sintetico")
+
+    async def test_bad_response_shape_maps_to_gateway_response_error(self) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(200, json={"data": []})
+            ),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            with self.assertRaises(GatewayResponseError):
+                await gateway.embed("texto sintetico")
+
+    async def test_input_text_and_api_key_are_not_logged(self) -> None:
+        logs: list[str] = []
+        sink_id = logger.add(
+            lambda message: logs.append(str(message)),
+            format="{message}",
+        )
+        try:
+            async with httpx.AsyncClient(
+                base_url=DEFAULT_LLM_BASE_URL,
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(200, json=_embedding_response())
+                ),
+            ) as client:
+                gateway = GatewayEmbedClient(
+                    config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                    client=client,
+                )
+                await gateway.embed("texto sintetico que nao deve aparecer")
+        finally:
+            logger.remove(sink_id)
+
+        joined = "\n".join(logs)
+        self.assertIn("gateway_embed", joined)
+        self.assertIn("model_alias=local_embed", joined)
+        self.assertNotIn("secret-test-key", joined)
+        self.assertNotIn("texto sintetico que nao deve aparecer", joined)
+
+    async def test_request_timeout_uses_local_embed_alias_budget(self) -> None:
+        seen_timeouts: list[dict[str, float]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_timeouts.append(cast("dict[str, float]", request.extensions["timeout"]))
+            return httpx.Response(200, json=_embedding_response())
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+            await gateway.embed("texto sintetico")
+
+        self.assertEqual(seen_timeouts[0]["read"], 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #30

## Summary

Evaluates the experimental `local_embed` route through LiteLLM without changing the current RAG embedding default. Adds `GatewayEmbedClient`, mocked unit coverage, guarded live embedding smoke tests, and a compact local script.

## Scope

Included:
- Experimental `backend.gateway.GatewayEmbedClient` for OpenAI-compatible `/embeddings` calls
- Single and batch synthetic embedding support
- 768-dimension numeric vector validation
- Domain error mapping for auth, connection, timeout and bad response cases
- Optional live smoke guarded by `RUN_LITELLM_EMBED_SMOKE=1`
- Script smoke: `scripts/test_local_embed_litellm.sh`
- Docs and handoff update with GW-06 decision status

Excluded:
- Default RAG embedding migration
- Qdrant changes or reindexing
- Retrieval/chunking/prompt-builder changes
- FastAPI, MCP, remote providers, quant tools
- Real documents or real portfolio data

## Live Evaluation

Local live evaluation passed on 2026-04-28:
- pytest embed smoke: 2/2 passed
- script smoke: passed
- single embedding: 768 dimensions, ~0.08s pytest / ~0.70s script
- batch embedding: 2 vectors, 768 dimensions each, ~0.05s
- direct Ollama parity: 768 dimensions
- cosine similarity: 1.000000

Decision: approved for future migration, but current RAG remains direct via Ollama until a migration PR preserves or replaces retry/backoff/concurrency behavior.

## Validation

- `git diff --check`
- `uv run pytest -v` -> 140 passed, 4 skipped, 55 subtests passed
- `uv run mypy --strict .` -> success
- `uv run pyright` -> 0 errors, 0 warnings
- `uv run python -m compileall backend tests scripts infra` -> success
- `uv run pytest tests/smoke/ -v` -> 5 passed, 4 skipped
- `RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v` -> 2 passed
- `scripts/test_local_embed_litellm.sh` -> passed

## Security

- No secrets committed
- `.env` untouched
- No Authorization headers or API keys logged
- No full input text logged by gateway client
- Synthetic text only
- Local-only LiteLLM/Ollama path
- No remote providers enabled