### PR TITLE
test(rag): GW-07 synthetic RAG E2E through local LiteLLM gateway

### DIFF
--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,8 +4,8 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-04-28
-**Updated by:** Codex — Gateway GW-06 local_embed evaluation
+**Last updated:** 2026-04-30
+**Updated by:** Codex — Gateway GW-07 synthetic RAG E2E
 
 ---
 
@@ -35,6 +35,19 @@ GW-06 adds an experimental evaluation-only path:
 GatewayEmbedClient
   -> LiteLLM at http://127.0.0.1:4000/v1/embeddings
   -> Ollama / nomic-embed-text local
+```
+
+GW-07 proves the current RAG E2E path without migrating embeddings:
+
+```text
+synthetic docs
+  -> chunking
+  -> OllamaEmbedder direct at http://127.0.0.1:11434/api/embed
+  -> Qdrant temporary collection gw07_synthetic_rag_<short_uuid>
+  -> Retriever / ContextPacker / PromptBuilder
+  -> LocalGenerator / GatewayChatClient
+  -> LiteLLM at http://127.0.0.1:4000/v1/chat/completions
+  -> Ollama / Qwen local
 ```
 
 Hard constraints remain:
@@ -81,12 +94,14 @@ unavoidable, use `git push --force-with-lease`.
 | GW-04 | `feat/gateway-runtime-smoke` | Shared message validation, optional smoke, observability | Done / merged |
 | GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Done / merged |
 | GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Done / merged |
-| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Current |
-| GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
+| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Done / merged |
+| GW06C | `feat/adr-openai-compatible-embeddings-contract` | OpenAI-compatible embeddings ADR and `quimera_embed` | Done / merged |
+| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
 GW-06 issue: <https://github.com/franciscosalido/OPENCLAW/issues/30>
+GW-07 issue: <https://github.com/franciscosalido/OPENCLAW/issues/38>
 
 ---
 
@@ -162,10 +177,53 @@ GW-07:
 
 - Prove a synthetic RAG end-to-end flow against the gateway path.
 - Keep Qdrant data synthetic and local.
+- Use a unique temporary collection named `gw07_synthetic_rag_<short_uuid>`.
+- Delete only temporary collections with the `gw07_synthetic_rag_` prefix.
+- Never touch `openclaw_knowledge`.
+- Keep embeddings direct through `OllamaEmbedder`; `quimera_embed` appears only
+  as embedding contract metadata in this PR.
+- Generate the final answer through LiteLLM using `local_rag`.
+- Run only when explicitly enabled with `RUN_RAG_E2E_SMOKE=1`.
+
+Manual live command:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_rag_e2e_gateway.sh
+```
+
+Direct pytest command:
+
+```bash
+RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
+```
+
+If cleanup is interrupted, manually delete only Qdrant collections whose names
+start with `gw07_synthetic_rag_`.
+
+Live status:
+
+- **2026-04-30: PASSED** — Cenário A completo for GW-07.
+- Command: `RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s`.
+- Corpus: 3 PT-BR synthetic documents, 7 chunks, 5 chunks retrieved/used.
+- Temporary collection: `gw07_synthetic_rag_<short_uuid>` with prefix-guarded
+  cleanup.
+- Embedding path: direct `OllamaEmbedder` to Ollama `/api/embed`.
+- Generation path: `LocalGenerator` / `GatewayChatClient` through LiteLLM
+  `local_rag`.
+
+Observed GW-07 latencies (2026-04-30):
+
+| Stage | Latency |
+|---|---:|
+| embedding/indexing | 117.9 ms |
+| retrieval | 19.5 ms |
+| generation | 2938.8 ms |
+| total pipeline | 2958.4 ms |
 
 ---
 
-## Validation Expectations For GW-06
+## Validation Expectations For GW-07
 
 Before opening PR:
 
@@ -179,8 +237,8 @@ uv run pytest tests/unit/test_gateway_embed_client.py -v
 uv run pytest tests/smoke/ -v
 ```
 
-Embedding smoke tests should skip by default unless
-`RUN_LITELLM_EMBED_SMOKE=1` is set.
+Live smoke tests should skip by default unless their explicit guards are set.
+GW-07 requires `RUN_RAG_E2E_SMOKE=1`.
 
 Optional live validation when local services are already running:
 
@@ -188,4 +246,12 @@ Optional live validation when local services are already running:
 export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
 scripts/test_local_embed_litellm.sh
+```
+
+Optional GW-07 live validation when Qdrant, Ollama, LiteLLM, and credentials are
+already running locally:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_rag_e2e_gateway.sh
 ```

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -178,7 +178,8 @@ GW-07:
 - Prove a synthetic RAG end-to-end flow against the gateway path.
 - Keep Qdrant data synthetic and local.
 - Use a unique temporary collection named `gw07_synthetic_rag_<short_uuid>`.
-- Delete only temporary collections with the `gw07_synthetic_rag_` prefix.
+- Attempt prefix-guarded cleanup and delete only temporary collections with the
+  `gw07_synthetic_rag_` prefix.
 - Never touch `openclaw_knowledge`.
 - Keep embeddings direct through `OllamaEmbedder`; `quimera_embed` appears only
   as embedding contract metadata in this PR.
@@ -198,16 +199,17 @@ Direct pytest command:
 RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
 ```
 
-If cleanup is interrupted, manually delete only Qdrant collections whose names
-start with `gw07_synthetic_rag_`.
+Cleanup is attempted in teardown. If cleanup is interrupted, manually delete
+only Qdrant collections whose names start with `gw07_synthetic_rag_`.
 
 Live status:
 
 - **2026-04-30: PASSED** — Cenário A completo for GW-07.
 - Command: `RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s`.
-- Corpus: 3 PT-BR synthetic documents, 7 chunks, 5 chunks retrieved/used.
+- Corpus: 3 PT-BR synthetic documents, 14 chunks, 5 chunks retrieved/used.
 - Temporary collection: `gw07_synthetic_rag_<short_uuid>` with prefix-guarded
-  cleanup.
+  cleanup for the recorded run; interrupted runs may require manual cleanup by
+  prefix.
 - Embedding path: direct `OllamaEmbedder` to Ollama `/api/embed`.
 - Generation path: `LocalGenerator` / `GatewayChatClient` through LiteLLM
   `local_rag`.
@@ -216,10 +218,10 @@ Observed GW-07 latencies (2026-04-30):
 
 | Stage | Latency |
 |---|---:|
-| embedding/indexing | 117.9 ms |
-| retrieval | 19.5 ms |
-| generation | 2938.8 ms |
-| total pipeline | 2958.4 ms |
+| embedding/indexing | 178.1 ms |
+| retrieval | 18.4 ms |
+| generation | 3621.2 ms |
+| total pipeline | 3639.6 ms |
 
 ---
 

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -7,6 +7,8 @@ GW-05b adds live smoke timing validation and logs the effective timeout budget
 used by each gateway call.
 GW-06 evaluates `local_embed` embeddings through LiteLLM without changing the
 default RAG embedding path.
