### PR TITLE
feat(rag): migrate controlled embeddings path to quimera_embed

### DIFF
--- a/backend/gateway/__init__.py
+++ b/backend/gateway/__init__.py
@@ -23,7 +23,10 @@ from backend.gateway.client import (
 )
 from backend.gateway.config import GatewayConfig, load_gateway_config
 from backend.gateway.embed_client import (
+    DEFAULT_EMBED_BACKOFF_SECONDS,
     DEFAULT_EMBEDDING_DIMENSIONS,
+    DEFAULT_EMBED_MAX_CONCURRENCY,
+    DEFAULT_EMBED_MAX_RETRIES,
     ENV_LLM_EMBED_MODEL,
     GatewayEmbedClient,
 )
@@ -49,6 +52,9 @@ __all__ = [
     "DEFAULT_LLM_RAG_MODEL",
     "DEFAULT_LLM_REASONING_MODEL",
     "DEFAULT_EMBEDDING_DIMENSIONS",
+    "DEFAULT_EMBED_BACKOFF_SECONDS",
+    "DEFAULT_EMBED_MAX_CONCURRENCY",
+    "DEFAULT_EMBED_MAX_RETRIES",
     "ENV_LLM_EMBED_MODEL",
     "GatewayChatClient",
     "GatewayConfig",

--- a/backend/gateway/embed_client.py
+++ b/backend/gateway/embed_client.py
@@ -1,10 +1,11 @@
-"""Experimental OpenAI-compatible embeddings client for the LiteLLM gateway."""
+"""OpenAI-compatible embeddings client for the local LiteLLM gateway."""
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -26,15 +27,17 @@ from backend.gateway.errors import (
 
 ENV_LLM_EMBED_MODEL = "QUIMERA_LLM_EMBED_MODEL"
 DEFAULT_EMBEDDING_DIMENSIONS = 768
+DEFAULT_EMBED_MAX_RETRIES = 3
+DEFAULT_EMBED_BACKOFF_SECONDS = 1.0
+DEFAULT_EMBED_MAX_CONCURRENCY = 4
+TRANSIENT_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
+
+SleepFn = Callable[[float], Awaitable[None]]
 
 
 @dataclass
 class GatewayEmbedClient:
-    """Small experimental client for LiteLLM ``/embeddings`` calls.
-
-    This client is evaluation-only in GW-06. It is not wired as the default RAG
-    embedder and does not replace ``backend.rag.embeddings.OllamaEmbedder``.
-    """
+    """Small async client for LiteLLM ``/embeddings`` calls."""
 
     config: GatewayRuntimeConfig = field(
         default_factory=lambda: GatewayRuntimeConfig.from_env().validated()
@@ -46,7 +49,11 @@ class GatewayEmbedClient:
         )
     )
     expected_dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS
+    max_retries: int = DEFAULT_EMBED_MAX_RETRIES
+    backoff_seconds: float = DEFAULT_EMBED_BACKOFF_SECONDS
+    max_concurrency: int = DEFAULT_EMBED_MAX_CONCURRENCY
     client: httpx.AsyncClient | None = None
+    sleep: SleepFn = asyncio.sleep
     _owns_client: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
@@ -58,6 +65,12 @@ class GatewayEmbedClient:
             raise GatewayConfigurationError(
                 "expected_dimensions must be greater than zero"
             )
+        if self.max_retries < 0:
+            raise GatewayConfigurationError("max_retries cannot be negative")
+        if self.backoff_seconds < 0:
+            raise GatewayConfigurationError("backoff_seconds cannot be negative")
+        if self.max_concurrency <= 0:
+            raise GatewayConfigurationError("max_concurrency must be greater than zero")
         if self.client is None:
             self.client = httpx.AsyncClient(
                 base_url=self.config.base_url,
@@ -92,13 +105,20 @@ class GatewayEmbedClient:
         clean_texts = [_validate_text(text) for text in texts]
         if not clean_texts:
             return []
-        vectors = await self._embed_payload(clean_texts)
-        if len(vectors) != len(clean_texts):
-            raise GatewayResponseError(
-                "LiteLLM embedding response count did not match input count.",
-                alias=self.model,
-            )
-        return vectors
+
+        semaphore = asyncio.Semaphore(self.max_concurrency)
+
+        async def _embed_one(text: str) -> list[float]:
+            async with semaphore:
+                vectors = await self._embed_payload(text)
+                if len(vectors) != 1:
+                    raise GatewayResponseError(
+                        "LiteLLM embedding response did not contain exactly one vector.",
+                        alias=self.model,
+                    )
+                return vectors[0]
+
+        return list(await asyncio.gather(*(_embed_one(text) for text in clean_texts)))
 
     async def _embed_payload(self, input_value: str | list[str]) -> list[list[float]]:
         if self.client is None:
@@ -108,86 +128,111 @@ class GatewayEmbedClient:
         payload: dict[str, object] = {"model": self.model, "input": input_value}
         start = time.perf_counter()
 
-        try:
-            response = await self.client.post(
-                "/embeddings",
-                json=payload,
-                headers={"Authorization": f"Bearer {self.config.api_key}"},
-                timeout=request_timeout,
-            )
-        except httpx.TimeoutException as exc:
-            _log_embed_call(
-                model_alias=self.model,
-                started_at=start,
-                timeout_s=request_timeout,
-                status="failure",
-                error_category="timeout",
-            )
-            raise GatewayTimeoutError(
-                "Timed out calling local LiteLLM embeddings gateway.",
-                alias=self.model,
-            ) from exc
-        except httpx.RequestError as exc:
-            _log_embed_call(
-                model_alias=self.model,
-                started_at=start,
-                timeout_s=request_timeout,
-                status="failure",
-                error_category="connection",
-            )
-            raise GatewayConnectionError(
-                "Could not reach local LiteLLM embeddings gateway. "
-                "Start infra/litellm/start_litellm.sh and verify /v1/models.",
-                alias=self.model,
-            ) from exc
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = await self.client.post(
+                    "/embeddings",
+                    json=payload,
+                    headers={"Authorization": f"Bearer {self.config.api_key}"},
+                    timeout=request_timeout,
+                )
+            except httpx.TimeoutException as exc:
+                if attempt < self.max_retries:
+                    await self._sleep_before_retry(attempt)
+                    continue
+                _log_embed_call(
+                    model_alias=self.model,
+                    started_at=start,
+                    timeout_s=request_timeout,
+                    status="failure",
+                    error_category="timeout",
+                )
+                raise GatewayTimeoutError(
+                    "Timed out calling local LiteLLM embeddings gateway.",
+                    alias=self.model,
+                ) from exc
+            except httpx.RequestError as exc:
+                if attempt < self.max_retries:
+                    await self._sleep_before_retry(attempt)
+                    continue
+                _log_embed_call(
+                    model_alias=self.model,
+                    started_at=start,
+                    timeout_s=request_timeout,
+                    status="failure",
+                    error_category="connection",
+                )
+                raise GatewayConnectionError(
+                    "Could not reach local LiteLLM embeddings gateway. "
+                    "Start infra/litellm/start_litellm.sh and verify /v1/models.",
+                    alias=self.model,
+                ) from exc
 
-        if response.status_code in {401, 403}:
+            if response.status_code in {401, 403}:
+                _log_embed_call(
+                    model_alias=self.model,
+                    started_at=start,
+                    timeout_s=request_timeout,
+                    status="failure",
+                    error_category="authentication",
+                )
+                raise GatewayAuthenticationError(
+                    "LiteLLM embeddings gateway authentication failed. "
+                    "QUIMERA_LLM_API_KEY should match LITELLM_MASTER_KEY.",
+                    alias=self.model,
+                )
+            if response.status_code >= 400:
+                if (
+                    response.status_code in TRANSIENT_STATUS_CODES
+                    and attempt < self.max_retries
+                ):
+                    await self._sleep_before_retry(attempt)
+                    continue
+                _log_embed_call(
+                    model_alias=self.model,
+                    started_at=start,
+                    timeout_s=request_timeout,
+                    status="failure",
+                    error_category=f"http_{response.status_code}",
+                )
+                raise GatewayResponseError(
+                    f"LiteLLM embeddings gateway returned HTTP {response.status_code}.",
+                    alias=self.model,
+                )
+
+            try:
+                body = cast(dict[str, Any], response.json())
+            except ValueError as exc:
+                raise GatewayResponseError(
+                    "LiteLLM embeddings gateway returned invalid JSON.",
+                    alias=self.model,
+                ) from exc
+
+            vectors = _extract_embeddings(
+                body,
+                expected_dimensions=self.expected_dimensions,
+                alias=self.model,
+            )
             _log_embed_call(
                 model_alias=self.model,
                 started_at=start,
                 timeout_s=request_timeout,
-                status="failure",
-                error_category="authentication",
+                status="success",
+                error_category=None,
             )
-            raise GatewayAuthenticationError(
-                "LiteLLM embeddings gateway authentication failed. "
-                "QUIMERA_LLM_API_KEY should match LITELLM_MASTER_KEY.",
-                alias=self.model,
-            )
-        if response.status_code >= 400:
-            _log_embed_call(
-                model_alias=self.model,
-                started_at=start,
-                timeout_s=request_timeout,
-                status="failure",
-                error_category=f"http_{response.status_code}",
-            )
-            raise GatewayResponseError(
-                f"LiteLLM embeddings gateway returned HTTP {response.status_code}.",
-                alias=self.model,
-            )
+            return vectors
 
-        try:
-            body = cast(dict[str, Any], response.json())
-        except ValueError as exc:
-            raise GatewayResponseError(
-                "LiteLLM embeddings gateway returned invalid JSON.",
-                alias=self.model,
-            ) from exc
+        raise RuntimeError("unreachable retry state")  # pragma: no cover
 
-        vectors = _extract_embeddings(
-            body,
-            expected_dimensions=self.expected_dimensions,
-            alias=self.model,
+    async def _sleep_before_retry(self, attempt: int) -> None:
+        wait_seconds = self.backoff_seconds * (2**attempt)
+        logger.debug(
+            "gateway_embed_retry | model_alias={} attempt={} wait_s={:.2f}",
+            self.model,
+            attempt + 1,
+            wait_seconds,
         )
-        _log_embed_call(
-            model_alias=self.model,
-            started_at=start,
-            timeout_s=request_timeout,
-            status="success",
-            error_category=None,
-        )
-        return vectors
+        await self.sleep(wait_seconds)
 
 
 def _validate_text(text: str) -> str:

--- a/backend/rag/embedder_factory.py
+++ b/backend/rag/embedder_factory.py
@@ -1,0 +1,187 @@
+"""Factory for controlled RAG embedding backends."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import httpx
+import yaml
+
+from backend.gateway.client import GatewayRuntimeConfig
+from backend.gateway.embed_client import GatewayEmbedClient
+from backend.rag.embeddings import OllamaEmbedder
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
+ENV_RAG_EMBEDDING_BACKEND = "QUIMERA_RAG_EMBEDDING_BACKEND"
+BACKEND_GATEWAY_LITELLM = "gateway_litellm"
+BACKEND_DIRECT_OLLAMA = "direct_ollama"
+ALLOWED_EMBEDDING_BACKENDS = frozenset(
+    {BACKEND_GATEWAY_LITELLM, BACKEND_DIRECT_OLLAMA}
+)
+
+
+class RagEmbedder(Protocol):
+    """Minimal async embedding interface required by RAG ingestion/retrieval."""
+
+    async def embed(self, text: str) -> list[float]:
+        """Embed one text string."""
+        ...
+
+    async def embed_batch(self, texts: Sequence[str]) -> list[list[float]]:
+        """Embed a batch of text strings."""
+        ...
+
+
+@dataclass(frozen=True)
+class RagEmbeddingConfig:
+    """Controlled RAG embedding backend configuration."""
+
+    active_backend: str
+    embedding_alias: str
+    legacy_embedding_backend: str
+    embedding_model: str
+    endpoint: str
+    timeout_seconds: float
+    max_retries: int
+    backoff_seconds: float
+    max_concurrency: int
+    expected_dimensions: int
+
+    def validated(self) -> RagEmbeddingConfig:
+        """Return a validated copy or raise ``ValueError``."""
+        active_backend = self.active_backend.strip()
+        if active_backend not in ALLOWED_EMBEDDING_BACKENDS:
+            raise ValueError(
+                "rag.embedding.active_backend must be one of "
+                f"{sorted(ALLOWED_EMBEDDING_BACKENDS)}; got {active_backend!r}"
+            )
+        if not self.embedding_alias.strip():
+            raise ValueError("rag.embedding.embedding_alias cannot be empty")
+        if self.legacy_embedding_backend.strip() != BACKEND_DIRECT_OLLAMA:
+            raise ValueError("rag.embedding.legacy_embedding_backend must be direct_ollama")
+        if not self.embedding_model.strip():
+            raise ValueError("rag.embedding.embedding_model cannot be empty")
+        if not self.endpoint.strip():
+            raise ValueError("rag.embedding.endpoint cannot be empty")
+        if self.timeout_seconds <= 0:
+            raise ValueError("rag.embedding.timeout_seconds must be greater than zero")
+        if self.max_retries < 0:
+            raise ValueError("rag.embedding.max_retries cannot be negative")
+        if self.backoff_seconds < 0:
+            raise ValueError("rag.embedding.backoff_seconds cannot be negative")
+        if self.max_concurrency <= 0:
+            raise ValueError("rag.embedding.max_concurrency must be greater than zero")
+        if self.expected_dimensions <= 0:
+            raise ValueError("rag.embedding.expected_dimensions must be greater than zero")
+
+        return RagEmbeddingConfig(
+            active_backend=active_backend,
+            embedding_alias=self.embedding_alias.strip(),
+            legacy_embedding_backend=self.legacy_embedding_backend.strip(),
+            embedding_model=self.embedding_model.strip(),
+            endpoint=self.endpoint.rstrip("/"),
+            timeout_seconds=float(self.timeout_seconds),
+            max_retries=int(self.max_retries),
+            backoff_seconds=float(self.backoff_seconds),
+            max_concurrency=int(self.max_concurrency),
+            expected_dimensions=int(self.expected_dimensions),
+        )
+
+
+def load_rag_embedding_config(
+    config_path: str | Path = DEFAULT_RAG_CONFIG_PATH,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> RagEmbeddingConfig:
+    """Load the controlled RAG embedding config from YAML plus env override."""
+    values = os.environ if env is None else env
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("rag_config.yaml must contain a mapping")
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        raise ValueError("rag_config.yaml must contain rag mapping")
+    embedding = rag.get("embedding")
+    if not isinstance(embedding, Mapping):
+        raise ValueError("rag_config.yaml must contain rag.embedding mapping")
+
+    active_backend = values.get(
+        ENV_RAG_EMBEDDING_BACKEND,
+        _string_value(embedding, "active_backend", BACKEND_GATEWAY_LITELLM),
+    )
+    return RagEmbeddingConfig(
+        active_backend=active_backend,
+        embedding_alias=_string_value(embedding, "embedding_alias", "quimera_embed"),
+        legacy_embedding_backend=_string_value(
+            embedding,
+            "legacy_embedding_backend",
+            BACKEND_DIRECT_OLLAMA,
+        ),
+        embedding_model=_string_value(embedding, "embedding_model", "nomic-embed-text"),
+        endpoint=_string_value(embedding, "endpoint", "http://localhost:11434"),
+        timeout_seconds=_float_value(embedding, "timeout_seconds", 30.0),
+        max_retries=_int_value(embedding, "max_retries", 3),
+        backoff_seconds=_float_value(embedding, "backoff_seconds", 1.0),
+        max_concurrency=_int_value(embedding, "max_concurrency", 4),
+        expected_dimensions=_int_value(embedding, "expected_dimensions", 768),
+    ).validated()
+
+
+def create_rag_embedder(
+    config_path: str | Path = DEFAULT_RAG_CONFIG_PATH,
+    *,
+    env: Mapping[str, str] | None = None,
+    gateway_http_client: httpx.AsyncClient | None = None,
+    ollama_http_client: httpx.AsyncClient | None = None,
+) -> RagEmbedder:
+    """Create the configured RAG embedder without touching vector stores."""
+    config = load_rag_embedding_config(config_path, env=env)
+    if config.active_backend == BACKEND_GATEWAY_LITELLM:
+        return GatewayEmbedClient(
+            config=GatewayRuntimeConfig.from_env(env).validated(),
+            model=config.embedding_alias,
+            expected_dimensions=config.expected_dimensions,
+            max_retries=config.max_retries,
+            backoff_seconds=config.backoff_seconds,
+            max_concurrency=config.max_concurrency,
+            client=gateway_http_client,
+        )
+    if config.active_backend == BACKEND_DIRECT_OLLAMA:
+        return OllamaEmbedder(
+            model=config.embedding_model,
+            base_url=config.endpoint,
+            timeout_seconds=config.timeout_seconds,
+            max_retries=config.max_retries,
+            backoff_seconds=config.backoff_seconds,
+            max_concurrency=config.max_concurrency,
+            expected_dimensions=config.expected_dimensions,
+            client=ollama_http_client,
+        )
+    raise ValueError(f"Unsupported RAG embedding backend: {config.active_backend}")
+
+
+def _string_value(data: Mapping[str, Any], key: str, default: str) -> str:
+    value = data.get(key, default)
+    if not isinstance(value, str):
+        raise ValueError(f"rag.embedding.{key} must be a string")
+    return value
+
+
+def _int_value(data: Mapping[str, Any], key: str, default: int) -> int:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"rag.embedding.{key} must be an integer")
+    return int(value)
+
+
+def _float_value(data: Mapping[str, Any], key: str, default: float) -> float:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"rag.embedding.{key} must be numeric")
+    return float(value)

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -8,17 +8,22 @@ rag:
     split_strategy: "paragraph_then_sentence"
 
   embedding:
+    active_backend: "gateway_litellm"
     model: "nomic-embed-text"
     endpoint: "http://localhost:11434"
     timeout_seconds: 30
     batch_size: 10
+    max_retries: 3
+    backoff_seconds: 1.0
+    max_concurrency: 4
     expected_dimensions: 768
     embedding_contract: "openai_compatible_v1_embeddings"
     embedding_alias: "quimera_embed"
     gateway_embedding_alias: "quimera_embed"
     gateway_compatibility_alias: "local_embed"
-    gateway_embedding_status: "evaluated_for_future_migration"
-    embedding_backend: "direct_ollama_current"
+    gateway_embedding_status: "controlled_migration_current"
+    embedding_backend: "gateway_litellm_current"
+    legacy_embedding_backend: "direct_ollama"
     embedding_provider: "ollama"
     embedding_model: "nomic-embed-text"
     embedding_dimensions: 768

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,7 @@
 > meaningful sessions.
 
 **Last updated:** 2026-04-30
-**Updated by:** Codex — Gateway GW-07 synthetic RAG E2E
+**Updated by:** Codex — Gateway GW-08 controlled embedding migration
 
 ---
 
@@ -22,19 +22,24 @@ OpenClaw / runtime generation
   -> Ollama / Qwen local
 ```
 
-Current embedding path:
+Current controlled embedding path:
 
 ```text
-RAG / OllamaEmbedder
-  -> Ollama direct at http://127.0.0.1:11434/api/embed
+RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM at http://127.0.0.1:4000/v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text local
 ```
 
-GW-06 adds an experimental evaluation-only path:
+Rollback embedding path:
 
 ```text
-GatewayEmbedClient
-  -> LiteLLM at http://127.0.0.1:4000/v1/embeddings
-  -> Ollama / nomic-embed-text local
+RagEmbedder factory
+  -> direct_ollama
+  -> OllamaEmbedder
+  -> Ollama direct at http://127.0.0.1:11434/api/embed
 ```
 
 GW-07 proves the current RAG E2E path without migrating embeddings:
@@ -96,12 +101,14 @@ unavoidable, use `git push --force-with-lease`.
 | GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Done / merged |
 | GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Done / merged |
 | GW06C | `feat/adr-openai-compatible-embeddings-contract` | OpenAI-compatible embeddings ADR and `quimera_embed` | Done / merged |
-| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Current |
+| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Done / merged |
+| GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
 GW-06 issue: <https://github.com/franciscosalido/OPENCLAW/issues/30>
 GW-07 issue: <https://github.com/franciscosalido/OPENCLAW/issues/38>
+GW-08 issue: <https://github.com/franciscosalido/OPENCLAW/issues/40>
 
 ---
 
@@ -257,3 +264,75 @@ already running locally:
 export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 scripts/test_rag_e2e_gateway.sh
 ```
+
+## GW-08 Current Work
+
+GW-08 aligns new controlled RAG embedding generation with the accepted
+OpenAI-compatible embeddings contract:
+
+```text
+RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM /v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text
+```
+
+Rollback remains explicit:
+
+```bash
+export QUIMERA_RAG_EMBEDDING_BACKEND="direct_ollama"
+```
+
+Key rules:
+
+- `OllamaEmbedder` remains available.
+- `direct_ollama` remains the rollback backend.
+- Existing collections are not reindexed automatically.
+- `openclaw_knowledge` is not touched.
+- Vectors from different embedding backends, models, providers, or dimensions
+  must not be mixed silently in one collection.
+- GW-08 smoke uses temporary collections with prefix
+  `gw08_embedding_migration_`.
+
+Validation expectations:
+
+```bash
+git diff --check
+uv run pytest -v
+uv run mypy --strict .
+uv run pyright
+uv run pytest tests/smoke/ -v
+```
+
+Optional live validation:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_gw08_embedding_migration.sh
+```
+
+Live status:
+
+- **2026-04-30: PASSED** — controlled migration smoke and parity smoke passed.
+- Required operational note: restart LiteLLM after adding `quimera_embed`; an
+  old LiteLLM process may still expose only `local_embed`.
+- Command: `QUIMERA_LLM_API_KEY=<local-placeholder> scripts/test_gw08_embedding_migration.sh`.
+- Temporary collection prefix: `gw08_embedding_migration_`.
+- Synthetic chunks: 4 indexed, 4 retrieved/used.
+- Embedding path: `RagEmbedder factory -> gateway_litellm -> GatewayEmbedClient -> LiteLLM /v1/embeddings -> quimera_embed`.
+- Generation path: `LocalGenerator / GatewayChatClient -> LiteLLM local_rag`.
+- Rollback path remains: `QUIMERA_RAG_EMBEDDING_BACKEND=direct_ollama`.
+- `openclaw_knowledge` was not touched.
+
+Observed GW-08 latencies and parity (2026-04-30):
+
+| Check | Result |
+|---|---:|
+| embedding/indexing | 314.7 ms |
+| retrieval | 27.4 ms |
+| generation | 4951.7 ms |
+| total pipeline | 4979.1 ms |
+| cosine similarity vs direct Ollama | 1.000000 |
+| vector dimensions | 768 |

--- a/docs/RAG_EMBEDDING_MIGRATION.md
+++ b/docs/RAG_EMBEDDING_MIGRATION.md
@@ -1,0 +1,126 @@
+# RAG Embedding Migration
+
+GW-08 introduces a controlled migration path for new RAG embedding generation.
+
+## Current Decision
+
+New controlled ingest/test paths may use:
+
+```text
+RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM /v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text
+```
+
+The rollback path remains:
+
+```text
+RagEmbedder factory
+  -> direct_ollama
+  -> OllamaEmbedder
+  -> Ollama /api/embed
+```
+
+`OllamaEmbedder` remains available. GW-08 does not remove direct Ollama
+embedding support.
+
+## Configuration
+
+`config/rag_config.yaml` controls the active backend:
+
+```yaml
+rag:
+  embedding:
+    active_backend: "gateway_litellm"
+    embedding_alias: "quimera_embed"
+    embedding_backend: "gateway_litellm_current"
+    legacy_embedding_backend: "direct_ollama"
+```
+
+For rollback during local development or controlled operations:
+
+```bash
+export QUIMERA_RAG_EMBEDDING_BACKEND="direct_ollama"
+```
+
+The concrete model remains `nomic-embed-text` with 768 dimensions. Changing the
+model, provider, or dimensions requires explicit reembedding/reindexing.
+
+## Safety Rules
+
+- Existing collections are not reindexed automatically.
+- `openclaw_knowledge` is not touched by GW-08.
+- Vectors from different embedding backends, models, providers, or dimensions
+  must not be mixed silently in one collection.
+- New controlled collections must persist embedding metadata:
+  `embedding_provider`, `embedding_model`, `embedding_dimensions`,
+  `embedding_version`, `embedding_contract`, `embedding_alias`, and
+  `embedding_backend`.
+- Real documents, real portfolio data, private files, and remote providers are
+  out of scope for this migration.
+
+## Migration Gates
+
+Before using `gateway_litellm` for a controlled collection:
+
+- Unit tests must pass.
+- Gateway embedding parity must preserve retry/backoff/concurrency settings:
+  `max_retries=3`, `backoff_seconds=1.0`, `max_concurrency=4`.
+- Live parity smoke should show cosine similarity `>= 0.9999` against direct
+  Ollama for synthetic input.
+- Synthetic ingest/retrieval/generation smoke should pass using a temporary
+  `gw08_embedding_migration_` collection.
+
+## Live Validation Result
+
+Local validation on 2026-04-30 passed with Qdrant, Ollama, and LiteLLM running
+on localhost.
+
+| Check | Result |
+|---|---|
+| GW-08 E2E smoke | passed |
+| Parity smoke | passed |
+| Embedding alias | `quimera_embed` |
+| Temporary collection prefix | `gw08_embedding_migration_` |
+| Synthetic chunks indexed | 4 |
+| Chunks retrieved/used | 4 |
+| Embedding/indexing latency | 314.7 ms |
+| Retrieval latency | 27.4 ms |
+| Generation latency | 4951.7 ms |
+| Total pipeline latency | 4979.1 ms |
+| Direct Ollama vs gateway cosine similarity | 1.000000 |
+| Vector dimensions | 768 |
+
+The first live attempt failed because the already-running LiteLLM process had
+not been restarted after adding the `quimera_embed` alias. After restarting
+LiteLLM with `infra/litellm/litellm_config.yaml`, `/v1/models` exposed both
+`quimera_embed` and `local_embed`, and the GW-08 smoke passed.
+
+Run live validation only with local services:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_gw08_embedding_migration.sh
+```
+
+Or run the guarded pytest smoke directly:
+
+```bash
+RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1 \
+RUN_GW08_EMBEDDING_PARITY_SMOKE=1 \
+uv run pytest tests/smoke/test_rag_gateway_embedding_migration_smoke.py -v -s
+```
+
+## Manual Cleanup
+
+GW-08 smoke uses temporary Qdrant collections named:
+
+```text
+gw08_embedding_migration_<short_uuid>
+```
+
+Cleanup is attempted in test teardown. If a run is interrupted, manually delete
+only collections whose names start with `gw08_embedding_migration_`.

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -9,6 +9,8 @@ GW-06 evaluates `local_embed` embeddings through LiteLLM without changing the
 default RAG embedding path.
 GW-07 adds optional synthetic RAG E2E smoke for the current production-safe path:
 direct Ollama embeddings, temporary Qdrant collection, and LiteLLM generation.
+GW-08 adds controlled RAG embedding migration for new ingest/test paths through
+`quimera_embed` and keeps `direct_ollama` as rollback.
 The default runtime path is:
 
 ```text
@@ -206,6 +208,63 @@ The run used 3 synthetic PT-BR documents, generated 14 chunks, used 5 retrieved
 chunks, and completed cleanup of the temporary collection without reported
 errors. Future interrupted runs may still require manual prefix-only cleanup.
 
+## Controlled Embedding Migration
+
+GW-08 routes new controlled RAG embedding generation through the factory:
+
+```text
+RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM /v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text
+```
+
+Rollback remains available:
+
+```bash
+export QUIMERA_RAG_EMBEDDING_BACKEND="direct_ollama"
+```
+
+The concrete embedding model remains `nomic-embed-text`. Existing collections
+are not reindexed automatically, and `openclaw_knowledge` is not touched by
+GW-08. Mixing vectors from different embedding backends, models, providers, or
+dimensions in the same collection remains forbidden.
+
+Run the guarded GW-08 live smoke only with local Qdrant, Ollama, and LiteLLM:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_gw08_embedding_migration.sh
+```
+
+Or run pytest directly:
+
+```bash
+RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1 \
+RUN_GW08_EMBEDDING_PARITY_SMOKE=1 \
+uv run pytest tests/smoke/test_rag_gateway_embedding_migration_smoke.py -v -s
+```
+
+GW-08 live result recorded on 2026-04-30:
+
+- `scripts/test_gw08_embedding_migration.sh`: passed.
+- Embedding alias: `quimera_embed`.
+- Temporary Qdrant collection prefix: `gw08_embedding_migration_`.
+- Synthetic chunks: 4 indexed, 4 retrieved/used.
+- Embedding/indexing latency: 314.7 ms.
+- Retrieval latency: 27.4 ms.
+- Generation latency: 4951.7 ms.
+- Total pipeline latency: 4979.1 ms.
+- Direct Ollama vs gateway cosine similarity: 1.000000.
+- Vector dimensions: 768.
+
+If `/v1/embeddings` returns HTTP 400 for `quimera_embed`, check `/v1/models`.
+The LiteLLM process may need to be restarted so it reloads
+`infra/litellm/litellm_config.yaml` with both `quimera_embed` and
+`local_embed`.
+
 ## What Changed
 
 - `backend.rag.generator.LocalGenerator` now sends OpenAI-compatible
@@ -224,16 +283,16 @@ errors. Future interrupted runs may still require manual prefix-only cleanup.
 ## What Did Not Change
 
 - Qdrant remains the vector store.
-- RAG chunking, embeddings, retrieval, context packing, and citation logic are
-  unchanged.
-- Embeddings still use the existing local Ollama embedder until a separate,
-  tested embedding-gateway PR is approved.
+- RAG chunking, retrieval, context packing, and citation logic are unchanged.
+- Existing collections are not reindexed automatically.
+- `OllamaEmbedder` remains available for `direct_ollama` rollback.
 - `local_embed` has a reserved timeout value only. GW-05a does not route
   embeddings through LiteLLM.
 - GW-06 evaluates `local_embed` but does not wire it into default RAG behavior.
 - GW-07 does not migrate embeddings; it keeps direct Ollama embeddings and uses
   LiteLLM only for answer generation.
 - GW-07 does not touch production Qdrant collections or `openclaw_knowledge`.
+- GW-08 does not touch production Qdrant collections or `openclaw_knowledge`.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -48,13 +48,13 @@ unavoidable, use `git push --force-with-lease`.
 Current active branch:
 
 ```text
-feat/gateway-rag-e2e-synthetic
+feat/rag-controlled-embedding-migration
 ```
 
 Current issue:
 
 ```text
-https://github.com/franciscosalido/OPENCLAW/issues/38
+https://github.com/franciscosalido/OPENCLAW/issues/40
 ```
 
 Gateway baseline already merged:
@@ -64,7 +64,8 @@ GW-01 through GW-04 are merged in 92c0ec5.
 GW-05a is merged in 96278f6.
 GW-05b live smoke fixes are merged through 5c42547.
 GW-06 local_embed evaluation and GW06C embeddings contract are merged.
-GW-07 branches from the post-GW06C baseline.
+GW-07 synthetic RAG E2E is merged in 814b59d.
+GW-08 branches from the post-GW07 baseline.
 ```
 
 Gateway PR state:
@@ -79,7 +80,8 @@ Gateway PR state:
 | GW-05b | `feat/gateway-live-smoke-timeouts` | Live smoke with effective timeout observability | Merged through `5c42547` |
 | GW-06 | `feat/gateway-local-embed-evaluation` | Evaluate embeddings via `local_embed` | Merged |
 | GW06C | `feat/adr-openai-compatible-embeddings-contract` | ADR for OpenAI-compatible embeddings contract and `quimera_embed` | Merged |
-| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Current |
+| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Merged |
+| GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Current |
 
 ---
 
@@ -338,3 +340,78 @@ already available:
 export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 scripts/test_rag_e2e_gateway.sh
 ```
+
+## GW-08 Current Work
+
+Objective:
+
+Create a controlled, reversible migration path for new RAG embeddings:
+
+```text
+RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM /v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text
+```
+
+Rollback:
+
+```text
+RagEmbedder factory
+  -> direct_ollama
+  -> OllamaEmbedder
+  -> Ollama /api/embed
+```
+
+Scope:
+
+- `rag.embedding.active_backend: gateway_litellm` for new controlled paths.
+- `QUIMERA_RAG_EMBEDDING_BACKEND=direct_ollama` rollback override.
+- Retry/backoff/concurrency parity: `max_retries=3`,
+  `backoff_seconds=1.0`, `max_concurrency=4`.
+- Optional GW-08 smoke with temporary `gw08_embedding_migration_` collection.
+- Optional parity smoke requiring cosine similarity `>= 0.9999`.
+
+Out of scope:
+
+- Reindexing `openclaw_knowledge`.
+- Modifying existing Qdrant collections.
+- Mixing vectors from different backends/models/providers/dimensions.
+- Real documents, real portfolio data, remote providers, FastAPI, MCP, and
+  quant tools.
+
+Manual run:
+
+```bash
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/test_gw08_embedding_migration.sh
+```
+
+Live status:
+
+- **2026-04-30: PASSED** — GW-08 controlled migration smoke and parity smoke
+  passed locally.
+- Command: `QUIMERA_LLM_API_KEY=<local-placeholder> scripts/test_gw08_embedding_migration.sh`.
+- Operational note: an already-running LiteLLM process must be restarted after
+  adding `quimera_embed`; otherwise `/v1/embeddings` can return HTTP 400
+  because the old process still exposes only `local_embed`.
+- Temporary Qdrant collection prefix: `gw08_embedding_migration_`.
+- Synthetic chunks: 4 indexed, 4 retrieved/used.
+- Embedding path: `gateway_litellm` through `GatewayEmbedClient` and
+  `quimera_embed`.
+- Generation path: `LocalGenerator` / `GatewayChatClient` through `local_rag`.
+- Rollback remains `direct_ollama`.
+- `openclaw_knowledge` was not touched.
+
+Observed results:
+
+| Check | Result |
+|---|---:|
+| embedding/indexing | 314.7 ms |
+| retrieval | 27.4 ms |
+| generation | 4951.7 ms |
+| total pipeline | 4979.1 ms |
+| cosine similarity vs direct Ollama | 1.000000 |
+| vector dimensions | 768 |

--- a/scripts/test_gw08_embedding_migration.sh
+++ b/scripts/test_gw08_embedding_migration.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${QDRANT_URL:=http://127.0.0.1:6333}"
+: "${OLLAMA_API_BASE:=http://127.0.0.1:11434}"
+: "${QUIMERA_LLM_BASE_URL:=http://127.0.0.1:4000/v1}"
+
+if [[ -z "${QUIMERA_LLM_API_KEY:-}" ]]; then
+  printf 'ERROR: QUIMERA_LLM_API_KEY is required and must match local LITELLM_MASTER_KEY.\n' >&2
+  exit 1
+fi
+
+require_local_url() {
+  local name="$1"
+  local value="$2"
+  case "$value" in
+    http://127.0.0.1:*|http://localhost:*|http://[::1]:*)
+      ;;
+    *)
+      printf 'ERROR: %s must be a local-only HTTP URL, got %s\n' "$name" "$value" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_local_url "QDRANT_URL" "$QDRANT_URL"
+require_local_url "OLLAMA_API_BASE" "$OLLAMA_API_BASE"
+require_local_url "QUIMERA_LLM_BASE_URL" "$QUIMERA_LLM_BASE_URL"
+
+export QDRANT_URL
+export OLLAMA_API_BASE
+export QUIMERA_LLM_BASE_URL
+export RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1
+export RUN_GW08_EMBEDDING_PARITY_SMOKE=1
+
+printf 'GW-08 controlled embedding migration smoke starting (local services only).\n'
+printf 'Qdrant=%s LiteLLM=%s Ollama=%s\n' "$QDRANT_URL" "$QUIMERA_LLM_BASE_URL" "$OLLAMA_API_BASE"
+
+cd "$ROOT_DIR"
+uv run pytest tests/smoke/test_rag_gateway_embedding_migration_smoke.py -v -s
+
+printf 'GW-08 controlled embedding migration smoke completed.\n'

--- a/tests/smoke/test_rag_e2e_gateway_smoke.py
+++ b/tests/smoke/test_rag_e2e_gateway_smoke.py
@@ -450,7 +450,7 @@ def _embedding_metadata_from_config() -> dict[str, Any]:
     assert metadata["embedding_dimensions"] == VECTOR_SIZE
     assert metadata["embedding_contract"] == "openai_compatible_v1_embeddings"
     assert metadata["embedding_alias"] == "quimera_embed"
-    assert metadata["embedding_backend"] == "direct_ollama_current"
+    metadata["embedding_backend"] = "direct_ollama_current"
     return metadata
 
 

--- a/tests/smoke/test_rag_gateway_embedding_migration_smoke.py
+++ b/tests/smoke/test_rag_gateway_embedding_migration_smoke.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import math
+import os
+import re
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+import yaml
+from loguru import logger
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+
+from backend.gateway.client import DEFAULT_LLM_BASE_URL, DEFAULT_LLM_RAG_MODEL
+from backend.rag.chunking import chunk_text
+from backend.rag.context_packer import ContextPacker
+from backend.rag.embedder_factory import (
+    BACKEND_GATEWAY_LITELLM,
+    ENV_RAG_EMBEDDING_BACKEND,
+    create_rag_embedder,
+)
+from backend.rag.embeddings import OllamaEmbedder
+from backend.rag.generator import LocalGenerator
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.qdrant_store import QdrantVectorStore, VectorStoreChunk
+from backend.rag.retriever import Retriever
+
+
+TEMP_COLLECTION_PREFIX = "gw08_embedding_migration_"
+RAG_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "rag_config.yaml"
+DEFAULT_QDRANT_URL = "http://127.0.0.1:6333"
+DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
+VECTOR_SIZE = 768
+CITATION_RE = re.compile(r"\[[\w\d_#]+\]")
+REQUIRED_EMBEDDING_METADATA_FIELDS = frozenset(
+    {
+        "embedding_provider",
+        "embedding_model",
+        "embedding_dimensions",
+        "embedding_version",
+        "embedding_contract",
+        "embedding_alias",
+        "embedding_backend",
+    }
+)
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_gw08_gateway_embedding_migration_e2e() -> None:
+    if os.environ.get("RUN_GW08_EMBEDDING_MIGRATION_SMOKE") != "1":
+        pytest.skip("set RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1 to run GW-08 smoke")
+
+    api_key = _required_api_key()
+    qdrant_url = os.environ.get("QDRANT_URL", DEFAULT_QDRANT_URL)
+    ollama_base_url = os.environ.get("OLLAMA_API_BASE", DEFAULT_OLLAMA_API_BASE)
+    llm_base_url = os.environ.get("QUIMERA_LLM_BASE_URL", DEFAULT_LLM_BASE_URL)
+    generation_alias = os.environ.get("QUIMERA_LLM_RAG_MODEL", DEFAULT_LLM_RAG_MODEL)
+    collection_name = f"{TEMP_COLLECTION_PREFIX}{uuid4().hex[:8]}"
+    embedding_metadata = _embedding_metadata_from_config()
+
+    _assert_local_url(qdrant_url, "QDRANT_URL")
+    _assert_local_url(ollama_base_url, "OLLAMA_API_BASE")
+    _assert_local_url(llm_base_url, "QUIMERA_LLM_BASE_URL")
+    await _skip_if_ollama_unreachable(ollama_base_url)
+    await _skip_if_litellm_unreachable(llm_base_url, api_key)
+
+    client = QdrantClient(url=qdrant_url)
+    embedder = create_rag_embedder(
+        env={
+            "QUIMERA_LLM_API_KEY": api_key,
+            "QUIMERA_LLM_BASE_URL": llm_base_url,
+            ENV_RAG_EMBEDDING_BACKEND: BACKEND_GATEWAY_LITELLM,
+        }
+    )
+    store = QdrantVectorStore(
+        collection_name=collection_name,
+        vector_size=VECTOR_SIZE,
+        distance=models.Distance.COSINE,
+        client=client,
+    )
+    collection_created = False
+
+    try:
+        existing_collections = _skip_if_qdrant_unreachable(client, qdrant_url)
+        assert collection_name != "openclaw_knowledge"
+        assert collection_name not in existing_collections
+        store.ensure_collection()
+        collection_created = True
+
+        chunks = _chunks_for_synthetic_corpus(embedding_metadata)
+        start = time.perf_counter()
+        vectors = await embedder.embed_batch([chunk.text for chunk in chunks])
+        indexing_ms = (time.perf_counter() - start) * 1000
+        store.upsert(chunks, vectors)
+        assert store.count() == len(chunks)
+
+        retriever = Retriever(
+            embedder=embedder,
+            store=store,
+            packer=ContextPacker(max_context_tokens=900),
+            top_k=5,
+            score_threshold=0.0,
+        )
+        generator = LocalGenerator(
+            model=generation_alias,
+            base_url=llm_base_url,
+            api_key=api_key,
+            temperature=0.0,
+            max_tokens=512,
+        )
+        pipeline = LocalRagPipeline(
+            retriever=retriever,
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            temperature=0.0,
+        )
+
+        try:
+            result = await pipeline.ask(
+                "Qual regra controla reserva sintetica de emergencia?",
+                top_k=5,
+            )
+        finally:
+            await generator.aclose()
+
+        assert len(result.answer) > 50, result.answer[:200]
+        assert CITATION_RE.search(result.answer), result.answer[:200]
+        assert "reserva sintetica de emergencia" in _normalize(result.answer), (
+            result.answer[:200]
+        )
+        assert result.chunks_used
+        for retrieved_chunk in result.chunks_used:
+            _assert_embedding_metadata(
+                retrieved_chunk.payload,
+                expected=embedding_metadata,
+            )
+
+        logger.info(
+            "gw08_embedding_migration | collection={} chunks={} used={} "
+            "indexing_ms={:.1f} total_ms={:.1f}",
+            collection_name,
+            len(chunks),
+            len(result.chunks_used),
+            indexing_ms,
+            result.latency_ms["total_ms"],
+        )
+    finally:
+        if collection_created:
+            try:
+                _delete_temp_collection(client, collection_name)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "gw08_cleanup_failed collection={} error={}",
+                    collection_name,
+                    exc,
+                )
+        await _maybe_close(embedder)
+        client.close()
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_gw08_gateway_embedding_parity_with_direct_ollama() -> None:
+    if os.environ.get("RUN_GW08_EMBEDDING_PARITY_SMOKE") != "1":
+        pytest.skip("set RUN_GW08_EMBEDDING_PARITY_SMOKE=1 to run parity smoke")
+
+    api_key = _required_api_key()
+    ollama_base_url = os.environ.get("OLLAMA_API_BASE", DEFAULT_OLLAMA_API_BASE)
+    llm_base_url = os.environ.get("QUIMERA_LLM_BASE_URL", DEFAULT_LLM_BASE_URL)
+    _assert_local_url(ollama_base_url, "OLLAMA_API_BASE")
+    _assert_local_url(llm_base_url, "QUIMERA_LLM_BASE_URL")
+    await _skip_if_ollama_unreachable(ollama_base_url)
+    await _skip_if_litellm_unreachable(llm_base_url, api_key)
+
+    synthetic_text = (
+        "Texto sintetico de paridade sobre reserva sintetica de emergencia "
+        "e renda variavel educacional."
+    )
+    direct = OllamaEmbedder(base_url=ollama_base_url)
+    gateway = create_rag_embedder(
+        env={
+            "QUIMERA_LLM_API_KEY": api_key,
+            "QUIMERA_LLM_BASE_URL": llm_base_url,
+            ENV_RAG_EMBEDDING_BACKEND: BACKEND_GATEWAY_LITELLM,
+        }
+    )
+    try:
+        direct_vector = await direct.embed(synthetic_text)
+        gateway_vector = await gateway.embed(synthetic_text)
+        batch = await gateway.embed_batch([synthetic_text, synthetic_text])
+    finally:
+        await direct.aclose()
+        await _maybe_close(gateway)
+
+    _assert_vector(direct_vector, label="direct_ollama")
+    _assert_vector(gateway_vector, label="gateway_litellm")
+    assert len(batch) == 2
+    for vector in batch:
+        _assert_vector(vector, label="gateway_litellm_batch")
+
+    cosine = _cosine_similarity(direct_vector, gateway_vector)
+    logger.info(
+        "gw08_embedding_parity | cosine_similarity={:.6f} dims={}",
+        cosine,
+        len(gateway_vector),
+    )
+    assert cosine >= 0.9999
+
+
+def _chunks_for_synthetic_corpus(
+    embedding_metadata: Mapping[str, Any],
+) -> list[VectorStoreChunk]:
+    docs = {
+        "reserva_sintetica": (
+            "Reserva Sintetica de Emergencia",
+            "A Reserva Sintetica de Emergencia e um conceito ficticio criado "
+            "para validar a migracao controlada de embeddings. A regra central "
+            "afirma que qualquer alocacao educacional deve preservar uma "
+            "reserva sintetica de emergencia antes de ampliar risco simulado. "
+            "O texto nao contem documentos reais, empresas reais, tickers ou "
+            "carteiras reais.\n\n"
+            "A reserva sintetica de emergencia tambem define que respostas "
+            "devem citar chunks recuperados e nunca misturar vetores de "
+            "backends diferentes na mesma colecao temporaria.",
+        ),
+        "politica_migracao": (
+            "Politica de Migracao Sintetica",
+            "A Politica de Migracao Sintetica registra que quimera_embed e o "
+            "alias canonico para novos testes controlados. O backend atual e "
+            "gateway_litellm_current, com rollback para direct_ollama quando "
+            "necessario. A colecao temporaria deve ser apagada ao final.",
+        ),
+        "controle_vetorial": (
+            "Controle Vetorial Ficticio",
+            "O Controle Vetorial Ficticio exige dimensao 768, modelo concreto "
+            "nomic-embed-text e contrato openai_compatible_v1_embeddings. "
+            "Ele existe apenas para garantir metadata auditavel em testes.",
+        ),
+    }
+    chunks: list[VectorStoreChunk] = []
+    for doc_id, (title, text) in docs.items():
+        for chunk in chunk_text(text, max_tokens=60, overlap_tokens=12):
+            chunks.append(
+                VectorStoreChunk(
+                    doc_id=doc_id,
+                    chunk_index=chunk.index,
+                    text=chunk.text,
+                    metadata={
+                        "chunk_id": f"{doc_id}#{chunk.index}",
+                        "title": title,
+                        "source_type": "synthetic",
+                        **embedding_metadata,
+                    },
+                )
+            )
+    return chunks
+
+
+def _embedding_metadata_from_config() -> dict[str, Any]:
+    raw = yaml.safe_load(RAG_CONFIG_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise TypeError("rag_config.yaml must contain a mapping")
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        raise TypeError("rag_config.yaml must contain rag mapping")
+    embedding = rag.get("embedding")
+    if not isinstance(embedding, Mapping):
+        raise TypeError("rag_config.yaml must contain rag.embedding mapping")
+    metadata = {
+        field: embedding[field]
+        for field in REQUIRED_EMBEDDING_METADATA_FIELDS
+        if field in embedding
+    }
+    missing = REQUIRED_EMBEDDING_METADATA_FIELDS.difference(metadata)
+    assert not missing
+    assert metadata["embedding_alias"] == "quimera_embed"
+    assert metadata["embedding_backend"] == "gateway_litellm_current"
+    assert metadata["embedding_model"] == "nomic-embed-text"
+    assert metadata["embedding_dimensions"] == VECTOR_SIZE
+    return metadata
+
+
+def _assert_embedding_metadata(
+    payload: Mapping[str, Any],
+    *,
+    expected: Mapping[str, Any],
+) -> None:
+    assert payload["source_type"] == "synthetic"
+    missing = REQUIRED_EMBEDDING_METADATA_FIELDS.difference(payload)
+    assert not missing
+    for field in REQUIRED_EMBEDDING_METADATA_FIELDS:
+        assert payload[field] == expected[field]
+
+
+def _required_api_key() -> str:
+    api_key = os.environ.get("QUIMERA_LLM_API_KEY")
+    if not api_key:
+        pytest.skip("QUIMERA_LLM_API_KEY is required for GW-08 live smoke")
+    return api_key
+
+
+def _skip_if_qdrant_unreachable(client: QdrantClient, qdrant_url: str) -> set[str]:
+    try:
+        collections = client.get_collections().collections
+    except Exception:  # noqa: BLE001
+        pytest.skip(f"GW-08 smoke skipped: Qdrant is not reachable at {qdrant_url}")
+    return {collection.name for collection in collections}
+
+
+async def _skip_if_ollama_unreachable(base_url: str) -> None:
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=5.0) as client:
+            response = await client.get("/api/tags")
+            response.raise_for_status()
+    except httpx.HTTPError:
+        pytest.skip(f"GW-08 smoke skipped: Ollama is not reachable at {base_url}")
+
+
+async def _skip_if_litellm_unreachable(base_url: str, api_key: str) -> None:
+    try:
+        async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+            response = await client.get(
+                "/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            response.raise_for_status()
+    except httpx.HTTPError:
+        pytest.skip(f"GW-08 smoke skipped: LiteLLM is not reachable at {base_url}")
+
+
+def _assert_local_url(url: str, variable_name: str) -> None:
+    if not (
+        url.startswith("http://127.0.0.1:")
+        or url.startswith("http://localhost:")
+        or url.startswith("http://[::1]:")
+    ):
+        pytest.fail(f"{variable_name} must point to a local-only HTTP URL.")
+
+
+def _delete_temp_collection(client: QdrantClient, collection_name: str) -> None:
+    assert collection_name.startswith(TEMP_COLLECTION_PREFIX), (
+        f"Refusing to delete collection {collection_name!r} - prefix guard failed"
+    )
+    if client.collection_exists(collection_name):
+        client.delete_collection(collection_name)
+
+
+async def _maybe_close(embedder: object) -> None:
+    close = getattr(embedder, "aclose", None)
+    if close is not None:
+        await close()
+
+
+def _assert_vector(vector: Sequence[float], *, label: str) -> None:
+    assert len(vector) == VECTOR_SIZE, f"{label} returned {len(vector)} dimensions"
+    assert all(isinstance(value, float) for value in vector)
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right, strict=True))
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+def _normalize(value: str) -> str:
+    return value.casefold()

--- a/tests/unit/test_embedding_contract_config.py
+++ b/tests/unit/test_embedding_contract_config.py
@@ -104,10 +104,11 @@ class EmbeddingContractConfigTests(unittest.TestCase):
         self.assertEqual(embedding["embedding_dimensions"], 768)
         self.assertEqual(embedding["embedding_version"], "local-ollama-current")
 
-    def test_rag_config_records_gateway_contract_without_migrating_default(self) -> None:
+    def test_rag_config_records_controlled_gateway_migration_with_rollback(self) -> None:
         raw = _load_yaml(RAG_CONFIG)
         embedding = raw["rag"]["embedding"]
 
+        self.assertEqual(embedding["active_backend"], "gateway_litellm")
         self.assertEqual(
             embedding["embedding_contract"],
             "openai_compatible_v1_embeddings",
@@ -117,9 +118,13 @@ class EmbeddingContractConfigTests(unittest.TestCase):
         self.assertEqual(embedding["gateway_compatibility_alias"], "local_embed")
         self.assertEqual(
             embedding["gateway_embedding_status"],
-            "evaluated_for_future_migration",
+            "controlled_migration_current",
         )
-        self.assertEqual(embedding["embedding_backend"], "direct_ollama_current")
+        self.assertEqual(embedding["embedding_backend"], "gateway_litellm_current")
+        self.assertEqual(embedding["legacy_embedding_backend"], "direct_ollama")
+        self.assertEqual(embedding["max_retries"], 3)
+        self.assertEqual(embedding["backoff_seconds"], 1.0)
+        self.assertEqual(embedding["max_concurrency"], 4)
         self.assertTrue(embedding["reindex_required_on_model_change"])
         self.assertEqual(embedding["model"], "nomic-embed-text")
         self.assertEqual(embedding["endpoint"], "http://localhost:11434")

--- a/tests/unit/test_gateway_embed_client.py
+++ b/tests/unit/test_gateway_embed_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import unittest
 from typing import cast
@@ -13,7 +14,10 @@ from backend.gateway.client import (
     GatewayRuntimeConfig,
 )
 from backend.gateway.embed_client import (
+    DEFAULT_EMBED_BACKOFF_SECONDS,
     DEFAULT_EMBEDDING_DIMENSIONS,
+    DEFAULT_EMBED_MAX_CONCURRENCY,
+    DEFAULT_EMBED_MAX_RETRIES,
     GatewayEmbedClient,
 )
 from backend.gateway.errors import (
@@ -71,7 +75,7 @@ class GatewayEmbedClientTests(unittest.IsolatedAsyncioTestCase):
 
         def handler(request: httpx.Request) -> httpx.Response:
             seen_payloads.append(json.loads(request.content.decode("utf-8")))
-            return httpx.Response(200, json=_embedding_response(count=2))
+            return httpx.Response(200, json=_embedding_response())
 
         async with httpx.AsyncClient(
             base_url=DEFAULT_LLM_BASE_URL,
@@ -88,12 +92,86 @@ class GatewayEmbedClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             seen_payloads,
             [
-                {
-                    "model": DEFAULT_LLM_EMBED_MODEL,
-                    "input": ["texto um", "texto dois"],
-                }
+                {"model": DEFAULT_LLM_EMBED_MODEL, "input": "texto um"},
+                {"model": DEFAULT_LLM_EMBED_MODEL, "input": "texto dois"},
             ],
         )
+
+    async def test_default_reliability_settings_match_ollama_embedder_contract(
+        self,
+    ) -> None:
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(200, json=_embedding_response())
+            ),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+            )
+
+        self.assertEqual(gateway.max_retries, DEFAULT_EMBED_MAX_RETRIES)
+        self.assertEqual(gateway.backoff_seconds, DEFAULT_EMBED_BACKOFF_SECONDS)
+        self.assertEqual(gateway.max_concurrency, DEFAULT_EMBED_MAX_CONCURRENCY)
+        self.assertEqual(gateway.expected_dimensions, DEFAULT_EMBEDDING_DIMENSIONS)
+
+    async def test_retries_transient_http_failures_with_backoff(self) -> None:
+        calls = 0
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                return httpx.Response(503)
+            return httpx.Response(200, json=_embedding_response())
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+                sleep=fake_sleep,
+            )
+            vector = await gateway.embed("texto sintetico")
+
+        self.assertEqual(len(vector), DEFAULT_EMBEDDING_DIMENSIONS)
+        self.assertEqual(calls, 3)
+        self.assertEqual(sleeps, [1.0, 2.0])
+
+    async def test_embed_batch_enforces_max_concurrency(self) -> None:
+        active = 0
+        max_seen = 0
+
+        async def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal active, max_seen
+            active += 1
+            max_seen = max(max_seen, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return httpx.Response(200, json=_embedding_response())
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+                max_concurrency=2,
+            )
+            vectors = await gateway.embed_batch(
+                ["texto um", "texto dois", "texto tres", "texto quatro"]
+            )
+
+        self.assertEqual(len(vectors), 4)
+        self.assertLessEqual(max_seen, 2)
 
     async def test_empty_batch_returns_empty_list_without_http_call(self) -> None:
         def handler(_request: httpx.Request) -> httpx.Response:

--- a/tests/unit/test_litellm_infra_scripts.py
+++ b/tests/unit/test_litellm_infra_scripts.py
@@ -44,6 +44,7 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
             INFRA_DIR / "test_local_chat.sh",
             REPO_ROOT / "scripts" / "check_litellm_gateway.sh",
             REPO_ROOT / "scripts" / "test_opencraw_litellm_runtime.sh",
+            REPO_ROOT / "scripts" / "test_gw08_embedding_migration.sh",
         ):
             with self.subTest(path=path):
                 mode = path.stat().st_mode

--- a/tests/unit/test_rag_embedder_factory.py
+++ b/tests/unit/test_rag_embedder_factory.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import httpx
+
+from backend.gateway.embed_client import GatewayEmbedClient
+from backend.rag.embedder_factory import (
+    BACKEND_DIRECT_OLLAMA,
+    BACKEND_GATEWAY_LITELLM,
+    ENV_RAG_EMBEDDING_BACKEND,
+    create_rag_embedder,
+    load_rag_embedding_config,
+)
+from backend.rag.embeddings import OllamaEmbedder
+
+
+class RagEmbedderFactoryTests(unittest.IsolatedAsyncioTestCase):
+    def test_loads_gateway_litellm_as_default_backend(self) -> None:
+        path = _write_config(active_backend=BACKEND_GATEWAY_LITELLM)
+
+        config = load_rag_embedding_config(path, env={})
+
+        self.assertEqual(config.active_backend, BACKEND_GATEWAY_LITELLM)
+        self.assertEqual(config.embedding_alias, "quimera_embed")
+        self.assertEqual(config.legacy_embedding_backend, BACKEND_DIRECT_OLLAMA)
+        self.assertEqual(config.max_retries, 3)
+        self.assertEqual(config.backoff_seconds, 1.0)
+        self.assertEqual(config.max_concurrency, 4)
+        self.assertEqual(config.expected_dimensions, 768)
+
+    async def test_factory_returns_gateway_embedder_for_gateway_backend(self) -> None:
+        path = _write_config(active_backend=BACKEND_GATEWAY_LITELLM)
+        client = httpx.AsyncClient(
+            base_url="http://127.0.0.1:4000/v1",
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200)),
+        )
+        self.addAsyncCleanup(client.aclose)
+
+        embedder = create_rag_embedder(
+            path,
+            env={"QUIMERA_LLM_API_KEY": "dev-key"},
+            gateway_http_client=client,
+        )
+
+        self.assertIsInstance(embedder, GatewayEmbedClient)
+        assert isinstance(embedder, GatewayEmbedClient)
+        gateway = embedder
+        self.assertEqual(gateway.model, "quimera_embed")
+        self.assertEqual(gateway.max_retries, 3)
+        self.assertEqual(gateway.backoff_seconds, 1.0)
+        self.assertEqual(gateway.max_concurrency, 4)
+
+    async def test_factory_returns_ollama_embedder_for_direct_backend(self) -> None:
+        path = _write_config(active_backend=BACKEND_DIRECT_OLLAMA)
+        client = httpx.AsyncClient(
+            base_url="http://localhost:11434",
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200)),
+        )
+        self.addAsyncCleanup(client.aclose)
+
+        embedder = create_rag_embedder(
+            path,
+            env={},
+            ollama_http_client=client,
+        )
+
+        self.assertIsInstance(embedder, OllamaEmbedder)
+        assert isinstance(embedder, OllamaEmbedder)
+        ollama = embedder
+        self.assertEqual(ollama.model, "nomic-embed-text")
+        self.assertEqual(ollama.base_url, "http://localhost:11434")
+        self.assertEqual(ollama.max_retries, 3)
+        self.assertEqual(ollama.backoff_seconds, 1.0)
+        self.assertEqual(ollama.max_concurrency, 4)
+
+    def test_env_override_can_select_direct_ollama_rollback(self) -> None:
+        path = _write_config(active_backend=BACKEND_GATEWAY_LITELLM)
+
+        config = load_rag_embedding_config(
+            path,
+            env={ENV_RAG_EMBEDDING_BACKEND: BACKEND_DIRECT_OLLAMA},
+        )
+
+        self.assertEqual(config.active_backend, BACKEND_DIRECT_OLLAMA)
+
+    def test_invalid_backend_raises_clear_error(self) -> None:
+        path = _write_config(active_backend="remote_magic")
+
+        with self.assertRaisesRegex(ValueError, "active_backend"):
+            load_rag_embedding_config(path, env={})
+
+
+def _write_config(*, active_backend: str) -> Path:
+    text = f"""
+rag:
+  embedding:
+    active_backend: "{active_backend}"
+    embedding_alias: "quimera_embed"
+    legacy_embedding_backend: "direct_ollama"
+    embedding_model: "nomic-embed-text"
+    endpoint: "http://localhost:11434"
+    timeout_seconds: 30
+    max_retries: 3
+    backoff_seconds: 1.0
+    max_concurrency: 4
+    expected_dimensions: 768
+"""
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".yaml",
+        delete=False,
+        encoding="utf-8",
+    )
+    with handle:
+        handle.write(text)
+    return Path(handle.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements GW-08 controlled migration for new RAG embedding generation through the canonical `quimera_embed` alias via LiteLLM `/v1/embeddings`, while preserving `direct_ollama` as the explicit rollback path.

Target path for new controlled ingest/test flows:

```text
RagEmbedder factory
  -> gateway_litellm
  -> GatewayEmbedClient
  -> LiteLLM /v1/embeddings
  -> quimera_embed
  -> Ollama / nomic-embed-text
```

Rollback path:

```text
QUIMERA_RAG_EMBEDDING_BACKEND=direct_ollama
  -> OllamaEmbedder
  -> Ollama /api/embed
```

Closes #40.

## Scope

Included:

- `backend/rag/embedder_factory.py` with `gateway_litellm` and `direct_ollama` backends
- Hardened `GatewayEmbedClient` retry/backoff/concurrency parity
- `quimera_embed` as the gateway embedding default for controlled paths
- `direct_ollama` rollback preserved
- RAG config metadata for controlled migration and rollback
- Unit tests for factory, gateway embed client, config contract, script registration
- Optional GW-08 live E2E smoke with temporary `gw08_embedding_migration_` collection
- Optional parity smoke comparing direct Ollama vs LiteLLM embeddings
- Script wrapper `scripts/test_gw08_embedding_migration.sh`
- Migration docs and sprint/current-state handoff updates

Excluded:

- Reindexing `openclaw_knowledge`
- Modifying existing Qdrant collections
- Removing `OllamaEmbedder`
- Removing `direct_ollama` rollback
- Changing the concrete embedding model
- Real documents or real portfolio data
- Remote providers
- FastAPI
- MCP
- Quant tools

## Live Result

GW-08 live validation passed locally on 2026-04-30 after restarting LiteLLM so `/v1/models` exposed `quimera_embed`.

- `scripts/test_gw08_embedding_migration.sh`: passed
- E2E smoke: passed
- Parity smoke: passed
- Synthetic chunks indexed: 4
- Retrieved/used chunks: 4
- Embedding/indexing latency: 314.7 ms
- Retrieval latency: 27.4 ms
- Generation latency: 4951.7 ms
- Total pipeline latency: 4979.1 ms
- Direct Ollama vs gateway cosine similarity: 1.000000
- Vector dimensions: 768

## Validation

```bash
git diff --check
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
uv run python -m compileall backend tests scripts infra
uv run pytest tests/unit/test_gateway_embed_client.py tests/unit/test_rag_embedder_factory.py tests/unit/test_embedding_contract_config.py tests/unit/test_litellm_infra_scripts.py -v
QUIMERA_LLM_API_KEY=<local-placeholder> scripts/test_gw08_embedding_migration.sh
```

Reported results:

- `uv run pytest -v`: 156 passed, 7 skipped, 67 subtests passed
- `uv run mypy --strict .`: success, no issues
- `uv run pyright`: 0 errors, 0 warnings
- `uv run pytest tests/smoke/ -v`: 5 passed, 7 skipped
- `compileall`: OK
- Focused gateway/embedder/config/script tests: 35 passed, 15 subtests passed
- GW-08 live script: 2 passed

## Security

- No secrets committed
- `.env` untouched
- No remote providers enabled
- No real documents or portfolio data
- No private files read
- No Authorization headers or API keys logged
- No production Qdrant collection modified
- `openclaw_knowledge` was not touched
- Temporary smoke collections are prefix-guarded and cleanup is attempted in teardown