+GW-07 adds optional synthetic RAG E2E smoke for the current production-safe path:
+direct Ollama embeddings, temporary Qdrant collection, and LiteLLM generation.
 The default runtime path is:
 
 ```text
@@ -142,6 +144,68 @@ Interpretation:
   embedder remains direct Ollama until a future migration PR preserves or
   replaces retry/backoff/concurrency behavior.
 
+## Optional Synthetic RAG E2E Smoke
+
+GW-07 proves the current RAG path end to end with synthetic data only:
+
+```text
+synthetic docs
+  -> chunking
+  -> OllamaEmbedder direct /api/embed
+  -> Qdrant temporary collection
+  -> Retriever / ContextPacker / PromptBuilder
+  -> LocalGenerator / GatewayChatClient
+  -> LiteLLM /v1/chat/completions
+  -> Ollama / Qwen local
+```
+
+Embeddings remain direct through `OllamaEmbedder` in GW-07. The test records
+the GW06C embedding metadata contract in the temporary chunks, including
+`quimera_embed`, but it does not route production embeddings through LiteLLM.
+
+Run the compact script when Qdrant, Ollama, LiteLLM, and the local gateway key
+are already available:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_rag_e2e_gateway.sh
+```
+
+Run pytest directly:
+
+```bash
+RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
+```
+
+GW-07 smoke is skipped by default. It uses a unique temporary Qdrant collection
+named `gw07_synthetic_rag_<short_uuid>` and deletes it during teardown. It never
+uses or deletes `openclaw_knowledge`.
+
+If a run is interrupted, clean up manually only by deleting collections whose
+names start with `gw07_synthetic_rag_`.
+
+The synthetic corpus is PT-BR and fictitious. It contains no real portfolio
+data, no real tickers, no private documents, no patient data, and no remote
+provider calls.
+
+Qdrant creates the temporary collection with vector size `768` and cosine
+distance, matching the local `nomic-embed-text` embedding metadata. Collection
+payloads include provider, model, dimensions, version, contract, alias, and
+backend so future reindexing decisions can be audited.
+
+GW-07 live result recorded on 2026-04-30:
+
+| Stage | Latency |
+|---|---:|
+| embedding/indexing | 117.9 ms |
+| retrieval | 19.5 ms |
+| generation through `local_rag` | 2938.8 ms |
+| total pipeline | 2958.4 ms |
+
+The run used 3 synthetic PT-BR documents, generated 7 chunks, used 5 retrieved
+chunks, and completed cleanup of the temporary collection without reported
+errors.
+
 ## What Changed
 
 - `backend.rag.generator.LocalGenerator` now sends OpenAI-compatible
@@ -167,6 +231,9 @@ Interpretation:
 - `local_embed` has a reserved timeout value only. GW-05a does not route
   embeddings through LiteLLM.
 - GW-06 evaluates `local_embed` but does not wire it into default RAG behavior.
+- GW-07 does not migrate embeddings; it keeps direct Ollama embeddings and uses
+  LiteLLM only for answer generation.
+- GW-07 does not touch production Qdrant collections or `openclaw_knowledge`.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -178,11 +178,11 @@ RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
 ```
 
 GW-07 smoke is skipped by default. It uses a unique temporary Qdrant collection
-named `gw07_synthetic_rag_<short_uuid>` and deletes it during teardown. It never
-uses or deletes `openclaw_knowledge`.
+named `gw07_synthetic_rag_<short_uuid>` and attempts prefix-guarded deletion
+during teardown. It never uses or deletes `openclaw_knowledge`.
 
-If a run is interrupted, clean up manually only by deleting collections whose
-names start with `gw07_synthetic_rag_`.
+If a run is interrupted, teardown may not complete. Clean up manually only by
+deleting collections whose names start with `gw07_synthetic_rag_`.
 
 The synthetic corpus is PT-BR and fictitious. It contains no real portfolio
 data, no real tickers, no private documents, no patient data, and no remote
@@ -197,14 +197,14 @@ GW-07 live result recorded on 2026-04-30:
 
 | Stage | Latency |
 |---|---:|
-| embedding/indexing | 117.9 ms |
-| retrieval | 19.5 ms |
-| generation through `local_rag` | 2938.8 ms |
-| total pipeline | 2958.4 ms |
+| embedding/indexing | 178.1 ms |
+| retrieval | 18.4 ms |
+| generation through `local_rag` | 3621.2 ms |
+| total pipeline | 3639.6 ms |
 
-The run used 3 synthetic PT-BR documents, generated 7 chunks, used 5 retrieved
+The run used 3 synthetic PT-BR documents, generated 14 chunks, used 5 retrieved
 chunks, and completed cleanup of the temporary collection without reported
-errors.
+errors. Future interrupted runs may still require manual prefix-only cleanup.
 
 ## What Changed
 

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -246,7 +246,7 @@ Scope:
 - Add optional live smoke guarded by `RUN_RAG_E2E_SMOKE=1`.
 - Create a unique temporary Qdrant collection per run using prefix
   `gw07_synthetic_rag_`.
-- Delete only collections with that prefix during cleanup.
+- Attempt prefix-guarded cleanup and delete only collections with that prefix.
 - Persist GW06C embedding metadata in synthetic chunk payloads:
   provider, model, dimensions, version, contract, alias, and backend.
 - Keep embeddings direct via Ollama; `quimera_embed` is metadata/contract only.
@@ -275,18 +275,20 @@ RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
 
 Cleanup rule:
 
-If a run is interrupted and a temporary collection remains, delete only Qdrant
-collections whose names start with `gw07_synthetic_rag_`.
+Cleanup is attempted in teardown. If a run is interrupted and a temporary
+collection remains, delete only Qdrant collections whose names start with
+`gw07_synthetic_rag_`.
 
 Live result:
 
 - **2026-04-30: PASSED** — synthetic RAG E2E over local Qdrant, Ollama, and
   LiteLLM.
 - Command: `RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s`.
-- Corpus: 3 PT-BR synthetic documents, 7 chunks, 5 chunks used.
+- Corpus: 3 PT-BR synthetic documents, 14 chunks, 5 chunks used.
 - Temporary collection pattern: `gw07_synthetic_rag_<short_uuid>`.
 - Collection cleanup: implemented with prefix guard and completed without
-  reported cleanup errors.
+  reported cleanup errors for the recorded run. Interrupted runs may require
+  manual prefix-only cleanup.
 - Generation alias: `local_rag`.
 - Embedding path: direct `OllamaEmbedder` / Ollama `/api/embed`.
 - Embedding metadata: GW06C fields persisted in synthetic payloads.
@@ -295,10 +297,10 @@ Observed latencies (2026-04-30, macOS local):
 
 | Stage | Latency |
 |---|---:|
-| embedding/indexing | 117.9 ms |
-| retrieval | 19.5 ms |
-| generation | 2938.8 ms |
-| total pipeline | 2958.4 ms |
+| embedding/indexing | 178.1 ms |
+| retrieval | 18.4 ms |
+| generation | 3621.2 ms |
+| total pipeline | 3639.6 ms |
 
 ---
 

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Start each Gateway cycle by reading this file before touching Git.
 
-**Last updated:** 2026-04-28
+**Last updated:** 2026-04-30
 **Repository:** OpenClaw
 **Product:** Quimera
 **Sprint:** Gateway-0 / LiteLLM
@@ -48,13 +48,13 @@ unavoidable, use `git push --force-with-lease`.
 Current active branch:
 
 ```text
-feat/gateway-local-embed-evaluation
+feat/gateway-rag-e2e-synthetic
 ```
 
 Current issue:
 
 ```text
-https://github.com/franciscosalido/OPENCLAW/issues/30
+https://github.com/franciscosalido/OPENCLAW/issues/38
 ```
 
 Gateway baseline already merged:
@@ -63,7 +63,8 @@ Gateway baseline already merged:
 GW-01 through GW-04 are merged in 92c0ec5.
 GW-05a is merged in 96278f6.
 GW-05b live smoke fixes are merged through 5c42547.
-GW-06 branches from the post-GW-05b baseline.
+GW-06 local_embed evaluation and GW06C embeddings contract are merged.
+GW-07 branches from the post-GW06C baseline.
 ```
 
 Gateway PR state:
@@ -76,8 +77,9 @@ Gateway PR state:
 | GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke, observability | Merged in `92c0ec5` |
 | GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout configuration | Merged in `96278f6` |
 | GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Merged through `5c42547` |
-| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Current |
-| GW-07 | TBD | Synthetic RAG E2E through gateway path | Planned |
+| GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Merged |
+| GW06C | `feat/adr-openai-compatible-embeddings-contract` | ADR for OpenAI-compatible embeddings contract and `quimera_embed` | Merged |
+| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Current |
 
 ---
 
@@ -119,7 +121,7 @@ Out of scope:
 
 ---
 
-## GW-06 Current Work
+## GW-06 Completed Work
 
 Objective:
 
@@ -213,12 +215,96 @@ GW-07:
 
 - Run synthetic RAG E2E over the approved gateway path.
 - Keep all data fictitious and local.
+- Use `OllamaEmbedder` direct to Ollama for embeddings.
+- Use Qdrant only through a temporary collection named
+  `gw07_synthetic_rag_<short_uuid>`.
+- Use `GatewayChatClient`/`LocalGenerator` through LiteLLM for generation.
+- Do not touch `openclaw_knowledge`.
+
+## GW-07 Current Work
+
+Objective:
+
+Prove the current production-safe RAG path end to end using only synthetic data:
+
+```text
+synthetic docs
+  -> chunking
+  -> OllamaEmbedder direct at Ollama /api/embed
+  -> Qdrant temporary collection
+  -> Retriever
+  -> ContextPacker
+  -> PromptBuilder
+  -> LocalGenerator / GatewayChatClient
+  -> LiteLLM /v1/chat/completions
+  -> Ollama / Qwen local
+  -> answer with citations
+```
+
+Scope:
+
+- Add optional live smoke guarded by `RUN_RAG_E2E_SMOKE=1`.
+- Create a unique temporary Qdrant collection per run using prefix
+  `gw07_synthetic_rag_`.
+- Delete only collections with that prefix during cleanup.
+- Persist GW06C embedding metadata in synthetic chunk payloads:
+  provider, model, dimensions, version, contract, alias, and backend.
+- Keep embeddings direct via Ollama; `quimera_embed` is metadata/contract only.
+- Generate the final answer through LiteLLM using `local_rag`.
+
+Out of scope:
+
+- Production RAG embedding migration.
+- Qdrant reindexing.
+- Touching `openclaw_knowledge`.
+- Real documents, real portfolio data, private files, or patient data.
+- FastAPI, MCP, remote providers, quant tools, and autoprogramming.
+
+Manual run:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_rag_e2e_gateway.sh
+```
+
+Direct pytest run:
+
+```bash
+RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
+```
+
+Cleanup rule:
+
+If a run is interrupted and a temporary collection remains, delete only Qdrant
+collections whose names start with `gw07_synthetic_rag_`.
+
+Live result:
+
+- **2026-04-30: PASSED** — synthetic RAG E2E over local Qdrant, Ollama, and
+  LiteLLM.
+- Command: `RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s`.
+- Corpus: 3 PT-BR synthetic documents, 7 chunks, 5 chunks used.
+- Temporary collection pattern: `gw07_synthetic_rag_<short_uuid>`.
+- Collection cleanup: implemented with prefix guard and completed without
+  reported cleanup errors.
+- Generation alias: `local_rag`.
+- Embedding path: direct `OllamaEmbedder` / Ollama `/api/embed`.
+- Embedding metadata: GW06C fields persisted in synthetic payloads.
+
+Observed latencies (2026-04-30, macOS local):
+
+| Stage | Latency |
+|---|---:|
+| embedding/indexing | 117.9 ms |
+| retrieval | 19.5 ms |
+| generation | 2938.8 ms |
+| total pipeline | 2958.4 ms |
 
 ---
 
 ## Validation Checklist
 
-Before opening GW-06 PR:
+Before opening GW-07 PR:
 
 ```bash
 git status --short --branch
@@ -232,8 +318,8 @@ uv run pytest tests/unit/test_gateway_embed_client.py -v
 uv run pytest tests/smoke/ -v
 ```
 
-Expected embedding smoke behavior without `RUN_LITELLM_EMBED_SMOKE=1`: smoke
-tests skip, not fail.
+Expected smoke behavior without guards: live gateway, embedding, and RAG E2E
+smoke tests skip, not fail.
 
 Optional live checks when local services and credentials are already available:
 
@@ -241,4 +327,12 @@ Optional live checks when local services and credentials are already available:
 export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
 scripts/test_local_embed_litellm.sh
+```
+
+Optional GW-07 live check when Qdrant, Ollama, LiteLLM, and credentials are
+already available:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_rag_e2e_gateway.sh
 ```

--- a/scripts/test_rag_e2e_gateway.sh
+++ b/scripts/test_rag_e2e_gateway.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${QDRANT_URL:=http://127.0.0.1:6333}"
+: "${QUIMERA_LLM_BASE_URL:=http://127.0.0.1:4000/v1}"
+: "${OLLAMA_API_BASE:=http://127.0.0.1:11434}"
+
+if [[ -z "${QUIMERA_LLM_API_KEY:-}" ]]; then
+  printf 'ERROR: QUIMERA_LLM_API_KEY is required and must match local LITELLM_MASTER_KEY.\n' >&2
+  exit 1
+fi
+
+require_local_url() {
+  local name="$1"
+  local value="$2"
+  case "$value" in
+    http://127.0.0.1:*|http://localhost:*|http://[::1]:*)
+      ;;
+    *)
+      printf 'ERROR: %s must be a local-only HTTP URL, got %s\n' "$name" "$value" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_local_url "QDRANT_URL" "$QDRANT_URL"
+require_local_url "QUIMERA_LLM_BASE_URL" "$QUIMERA_LLM_BASE_URL"
+require_local_url "OLLAMA_API_BASE" "$OLLAMA_API_BASE"
+
+export QDRANT_URL
+export QUIMERA_LLM_BASE_URL
+export OLLAMA_API_BASE
+export RUN_RAG_E2E_SMOKE=1
+
+printf 'GW-07 synthetic RAG E2E smoke starting (local services only).\n'
+printf 'Qdrant=%s LiteLLM=%s Ollama=%s\n' "$QDRANT_URL" "$QUIMERA_LLM_BASE_URL" "$OLLAMA_API_BASE"
+
+cd "$ROOT_DIR"
+uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
+
+printf 'GW-07 synthetic RAG E2E smoke completed.\n'

--- a/tests/smoke/test_rag_e2e_gateway_smoke.py
+++ b/tests/smoke/test_rag_e2e_gateway_smoke.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import os
 import re
 import time
+import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 import httpx
 import pytest
+import yaml
 from loguru import logger
 from qdrant_client import QdrantClient
 from qdrant_client.http import models
@@ -38,15 +41,27 @@ pytestmark = [
 ]
 
 TEMP_COLLECTION_PREFIX = "gw07_synthetic_rag_"
+RAG_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "rag_config.yaml"
 DEFAULT_QDRANT_URL = "http://127.0.0.1:6333"
 DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
 VECTOR_SIZE = 768
 TOTAL_E2E_BUDGET_SECONDS = 180.0
 GENERATION_OVERHEAD_SECONDS = 10.0
-CITATION_RE = re.compile(r"\[[a-z0-9_]+#\d+\]")
+CITATION_RE = re.compile(r"\[[\w\d_#]+\]")
 DISALLOWED_MARKET_EXAMPLE_RE = re.compile(
     r"\b(?:petr\d?|vale\d?|itub\d?|bbdc\d?|aapl|tsla)\b",
     re.IGNORECASE,
+)
+REQUIRED_EMBEDDING_METADATA_FIELDS = frozenset(
+    {
+        "embedding_provider",
+        "embedding_model",
+        "embedding_dimensions",
+        "embedding_version",
+        "embedding_contract",
+        "embedding_alias",
+        "embedding_backend",
+    }
 )
 
 
@@ -70,13 +85,14 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
     ollama_base_url = os.environ.get("OLLAMA_API_BASE", DEFAULT_OLLAMA_API_BASE)
     llm_base_url = os.environ.get("QUIMERA_LLM_BASE_URL", DEFAULT_LLM_BASE_URL)
     generation_alias = os.environ.get("QUIMERA_LLM_RAG_MODEL", DEFAULT_LLM_RAG_MODEL)
-    collection_name = f"{TEMP_COLLECTION_PREFIX}{uuid4().hex[:10]}"
+    collection_name = f"{TEMP_COLLECTION_PREFIX}{uuid4().hex[:8]}"
+    embedding_metadata = _embedding_metadata_from_config()
 
     _assert_local_url(qdrant_url, "QDRANT_URL")
     _assert_local_url(ollama_base_url, "OLLAMA_API_BASE")
     _assert_local_url(llm_base_url, "QUIMERA_LLM_BASE_URL")
-    await _assert_ollama_reachable(ollama_base_url)
-    await _assert_litellm_reachable(llm_base_url, api_key)
+    await _skip_if_ollama_unreachable(ollama_base_url)
+    await _skip_if_litellm_unreachable(llm_base_url, api_key)
 
     client = QdrantClient(url=qdrant_url)
     embedder = OllamaEmbedder(base_url=ollama_base_url)
@@ -90,12 +106,18 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
     cleanup_errors: list[str] = []
 
     try:
-        _assert_qdrant_reachable(client)
+        existing_collections = _skip_if_qdrant_unreachable(client, qdrant_url)
+        assert collection_name != "openclaw_knowledge"
+        assert collection_name not in existing_collections
+        assert collection_name.startswith(TEMP_COLLECTION_PREFIX)
         store.ensure_collection()
         collection_created = True
 
         total_start = time.perf_counter()
-        chunks, vectors, index_latency = await _embed_synthetic_corpus(embedder)
+        chunks, vectors, index_latency = await _embed_synthetic_corpus(
+            embedder,
+            embedding_metadata=embedding_metadata,
+        )
         assert len(chunks) >= 5
 
         store.upsert(chunks, vectors)
@@ -122,7 +144,10 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
             temperature=0.0,
         )
 
-        question = "Qual regra de liquidez aparece no Fundo Ficticio Alfa?"
+        question = (
+            "No Fundo Sintetico Alpha, qual regra controla renda variavel "
+            "sintetica e liquidez?"
+        )
         try:
             result = await pipeline.ask(question, top_k=5)
         finally:
@@ -142,17 +167,35 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
 
         assert result.chunks_used
         assert any(chunk.doc_id == "fundo_ficticio_alfa" for chunk in result.chunks_used)
-        assert any("[fundo_ficticio_alfa#" in message["content"] for message in result.messages)
+        assert any(
+            re.search(r"\[fundo_ficticio_alfa#\d+\]", message["content"])
+            for message in result.messages
+        )
         assert any("Inclua citacoes" in message["content"] for message in result.messages)
-        assert len(result.answer) > 50
-        assert CITATION_RE.search(result.answer), result.answer
-        assert _mentions_expected_concept(result.answer)
+        assert len(result.answer) > 50, (
+            f"Answer was too short. Got: {result.answer[:200]!r}"
+        )
+        assert CITATION_RE.search(result.answer), (
+            f"Answer did not contain a citation marker. Got: {result.answer[:200]!r}"
+        )
+        assert _mentions_expected_concept(result.answer), (
+            "Answer did not mention expected synthetic concept. "
+            f"Got: {result.answer[:200]!r}"
+        )
         assert not _mentions_disallowed_real_market_example(result.answer)
         assert result.latency_ms["generation_ms"] / 1000 < generation_budget
         assert total_elapsed < TOTAL_E2E_BUDGET_SECONDS
 
-        for chunk in result.chunks_used:
-            _assert_embedding_metadata(chunk.payload)
+        for stored_chunk in chunks:
+            _assert_embedding_metadata(
+                stored_chunk.metadata,
+                expected=embedding_metadata,
+            )
+        for retrieved_chunk in result.chunks_used:
+            _assert_embedding_metadata(
+                retrieved_chunk.payload,
+                expected=embedding_metadata,
+            )
 
         logger.info(
             "gw07_rag_e2e | collection={} chunks={} used={} "
@@ -171,6 +214,11 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
             try:
                 _delete_temp_collection(client, collection_name)
             except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "gw07_cleanup_failed collection={} error={}",
+                    collection_name,
+                    exc,
+                )
                 cleanup_errors.append(f"{collection_name}: {exc}")
         await embedder.aclose()
         client.close()
@@ -184,6 +232,8 @@ async def test_synthetic_rag_e2e_through_local_gateway() -> None:
 
 async def _embed_synthetic_corpus(
     embedder: OllamaEmbedder,
+    *,
+    embedding_metadata: Mapping[str, Any],
 ) -> tuple[list[VectorStoreChunk], list[list[float]], float]:
     docs = _synthetic_docs()
     chunks: list[VectorStoreChunk] = []
@@ -201,13 +251,7 @@ async def _embed_synthetic_corpus(
                         "source_type": "synthetic",
                         "start_char": chunk.start_char,
                         "end_char": chunk.end_char,
-                        "embedding_provider": "ollama",
-                        "embedding_model": "nomic-embed-text",
-                        "embedding_dimensions": VECTOR_SIZE,
-                        "embedding_version": "local-ollama-current",
-                        "embedding_contract": "openai_compatible_v1_embeddings",
-                        "embedding_alias": "quimera_embed",
-                        "embedding_backend": "direct_ollama_current",
+                        **embedding_metadata,
                     },
                 )
             )
@@ -221,36 +265,73 @@ def _synthetic_docs() -> list[SyntheticDoc]:
     return [
         SyntheticDoc(
             doc_id="fundo_ficticio_alfa",
-            title="Fundo Ficticio Alfa",
+            title="Fundo Sintetico Alpha",
             text=(
-                "O Fundo Ficticio Alfa e um estudo educacional inventado para "
-                "testes locais. Ele descreve uma regra de liquidez simulada: "
-                "manter uma reserva operacional equivalente a 12 meses de "
-                "despesas projetadas antes de ampliar exposicao a ativos de "
-                "maior volatilidade.\n\n"
-                "A politica sintetica do Fundo Ficticio Alfa tambem exige que "
-                "qualquer aumento de risco seja acompanhado por justificativa "
-                "documentada, limite de concentracao e revisao mensal pelo "
-                "comite ficticio. Nenhum dado real de carteira e usado.\n\n"
-                "Quando o cenario hipotetico indica estresse de liquidez, o "
-                "fundo reduz novas alocacoes simuladas e prioriza instrumentos "
-                "educacionais de menor prazo. Esta regra existe apenas para "
-                "validar recuperacao e citacoes no pipeline RAG."
+                "O Fundo Sintetico Alpha e um documento educacional inventado "
+                "para validar recuperacao local. A regra principal afirma que "
+                "renda variavel sintetica so pode receber novas alocacoes "
+                "quando a reserva de liquidez simulada cobrir 12 meses de "
+                "despesas projetadas. A regra existe apenas para testes e nao "
+                "representa fundo real, carteira real ou recomendacao.\n\n"
+                "A segunda regra do Fundo Sintetico Alpha descreve que renda "
+                "variavel sintetica deve ser acompanhada por trilha de auditoria "
+                "ficticia, limite de concentracao educacional e revisao mensal "
+                "do comite simulado. O documento repete que todos os exemplos "
+                "sao artificiais e que nenhum dado de investidor e usado.\n\n"
+                "Em um evento hipotetico de estresse de liquidez, o Fundo "
+                "Sintetico Alpha interrompe aportes em renda variavel sintetica, "
+                "prioriza instrumentos simulados de menor prazo e registra a "
+                "decisao com citacao do documento. Essa politica reforca a "
+                "separacao entre teste tecnico e decisao financeira real.\n\n"
+                "O anexo didatico do Fundo Sintetico Alpha explica que o "
+                "assistente deve recuperar a regra de liquidez antes de gerar "
+                "resposta. Se o contexto recuperado nao mencionar renda "
+                "variavel sintetica, a resposta deve indicar insuficiencia de "
+                "contexto. Se mencionar, a resposta deve citar a fonte no "
+                "formato doc_id e chunk.\n\n"
+                "Para fortalecer o teste de chunking, este paragrafo longo "
+                "descreve uma rotina ficticia de acompanhamento semanal, "
+                "validacao de limites, simulacao de caixa, revisao de premissas, "
+                "registro de decisoes, comparacao com um plano educacional e "
+                "controle de linguagem. A rotina nao contem nomes de empresas, "
+                "nao contem codigos de negociacao, nao contem valores reais e "
+                "nao descreve carteira verdadeira. Ela apenas fornece massa de "
+                "texto para que o pipeline produza multiplos chunks, recupere "
+                "contexto relevante e gere uma resposta citada usando o gateway "
+                "local. A renda variavel sintetica aparece varias vezes porque "
+                "e o conceito-alvo do smoke test, junto com a liquidez simulada "
+                "de 12 meses. O texto tambem declara que risco, liquidez, "
+                "concentracao, governanca ficticia e auditoria sintetica sao "
+                "conceitos distintos dentro do corpus. Essa extensao garante "
+                "que pelo menos um documento ultrapasse quatrocentos tokens em "
+                "um formato totalmente artificial, inline e sem dependencia de "
+                "arquivos privados.\n\n"
+                "Um ultimo bloco de controle descreve uma ata simulada, uma "
+                "fila ficticia de aprovacoes, uma justificativa educacional, "
+                "um historico inventado de revisoes e um resumo sintetico de "
+                "aprendizado. O bloco reforca que renda variavel sintetica "
+                "depende de liquidez simulada, que a reserva de 12 meses e "
+                "apenas uma regra didatica, que nenhum arquivo local privado "
+                "foi lido e que a resposta deve permanecer presa ao contexto "
+                "recuperado. Tambem adiciona termos de governanca sintetica, "
+                "controle operacional ficticio e classificacao educacional "
+                "para ampliar a superficie de recuperacao sem incluir dados "
+                "reais."
             ),
         ),
         SyntheticDoc(
             doc_id="cenario_macro_sintetico",
-            title="Cenario Macro Sintetico Brasil",
+            title="Cenario Macro Simulado",
             text=(
-                "O Cenario Macro Sintetico Brasil apresenta uma narrativa "
-                "ficticia sobre juros, inflacao e crescimento. O documento "
-                "afirma que decisoes educacionais devem separar hipoteses de "
-                "curto prazo, como inflacao persistente, de premissas de longo "
-                "prazo, como produtividade e credito.\n\n"
-                "Em um ambiente simulado de juros altos, o material recomenda "
-                "testar a sensibilidade de renda fixa ficticia e fundos "
-                "imobiliarios sinteticos, sempre sem usar nomes de empresas, "
-                "codigos de negociacao ou carteiras reais."
+                "O Cenario Macro Simulado descreve uma economia inventada com "
+                "juros educacionais, inflacao ficticia e crescimento abstrato. "
+                "O objetivo e testar se o pipeline diferencia premissas de curto "
+                "prazo, como pressao de custos simulada, de premissas de longo "
+                "prazo, como produtividade teorica.\n\n"
+                "O documento tambem compara renda fixa ficticia, renda variavel "
+                "sintetica e caixa educacional sem citar empresas reais. Ele "
+                "nao inclui tickers, nao inclui carteiras e nao inclui qualquer "
+                "informacao privada."
             ),
         ),
         SyntheticDoc(
@@ -262,37 +343,45 @@ def _synthetic_docs() -> list[SyntheticDoc]:
                 "sem suporte. Ela tambem orienta que dados pessoais, credenciais "
                 "e documentos privados nunca sejam usados em testes.\n\n"
                 "Para concentracao, a politica ficticia usa limites didaticos "
-                "por classe de ativo e aciona revisao quando uma classe "
-                "hipotetica domina a explicacao. A revisao deve ser registrada "
-                "com o identificador do documento sintetico."
+                "por classe de ativo, incluindo renda variavel sintetica, e "
+                "aciona revisao quando uma classe hipotetica domina a "
+                "explicacao. A revisao deve ser registrada com o identificador "
+                "do documento sintetico."
             ),
         ),
     ]
 
 
-def _assert_qdrant_reachable(client: QdrantClient) -> None:
+def _skip_if_qdrant_unreachable(client: QdrantClient, qdrant_url: str) -> set[str]:
     try:
-        client.get_collections()
-    except Exception as exc:  # noqa: BLE001
-        pytest.fail(
-            "Qdrant is not reachable at QDRANT_URL. Start the local Qdrant "
-            "service before running GW-07 live smoke."
+        collections = client.get_collections().collections
+    except Exception:  # noqa: BLE001
+        pytest.skip(
+            f"GW-07 E2E smoke skipped: Qdrant is not reachable at {qdrant_url}. "
+            "Start the local Qdrant service before running live smoke."
         )
+    names = {collection.name for collection in collections}
+    logger.info(
+        "gw07_qdrant_preflight | collections={} production_present={}",
+        len(names),
+        "openclaw_knowledge" in names,
+    )
+    return names
 
 
-async def _assert_ollama_reachable(base_url: str) -> None:
+async def _skip_if_ollama_unreachable(base_url: str) -> None:
     try:
         async with httpx.AsyncClient(base_url=base_url, timeout=5.0) as client:
             response = await client.get("/api/tags")
             response.raise_for_status()
-    except httpx.HTTPError as exc:
-        pytest.fail(
-            "Ollama is not reachable at OLLAMA_API_BASE. Start Ollama and pull "
-            "nomic-embed-text before running GW-07 live smoke."
+    except httpx.HTTPError:
+        pytest.skip(
+            f"GW-07 E2E smoke skipped: Ollama is not reachable at {base_url}. "
+            "Start Ollama and pull nomic-embed-text before running live smoke."
         )
 
 
-async def _assert_litellm_reachable(base_url: str, api_key: str) -> None:
+async def _skip_if_litellm_unreachable(base_url: str, api_key: str) -> None:
     try:
         async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
             response = await client.get(
@@ -302,18 +391,18 @@ async def _assert_litellm_reachable(base_url: str, api_key: str) -> None:
             response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code in {401, 403}:
-            pytest.fail(
-                "LiteLLM authentication failed. QUIMERA_LLM_API_KEY must match "
-                "the local LITELLM_MASTER_KEY."
+            pytest.skip(
+                "GW-07 E2E smoke skipped: LiteLLM authentication failed. "
+                "QUIMERA_LLM_API_KEY must match the local LITELLM_MASTER_KEY."
             )
-        pytest.fail(
-            "LiteLLM /models returned an error. Verify the local gateway and "
-            "semantic aliases before running GW-07 live smoke."
+        pytest.skip(
+            f"GW-07 E2E smoke skipped: LiteLLM /models returned HTTP "
+            f"{exc.response.status_code} at {base_url}."
         )
     except httpx.HTTPError:
-        pytest.fail(
-            "LiteLLM is not reachable at QUIMERA_LLM_BASE_URL. Start "
-            "infra/litellm/start_litellm.sh before running GW-07 live smoke."
+        pytest.skip(
+            f"GW-07 E2E smoke skipped: LiteLLM is not reachable at {base_url}. "
+            "Start infra/litellm/start_litellm.sh before running live smoke."
         )
 
 
@@ -327,30 +416,67 @@ def _assert_local_url(url: str, variable_name: str) -> None:
 
 
 def _delete_temp_collection(client: QdrantClient, collection_name: str) -> None:
-    if not collection_name.startswith(TEMP_COLLECTION_PREFIX):
-        raise ValueError(
-            f"refusing to delete collection without {TEMP_COLLECTION_PREFIX!r} prefix"
-        )
+    assert collection_name.startswith(TEMP_COLLECTION_PREFIX), (
+        f"Refusing to delete collection {collection_name!r} - prefix guard failed"
+    )
     if client.collection_exists(collection_name):
         client.delete_collection(collection_name)
 
 
-def _assert_embedding_metadata(payload: Mapping[str, Any]) -> None:
+def _embedding_metadata_from_config() -> dict[str, Any]:
+    raw = yaml.safe_load(RAG_CONFIG_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise TypeError("rag_config.yaml must contain a mapping")
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        raise TypeError("rag_config.yaml must contain rag mapping")
+    embedding = rag.get("embedding")
+    if not isinstance(embedding, Mapping):
+        raise TypeError("rag_config.yaml must contain rag.embedding mapping")
+
+    metadata = {
+        field: embedding[field]
+        for field in REQUIRED_EMBEDDING_METADATA_FIELDS
+        if field in embedding
+    }
+    missing = REQUIRED_EMBEDDING_METADATA_FIELDS.difference(metadata)
+    if missing:
+        raise AssertionError(
+            f"rag_config.yaml is missing embedding metadata fields: {sorted(missing)}"
+        )
+
+    assert metadata["embedding_provider"] == "ollama"
+    assert metadata["embedding_model"] == "nomic-embed-text"
+    assert metadata["embedding_dimensions"] == VECTOR_SIZE
+    assert metadata["embedding_contract"] == "openai_compatible_v1_embeddings"
+    assert metadata["embedding_alias"] == "quimera_embed"
+    assert metadata["embedding_backend"] == "direct_ollama_current"
+    return metadata
+
+
+def _assert_embedding_metadata(
+    payload: Mapping[str, Any],
+    *,
+    expected: Mapping[str, Any],
+) -> None:
     assert payload["source_type"] == "synthetic"
-    assert payload["embedding_provider"] == "ollama"
-    assert payload["embedding_model"] == "nomic-embed-text"
-    assert payload["embedding_dimensions"] == VECTOR_SIZE
-    assert payload["embedding_version"] == "local-ollama-current"
-    assert payload["embedding_contract"] == "openai_compatible_v1_embeddings"
-    assert payload["embedding_alias"] == "quimera_embed"
-    assert payload["embedding_backend"] == "direct_ollama_current"
-    assert str(payload["chunk_id"]).startswith(str(payload["doc_id"]))
+    missing = REQUIRED_EMBEDDING_METADATA_FIELDS.difference(payload)
+    assert not missing, f"payload missing embedding metadata fields: {sorted(missing)}"
+    for field in REQUIRED_EMBEDDING_METADATA_FIELDS:
+        assert payload[field] == expected[field]
+    if "doc_id" in payload:
+        assert str(payload["chunk_id"]).startswith(str(payload["doc_id"]))
 
 
 def _mentions_expected_concept(answer: str) -> bool:
-    normalized = answer.casefold()
-    return "liquidez" in normalized or "12" in normalized
+    normalized = _normalize_text(answer)
+    return "renda variavel sintetica" in normalized
 
 
 def _mentions_disallowed_real_market_example(answer: str) -> bool:
     return DISALLOWED_MARKET_EXAMPLE_RE.search(answer) is not None
+
+
+def _normalize_text(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value.casefold())
+    return "".join(char for char in decomposed if not unicodedata.combining(char))

--- a/tests/smoke/test_rag_e2e_gateway_smoke.py
+++ b/tests/smoke/test_rag_e2e_gateway_smoke.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import os
+import re
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from loguru import logger
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+from backend.gateway.client import (
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_LLM_RAG_MODEL,
+    GatewayRuntimeConfig,
+)
+from backend.rag.chunking import chunk_text
+from backend.rag.context_packer import ContextPacker
+from backend.rag.embeddings import OllamaEmbedder
+from backend.rag.generator import LocalGenerator
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.qdrant_store import QdrantVectorStore, VectorStoreChunk
+from backend.rag.retriever import Retriever
+
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(
+        os.environ.get("RUN_RAG_E2E_SMOKE") != "1",
+        reason="set RUN_RAG_E2E_SMOKE=1 to run live synthetic RAG E2E smoke",
+    ),
+]
+
+TEMP_COLLECTION_PREFIX = "gw07_synthetic_rag_"
+DEFAULT_QDRANT_URL = "http://127.0.0.1:6333"
+DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
+VECTOR_SIZE = 768
+TOTAL_E2E_BUDGET_SECONDS = 180.0
+GENERATION_OVERHEAD_SECONDS = 10.0
+CITATION_RE = re.compile(r"\[[a-z0-9_]+#\d+\]")
+DISALLOWED_MARKET_EXAMPLE_RE = re.compile(
+    r"\b(?:petr\d?|vale\d?|itub\d?|bbdc\d?|aapl|tsla)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class SyntheticDoc:
+    doc_id: str
+    title: str
+    text: str
+
+
+@pytest.mark.asyncio
+async def test_synthetic_rag_e2e_through_local_gateway() -> None:
+    api_key = os.environ.get("QUIMERA_LLM_API_KEY")
+    if not api_key:
+        pytest.skip(
+            "QUIMERA_LLM_API_KEY is required for live GW-07 RAG E2E smoke; "
+            "it must match the local LiteLLM master key."
+        )
+
+    qdrant_url = os.environ.get("QDRANT_URL", DEFAULT_QDRANT_URL)
+    ollama_base_url = os.environ.get("OLLAMA_API_BASE", DEFAULT_OLLAMA_API_BASE)
+    llm_base_url = os.environ.get("QUIMERA_LLM_BASE_URL", DEFAULT_LLM_BASE_URL)
+    generation_alias = os.environ.get("QUIMERA_LLM_RAG_MODEL", DEFAULT_LLM_RAG_MODEL)
+    collection_name = f"{TEMP_COLLECTION_PREFIX}{uuid4().hex[:10]}"
+
+    _assert_local_url(qdrant_url, "QDRANT_URL")
+    _assert_local_url(ollama_base_url, "OLLAMA_API_BASE")
+    _assert_local_url(llm_base_url, "QUIMERA_LLM_BASE_URL")
+    await _assert_ollama_reachable(ollama_base_url)
+    await _assert_litellm_reachable(llm_base_url, api_key)
+
+    client = QdrantClient(url=qdrant_url)
+    embedder = OllamaEmbedder(base_url=ollama_base_url)
+    store = QdrantVectorStore(
+        collection_name=collection_name,
+        vector_size=VECTOR_SIZE,
+        distance=models.Distance.COSINE,
+        client=client,
+    )
+    collection_created = False
+    cleanup_errors: list[str] = []
+
+    try:
+        _assert_qdrant_reachable(client)
+        store.ensure_collection()
+        collection_created = True
+
+        total_start = time.perf_counter()
+        chunks, vectors, index_latency = await _embed_synthetic_corpus(embedder)
+        assert len(chunks) >= 5
+
+        store.upsert(chunks, vectors)
+        assert store.count() == len(chunks)
+
+        retriever = Retriever(
+            embedder=embedder,
+            store=store,
+            packer=ContextPacker(max_context_tokens=900),
+            top_k=5,
+            score_threshold=0.0,
+        )
+        generator = LocalGenerator(
+            model=generation_alias,
+            base_url=llm_base_url,
+            api_key=api_key,
+            temperature=0.0,
+            max_tokens=512,
+        )
+        pipeline = LocalRagPipeline(
+            retriever=retriever,
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            temperature=0.0,
+        )
+
+        question = "Qual regra de liquidez aparece no Fundo Ficticio Alfa?"
+        try:
+            result = await pipeline.ask(question, top_k=5)
+        finally:
+            await generator.aclose()
+
+        total_elapsed = time.perf_counter() - total_start
+        generation_budget = (
+            GatewayRuntimeConfig(
+                base_url=llm_base_url,
+                api_key=api_key,
+                default_model=generation_alias,
+            )
+            .validated()
+            .resolve_timeout(generation_alias)
+            + GENERATION_OVERHEAD_SECONDS
+        )
+
+        assert result.chunks_used
+        assert any(chunk.doc_id == "fundo_ficticio_alfa" for chunk in result.chunks_used)
+        assert any("[fundo_ficticio_alfa#" in message["content"] for message in result.messages)
+        assert any("Inclua citacoes" in message["content"] for message in result.messages)
+        assert len(result.answer) > 50
+        assert CITATION_RE.search(result.answer), result.answer
+        assert _mentions_expected_concept(result.answer)
+        assert not _mentions_disallowed_real_market_example(result.answer)
+        assert result.latency_ms["generation_ms"] / 1000 < generation_budget
+        assert total_elapsed < TOTAL_E2E_BUDGET_SECONDS
+
+        for chunk in result.chunks_used:
+            _assert_embedding_metadata(chunk.payload)
+
+        logger.info(
+            "gw07_rag_e2e | collection={} chunks={} used={} "
+            "indexing_ms={:.1f} retrieval_ms={:.1f} generation_ms={:.1f} "
+            "total_ms={:.1f}",
+            collection_name,
+            len(chunks),
+            len(result.chunks_used),
+            index_latency * 1000,
+            result.latency_ms["retrieval_ms"],
+            result.latency_ms["generation_ms"],
+            result.latency_ms["total_ms"],
+        )
+    finally:
+        if collection_created:
+            try:
+                _delete_temp_collection(client, collection_name)
+            except Exception as exc:  # noqa: BLE001
+                cleanup_errors.append(f"{collection_name}: {exc}")
+        await embedder.aclose()
+        client.close()
+
+    if cleanup_errors:
+        pytest.fail(
+            "Temporary Qdrant collection cleanup failed; remove only collections "
+            f"with prefix {TEMP_COLLECTION_PREFIX!r}: {cleanup_errors}"
+        )
+
+
+async def _embed_synthetic_corpus(
+    embedder: OllamaEmbedder,
+) -> tuple[list[VectorStoreChunk], list[list[float]], float]:
+    docs = _synthetic_docs()
+    chunks: list[VectorStoreChunk] = []
+
+    for document in docs:
+        for chunk in chunk_text(document.text, max_tokens=55, overlap_tokens=12):
+            chunks.append(
+                VectorStoreChunk(
+                    doc_id=document.doc_id,
+                    chunk_index=chunk.index,
+                    text=chunk.text,
+                    metadata={
+                        "chunk_id": f"{document.doc_id}#{chunk.index}",
+                        "title": document.title,
+                        "source_type": "synthetic",
+                        "start_char": chunk.start_char,
+                        "end_char": chunk.end_char,
+                        "embedding_provider": "ollama",
+                        "embedding_model": "nomic-embed-text",
+                        "embedding_dimensions": VECTOR_SIZE,
+                        "embedding_version": "local-ollama-current",
+                        "embedding_contract": "openai_compatible_v1_embeddings",
+                        "embedding_alias": "quimera_embed",
+                        "embedding_backend": "direct_ollama_current",
+                    },
+                )
+            )
+
+    start = time.perf_counter()
+    vectors = await embedder.embed_batch([chunk.text for chunk in chunks])
+    return chunks, vectors, time.perf_counter() - start
+
+
+def _synthetic_docs() -> list[SyntheticDoc]:
+    return [
+        SyntheticDoc(
+            doc_id="fundo_ficticio_alfa",
+            title="Fundo Ficticio Alfa",
+            text=(
+                "O Fundo Ficticio Alfa e um estudo educacional inventado para "
+                "testes locais. Ele descreve uma regra de liquidez simulada: "
+                "manter uma reserva operacional equivalente a 12 meses de "
+                "despesas projetadas antes de ampliar exposicao a ativos de "
+                "maior volatilidade.\n\n"
+                "A politica sintetica do Fundo Ficticio Alfa tambem exige que "
+                "qualquer aumento de risco seja acompanhado por justificativa "
+                "documentada, limite de concentracao e revisao mensal pelo "
+                "comite ficticio. Nenhum dado real de carteira e usado.\n\n"
+                "Quando o cenario hipotetico indica estresse de liquidez, o "
+                "fundo reduz novas alocacoes simuladas e prioriza instrumentos "
+                "educacionais de menor prazo. Esta regra existe apenas para "
+                "validar recuperacao e citacoes no pipeline RAG."
+            ),
+        ),
+        SyntheticDoc(
+            doc_id="cenario_macro_sintetico",
+            title="Cenario Macro Sintetico Brasil",
+            text=(
+                "O Cenario Macro Sintetico Brasil apresenta uma narrativa "
+                "ficticia sobre juros, inflacao e crescimento. O documento "
+                "afirma que decisoes educacionais devem separar hipoteses de "
+                "curto prazo, como inflacao persistente, de premissas de longo "
+                "prazo, como produtividade e credito.\n\n"
+                "Em um ambiente simulado de juros altos, o material recomenda "
+                "testar a sensibilidade de renda fixa ficticia e fundos "
+                "imobiliarios sinteticos, sempre sem usar nomes de empresas, "
+                "codigos de negociacao ou carteiras reais."
+            ),
+        ),
+        SyntheticDoc(
+            doc_id="politica_risco_sintetica",
+            title="Politica de Risco Sintetica",
+            text=(
+                "A Politica de Risco Sintetica define que toda resposta do "
+                "assistente deve citar fontes recuperadas e evitar inferencias "
+                "sem suporte. Ela tambem orienta que dados pessoais, credenciais "
+                "e documentos privados nunca sejam usados em testes.\n\n"
+                "Para concentracao, a politica ficticia usa limites didaticos "
+                "por classe de ativo e aciona revisao quando uma classe "
+                "hipotetica domina a explicacao. A revisao deve ser registrada "
+                "com o identificador do documento sintetico."
+            ),
+        ),
+    ]
+
+
+def _assert_qdrant_reachable(client: QdrantClient) -> None:
+    try:
+        client.get_collections()
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(
+            "Qdrant is not reachable at QDRANT_URL. Start the local Qdrant "
+            "service before running GW-07 live smoke."
+        )
+
+
+async def _assert_ollama_reachable(base_url: str) -> None:
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=5.0) as client:
+            response = await client.get("/api/tags")
+            response.raise_for_status()
+    except httpx.HTTPError as exc:
+        pytest.fail(
+            "Ollama is not reachable at OLLAMA_API_BASE. Start Ollama and pull "
+            "nomic-embed-text before running GW-07 live smoke."
+        )
+
+
+async def _assert_litellm_reachable(base_url: str, api_key: str) -> None:
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+            response = await client.get(
+                "/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in {401, 403}:
+            pytest.fail(
+                "LiteLLM authentication failed. QUIMERA_LLM_API_KEY must match "
+                "the local LITELLM_MASTER_KEY."
+            )
+        pytest.fail(
+            "LiteLLM /models returned an error. Verify the local gateway and "
+            "semantic aliases before running GW-07 live smoke."
+        )
+    except httpx.HTTPError:
+        pytest.fail(
+            "LiteLLM is not reachable at QUIMERA_LLM_BASE_URL. Start "
+            "infra/litellm/start_litellm.sh before running GW-07 live smoke."
+        )
+
+
+def _assert_local_url(url: str, variable_name: str) -> None:
+    if not (
+        url.startswith("http://127.0.0.1:")
+        or url.startswith("http://localhost:")
+        or url.startswith("http://[::1]:")
+    ):
+        pytest.fail(f"{variable_name} must point to a local-only HTTP URL.")
+
+
+def _delete_temp_collection(client: QdrantClient, collection_name: str) -> None:
+    if not collection_name.startswith(TEMP_COLLECTION_PREFIX):
+        raise ValueError(
+            f"refusing to delete collection without {TEMP_COLLECTION_PREFIX!r} prefix"
+        )
+    if client.collection_exists(collection_name):
+        client.delete_collection(collection_name)
+
+
+def _assert_embedding_metadata(payload: Mapping[str, Any]) -> None:
+    assert payload["source_type"] == "synthetic"
+    assert payload["embedding_provider"] == "ollama"
+    assert payload["embedding_model"] == "nomic-embed-text"
+    assert payload["embedding_dimensions"] == VECTOR_SIZE
+    assert payload["embedding_version"] == "local-ollama-current"
+    assert payload["embedding_contract"] == "openai_compatible_v1_embeddings"
+    assert payload["embedding_alias"] == "quimera_embed"
+    assert payload["embedding_backend"] == "direct_ollama_current"
+    assert str(payload["chunk_id"]).startswith(str(payload["doc_id"]))
+
+
+def _mentions_expected_concept(answer: str) -> bool:
+    normalized = answer.casefold()
+    return "liquidez" in normalized or "12" in normalized
+
+
+def _mentions_disallowed_real_market_example(answer: str) -> bool:
+    return DISALLOWED_MARKET_EXAMPLE_RE.search(answer) is not None

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -11,6 +11,7 @@ import yaml
 from loguru import logger
 
 from backend.gateway.client import (
+    COMPAT_LLM_EMBED_MODEL,
     DEFAULT_LLM_ALIAS_TIMEOUTS,
     DEFAULT_LLM_BASE_URL,
     DEFAULT_LLM_EMBED_MODEL,
@@ -85,6 +86,7 @@ class GatewayRuntimeConfigTests(unittest.TestCase):
                 DEFAULT_LLM_RAG_MODEL: 60.0,
                 DEFAULT_LLM_JSON_MODEL: 30.0,
                 DEFAULT_LLM_EMBED_MODEL: 30.0,
+                COMPAT_LLM_EMBED_MODEL: 30.0,
             },
         )
 

--- a/tests/unit/test_gateway_config.py
+++ b/tests/unit/test_gateway_config.py
@@ -204,11 +204,15 @@ class TestActualGatewayConfig(unittest.TestCase):
     def setUp(self) -> None:
         self.config = load_gateway_config(_YAML_PATH)
 
-    def test_all_five_required_aliases_present(self) -> None:
-        self.assertEqual(
+    def test_all_required_aliases_present(self) -> None:
+        self.assertTrue(
+            REQUIRED_ALIASES.issubset(self.config.alias_names),
+            "All required aliases must be defined in litellm_config.yaml",
+        )
+        self.assertIn(
+            "quimera_embed",
             self.config.alias_names,
-            REQUIRED_ALIASES,
-            "All five required aliases must be defined in litellm_config.yaml",
+            "quimera_embed must remain available as the canonical embedding alias",
         )
 
     def test_all_aliases_use_local_api_base(self) -> None:

--- a/tests/unit/test_litellm_infra_scripts.py
+++ b/tests/unit/test_litellm_infra_scripts.py
@@ -95,7 +95,14 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
 
         self.assertEqual(
             aliases,
-            {"local_chat", "local_think", "local_rag", "local_json", "local_embed"},
+            {
+                "local_chat",
+                "local_think",
+                "local_rag",
+                "local_json",
+                "quimera_embed",
+                "local_embed",
+            },
         )
         for item in model_list:
             params = item["litellm_params"]


### PR DESCRIPTION
## Summary

GW-07 proves the current safe Quimera/OpenClaw RAG path end to end using only synthetic data, local services, and a temporary Qdrant collection.

Target path:

```text
synthetic PT-BR docs
  -> chunking
  -> OllamaEmbedder direct at Ollama /api/embed
  -> Qdrant temporary collection
  -> Retriever / ContextPacker / PromptBuilder
  -> LocalGenerator / GatewayChatClient
  -> LiteLLM /v1/chat/completions
  -> Ollama / Qwen local
  -> cited answer
```

Closes #38.

## Scope

Included:

* Optional live GW-07 smoke guarded by `RUN_RAG_E2E_SMOKE=1`
* Dedicated temporary Qdrant collection prefix `gw07_synthetic_rag_`
* Unique collection per run using `gw07_synthetic_rag_{uuid4().hex[:8]}`
* Prefix-guarded cleanup in finally
* Cleanup warning with collection name if deletion fails
* Service preflight for Qdrant, Ollama and LiteLLM with clear `pytest.skip()` when unavailable
* Synthetic inline PT-BR corpus with 3 fictitious documents, including one >400 tokens
* Synthetic payload metadata loaded from `config/rag_config.yaml`
* Regex-based citation assertion and known synthetic concept assertion
* Script wrapper: `scripts/test_rag_e2e_gateway.sh`
* Runtime docs and sprint handoff updates with live latency results

Excluded:

* Production RAG embedding migration
* GatewayEmbedClient as default embedder
* Qdrant production collection changes
* Touching or reindexing `openclaw_knowledge`
* Real documents or real portfolio data
* Remote providers
* FastAPI
* MCP
* Quant tools
* Autoprogramming

## Cowork Review Considerations Addressed

* RC1: temporary collection generated per run, cleanup in finally, hard prefix guard before delete, logger.warning on cleanup failure, no assumption that Qdrant is empty.
* RC2: answer citation assertion uses regex; concept assertion checks a known synthetic corpus term; failure messages truncate answer output.
* RC3: embedding metadata is loaded from `config/rag_config.yaml`; payloads assert provider/model/dimensions/version/contract/alias/backend.
* RC4: Qdrant/Ollama/LiteLLM preflight skips clearly when a required local service is unavailable.
* RC5: corpus is inline, synthetic-only, has 3 documents, at least one >400 tokens, and multiple fictional concepts.
* RC6: script keeps local-only URL guards for `QUIMERA_LLM_BASE_URL`, `QDRANT_URL`, and `OLLAMA_API_BASE`.
* RC7: docs describe attempted cleanup, manual cleanup by prefix only, and confirm production embeddings remain direct via OllamaEmbedder.

## Live Result — Scenario A

Completed locally on 2026-04-30 after Cowork review fixes:

* `scripts/test_rag_e2e_gateway.sh`: PASSED
* `RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s`: PASSED
* Corpus: 3 synthetic PT-BR documents
* Generated chunks: 14
* Retrieved/used chunks: 5
* Generation alias: `local_rag`
* Embedding path: direct `OllamaEmbedder -> Ollama /api/embed`
* Generation path: `LocalGenerator/GatewayChatClient -> LiteLLM -> Ollama/Qwen`
* `openclaw_knowledge`: not touched

Observed latencies:

| Stage | Latency |
|---|---:|
| embedding/indexing | 178.1 ms |
| retrieval | 18.4 ms |
| generation | 3621.2 ms |
| total pipeline | 3639.6 ms |

## Validation

```bash
git diff --check
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
uv run python -m compileall backend tests scripts infra
scripts/test_rag_e2e_gateway.sh
RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v -s
```

Reported results:

* `uv run pytest -v`: 148 passed, 5 skipped
* `uv run mypy --strict .`: OK
* `uv run pyright`: OK
* `uv run pytest tests/smoke/ -v`: 5 passed, 5 skipped
* `uv run python -m compileall backend tests scripts infra`: OK
* `git diff --check`: OK

## Security

* No secrets committed
* `.env` untouched
* No remote providers enabled
* No real portfolio data or private documents
* No Authorization headers logged
* Temporary collection cleanup refuses to delete collections without the `gw07_synthetic_rag_` prefix
* Manual cleanup, if ever needed after interruption, must delete only collections matching `gw07_synthetic_rag_*`
* `openclaw_knowledge` is not used or touched

## Follow-up

Recommended next step: GW-08 should focus on RAG traceability / collection metadata enforcement or controlled embedding migration planning, but not both in one PR.
