### PR TITLE
feat(rag): add structured RAG observability events

### DIFF
--- a/backend/gateway/embed_client.py
+++ b/backend/gateway/embed_client.py
@@ -23,6 +23,16 @@ from backend.gateway.errors import (
     GatewayResponseError,
     GatewayTimeoutError,
 )
+from backend.rag.observability import (
+    RagErrorCategory,
+    RagEventKind,
+    RagObservabilityConfig,
+    RagObservabilityEvent,
+    categorize_exception,
+    emit_rag_event,
+    load_rag_observability_config,
+    utc_now_iso,
+)
 
 
 ENV_LLM_EMBED_MODEL = "QUIMERA_LLM_EMBED_MODEL"
@@ -54,10 +64,13 @@ class GatewayEmbedClient:
     max_concurrency: int = DEFAULT_EMBED_MAX_CONCURRENCY
     client: httpx.AsyncClient | None = None
     sleep: SleepFn = asyncio.sleep
+    observability_config: RagObservabilityConfig | None = None
     _owns_client: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
         self.config = self.config.validated()
+        if self.observability_config is None:
+            self.observability_config = load_rag_observability_config()
         self.model = self.model.strip()
         if not self.model:
             raise GatewayConfigurationError(f"{ENV_LLM_EMBED_MODEL} cannot be empty")
@@ -92,12 +105,34 @@ class GatewayEmbedClient:
     async def embed(self, text: str) -> list[float]:
         """Embed one synthetic/local text through LiteLLM ``/embeddings``."""
         clean_text = _validate_text(text)
-        vectors = await self._embed_payload(clean_text)
-        if len(vectors) != 1:
-            raise GatewayResponseError(
-                "LiteLLM embedding response did not contain exactly one vector.",
-                alias=self.model,
+        start = time.perf_counter()
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_STARTED,
+            batch_size=1,
+            status="started",
+        )
+        try:
+            vectors = await self._embed_payload(clean_text)
+            if len(vectors) != 1:
+                raise GatewayResponseError(
+                    "LiteLLM embedding response did not contain exactly one vector.",
+                    alias=self.model,
+                )
+        except Exception as exc:
+            self._emit_embedding_event(
+                RagEventKind.EMBEDDING_CALL_FAILED,
+                latency_ms=_elapsed_ms(start),
+                batch_size=1,
+                status="failed",
+                error_category=categorize_exception(exc),
             )
+            raise
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_FINISHED,
+            latency_ms=_elapsed_ms(start),
+            batch_size=1,
+            status="success",
+        )
         return vectors[0]
 
     async def embed_batch(self, texts: Sequence[str]) -> list[list[float]]:
@@ -106,6 +141,12 @@ class GatewayEmbedClient:
         if not clean_texts:
             return []
 
+        start = time.perf_counter()
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_STARTED,
+            batch_size=len(clean_texts),
+            status="started",
+        )
         semaphore = asyncio.Semaphore(self.max_concurrency)
 
         async def _embed_one(text: str) -> list[float]:
@@ -118,7 +159,26 @@ class GatewayEmbedClient:
                     )
                 return vectors[0]
 
-        return list(await asyncio.gather(*(_embed_one(text) for text in clean_texts)))
+        try:
+            vectors = list(
+                await asyncio.gather(*(_embed_one(text) for text in clean_texts))
+            )
+        except Exception as exc:
+            self._emit_embedding_event(
+                RagEventKind.EMBEDDING_CALL_FAILED,
+                latency_ms=_elapsed_ms(start),
+                batch_size=len(clean_texts),
+                status="failed",
+                error_category=categorize_exception(exc),
+            )
+            raise
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_FINISHED,
+            latency_ms=_elapsed_ms(start),
+            batch_size=len(clean_texts),
+            status="success",
+        )
+        return vectors
 
     async def _embed_payload(self, input_value: str | list[str]) -> list[list[float]]:
         if self.client is None:
@@ -234,6 +294,36 @@ class GatewayEmbedClient:
         )
         await self.sleep(wait_seconds)
 
+    def _emit_embedding_event(
+        self,
+        event_kind: RagEventKind,
+        *,
+        latency_ms: float | None = None,
+        batch_size: int | None = None,
+        status: str | None = None,
+        error_category: RagErrorCategory | None = None,
+    ) -> None:
+        config = self.observability_config
+        if (
+            config is None
+            or not config.enabled
+            or not config.embedding_events_enabled
+        ):
+            return
+        event = RagObservabilityEvent(
+            event_kind=event_kind,
+            timestamp_utc=utc_now_iso(),
+            backend="gateway_litellm",
+            alias=self.model,
+            model=self.model,
+            dimensions=self.expected_dimensions,
+            latency_ms=latency_ms,
+            batch_size=batch_size,
+            status=status,
+            error_category=error_category,
+        )
+        emit_rag_event(event, config)
+
 
 def _validate_text(text: str) -> str:
     if not isinstance(text, str):
@@ -319,3 +409,7 @@ def _log_embed_call(
         status,
         error_category or "none",
     )
+
+
+def _elapsed_ms(start: float) -> float:
+    return (time.perf_counter() - start) * 1000

--- a/backend/rag/embeddings.py
+++ b/backend/rag/embeddings.py
@@ -16,6 +16,17 @@ from typing import Any, cast
 import httpx
 from loguru import logger
 
+from backend.rag.observability import (
+    RagErrorCategory,
+    RagEventKind,
+    RagObservabilityConfig,
+    RagObservabilityEvent,
+    categorize_exception,
+    emit_rag_event,
+    load_rag_observability_config,
+    utc_now_iso,
+)
+
 
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 DEFAULT_EMBED_MODEL = "nomic-embed-text"
@@ -60,9 +71,12 @@ class OllamaEmbedder:
     expected_dimensions: int = DEFAULT_EXPECTED_DIMENSIONS
     client: httpx.AsyncClient | None = None
     sleep: SleepFn = asyncio.sleep
+    observability_config: RagObservabilityConfig | None = None
     _owns_client: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
+        if self.observability_config is None:
+            self.observability_config = load_rag_observability_config()
         if not self.model.strip():
             raise ValueError("model cannot be empty")
         if self.timeout_seconds <= 0:
@@ -111,15 +125,30 @@ class OllamaEmbedder:
         """
         clean_text = _validate_text(text)
         t0 = time.monotonic()
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_STARTED,
+            batch_size=1,
+            status="started",
+        )
 
-        response = await self._post_embed({"model": self.model, "input": clean_text})
-        vector = _extract_single_embedding(response)
+        try:
+            response = await self._post_embed({"model": self.model, "input": clean_text})
+            vector = _extract_single_embedding(response)
 
-        if len(vector) != self.expected_dimensions:
-            raise EmbeddingError(
-                f"Expected {self.expected_dimensions} dimensions, "
-                f"got {len(vector)} from model '{self.model}'"
+            if len(vector) != self.expected_dimensions:
+                raise EmbeddingError(
+                    f"Expected {self.expected_dimensions} dimensions, "
+                    f"got {len(vector)} from model '{self.model}'"
+                )
+        except Exception as exc:
+            self._emit_embedding_event(
+                RagEventKind.EMBEDDING_CALL_FAILED,
+                latency_ms=(time.monotonic() - t0) * 1000,
+                batch_size=1,
+                status="failed",
+                error_category=categorize_exception(exc),
             )
+            raise
 
         latency_ms = (time.monotonic() - t0) * 1000
         logger.debug(
@@ -127,6 +156,12 @@ class OllamaEmbedder:
             self.model,
             len(vector),
             latency_ms,
+        )
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_FINISHED,
+            latency_ms=latency_ms,
+            batch_size=1,
+            status="success",
         )
         return vector
 
@@ -149,14 +184,29 @@ class OllamaEmbedder:
 
         semaphore = asyncio.Semaphore(self.max_concurrency)
         t0 = time.monotonic()
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_STARTED,
+            batch_size=len(clean_texts),
+            status="started",
+        )
 
         async def _embed_one(text: str) -> list[float]:
             async with semaphore:
                 return await self.embed(text)
 
-        vectors = list(
-            await asyncio.gather(*(_embed_one(t) for t in clean_texts))
-        )
+        try:
+            vectors = list(
+                await asyncio.gather(*(_embed_one(t) for t in clean_texts))
+            )
+        except Exception as exc:
+            self._emit_embedding_event(
+                RagEventKind.EMBEDDING_CALL_FAILED,
+                latency_ms=(time.monotonic() - t0) * 1000,
+                batch_size=len(clean_texts),
+                status="failed",
+                error_category=categorize_exception(exc),
+            )
+            raise
 
         latency_ms = (time.monotonic() - t0) * 1000
         logger.debug(
@@ -164,6 +214,12 @@ class OllamaEmbedder:
             self.model,
             len(vectors),
             latency_ms,
+        )
+        self._emit_embedding_event(
+            RagEventKind.EMBEDDING_CALL_FINISHED,
+            latency_ms=latency_ms,
+            batch_size=len(clean_texts),
+            status="success",
         )
         return vectors
 
@@ -191,6 +247,36 @@ class OllamaEmbedder:
                 await self.sleep(wait)
 
         raise RuntimeError("unreachable retry state")  # pragma: no cover
+
+    def _emit_embedding_event(
+        self,
+        event_kind: RagEventKind,
+        *,
+        latency_ms: float | None = None,
+        batch_size: int | None = None,
+        status: str | None = None,
+        error_category: RagErrorCategory | None = None,
+    ) -> None:
+        config = self.observability_config
+        if (
+            config is None
+            or not config.enabled
+            or not config.embedding_events_enabled
+        ):
+            return
+        event = RagObservabilityEvent(
+            event_kind=event_kind,
+            timestamp_utc=utc_now_iso(),
+            backend="direct_ollama",
+            alias=self.model,
+            model=self.model,
+            dimensions=self.expected_dimensions,
+            latency_ms=latency_ms,
+            batch_size=batch_size,
+            status=status,
+            error_category=error_category,
+        )
+        emit_rag_event(event, config)
 
 
 def _validate_text(text: str) -> str:

--- a/backend/rag/embeddings.py
+++ b/backend/rag/embeddings.py
@@ -192,7 +192,14 @@ class OllamaEmbedder:
 
         async def _embed_one(text: str) -> list[float]:
             async with semaphore:
-                return await self.embed(text)
+                response = await self._post_embed({"model": self.model, "input": text})
+                vector = _extract_single_embedding(response)
+                if len(vector) != self.expected_dimensions:
+                    raise EmbeddingError(
+                        f"Expected {self.expected_dimensions} dimensions, "
+                        f"got {len(vector)} from model '{self.model}'"
+                    )
+                return vector
 
         try:
             vectors = list(

--- a/backend/rag/observability.py
+++ b/backend/rag/observability.py
@@ -1,0 +1,270 @@
+"""Safe local RAG lifecycle observability events.
+
+These events are local loguru structured logs only.  They deliberately carry
+metadata about the lifecycle stage, never user text, chunks, prompts, answers,
+vectors, payloads, or secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+
+import httpx
+import yaml
+from loguru import logger
+
+from backend.rag.collection_guard import EmbeddingDimensionMismatchError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
+ALLOWED_OBSERVABILITY_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING"})
+FORBIDDEN_OBSERVABILITY_KEYS = frozenset(
+    {
+        "query",
+        "question",
+        "prompt",
+        "answer",
+        "response",
+        "chunk",
+        "chunk_text",
+        "chunks",
+        "document",
+        "documents",
+        "vector",
+        "vectors",
+        "embedding",
+        "embedding_values",
+        "payload",
+        "qdrant_payload",
+        "portfolio",
+        "carteira",
+        "api_key",
+        "authorization",
+        "secret",
+        "token",
+        "password",
+        "headers",
+    }
+)
+
+
+class RagEventKind(str, Enum):
+    """Safe RAG lifecycle event names."""
+
+    EMBEDDING_CALL_STARTED = "embedding_call_started"
+    EMBEDDING_CALL_FINISHED = "embedding_call_finished"
+    EMBEDDING_CALL_FAILED = "embedding_call_failed"
+    RETRIEVAL_STARTED = "retrieval_started"
+    RETRIEVAL_FINISHED = "retrieval_finished"
+    RETRIEVAL_FAILED = "retrieval_failed"
+    GENERATION_STARTED = "generation_started"
+    GENERATION_FINISHED = "generation_finished"
+    GENERATION_FAILED = "generation_failed"
+    COLLECTION_GUARD_WARNING = "collection_guard_warning"
+    COLLECTION_GUARD_ERROR = "collection_guard_error"
+
+
+class RagErrorCategory(str, Enum):
+    """Coarse, safe error categories for lifecycle events."""
+
+    TIMEOUT = "timeout"
+    CONNECTION = "connection"
+    AUTHENTICATION = "authentication"
+    INVALID_RESPONSE = "invalid_response"
+    DIMENSION_MISMATCH = "dimension_mismatch"
+    HTTP_ERROR = "http_error"
+    BACKEND_UNREACHABLE = "backend_unreachable"
+    EMPTY_RESULT = "empty_result"
+    COLLECTION_GUARD_STRICT = "collection_guard_strict"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RagObservabilityConfig:
+    """Configuration for local RAG lifecycle event emission."""
+
+    enabled: bool = True
+    log_level: str = "INFO"
+    embedding_events_enabled: bool = True
+    retrieval_events_enabled: bool = True
+    generation_events_enabled: bool = True
+    collection_guard_events_enabled: bool = True
+
+    def validated(self) -> RagObservabilityConfig:
+        """Return a validated copy of this config."""
+        level = self.log_level.strip().upper()
+        if level not in ALLOWED_OBSERVABILITY_LOG_LEVELS:
+            allowed = ", ".join(sorted(ALLOWED_OBSERVABILITY_LOG_LEVELS))
+            raise ValueError(f"rag.observability.log_level must be one of: {allowed}")
+        return RagObservabilityConfig(
+            enabled=self.enabled,
+            log_level=level,
+            embedding_events_enabled=self.embedding_events_enabled,
+            retrieval_events_enabled=self.retrieval_events_enabled,
+            generation_events_enabled=self.generation_events_enabled,
+            collection_guard_events_enabled=self.collection_guard_events_enabled,
+        )
+
+
+@dataclass(frozen=True)
+class RagObservabilityEvent:
+    """Safe metadata-only RAG lifecycle event."""
+
+    event_kind: RagEventKind
+    timestamp_utc: str
+    backend: str
+    alias: str
+    model: str | None = None
+    dimensions: int | None = None
+    latency_ms: float | None = None
+    chunk_count: int | None = None
+    batch_size: int | None = None
+    status: str | None = None
+    error_category: RagErrorCategory | None = None
+    collection_name: str | None = None
+    query_id: str | None = None
+    gateway_alias: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty(self.timestamp_utc, "timestamp_utc")
+        _validate_non_empty(self.backend, "backend")
+        _validate_non_empty(self.alias, "alias")
+        if self.dimensions is not None and self.dimensions <= 0:
+            raise ValueError("dimensions must be greater than zero")
+        if self.latency_ms is not None and self.latency_ms < 0:
+            raise ValueError("latency_ms cannot be negative")
+        if self.chunk_count is not None and self.chunk_count < 0:
+            raise ValueError("chunk_count cannot be negative")
+        if self.batch_size is not None and self.batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
+    def to_log_dict(self) -> dict[str, object]:
+        """Return allowlisted safe scalar metadata for loguru binding."""
+        data: dict[str, object] = {
+            "event_kind": self.event_kind.value,
+            "timestamp_utc": self.timestamp_utc,
+            "backend": self.backend,
+            "alias": self.alias,
+        }
+        optional_values: Mapping[str, object | None] = {
+            "model": self.model,
+            "dimensions": self.dimensions,
+            "latency_ms": self.latency_ms,
+            "chunk_count": self.chunk_count,
+            "batch_size": self.batch_size,
+            "status": self.status,
+            "error_category": (
+                self.error_category.value if self.error_category is not None else None
+            ),
+            "collection_name": self.collection_name,
+            "query_id": self.query_id,
+            "gateway_alias": self.gateway_alias,
+        }
+        for key, value in optional_values.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+def load_rag_observability_config(
+    config_path: str | Path = DEFAULT_RAG_CONFIG_PATH,
+) -> RagObservabilityConfig:
+    """Load RAG observability config from ``config/rag_config.yaml``."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        return RagObservabilityConfig().validated()
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        return RagObservabilityConfig().validated()
+    observability = rag.get("observability")
+    if not isinstance(observability, Mapping):
+        return RagObservabilityConfig().validated()
+
+    return RagObservabilityConfig(
+        enabled=_bool_from_mapping(observability, "enabled", True),
+        log_level=str(observability.get("log_level", "INFO")),
+        embedding_events_enabled=_bool_from_mapping(
+            observability,
+            "embedding_events_enabled",
+            True,
+        ),
+        retrieval_events_enabled=_bool_from_mapping(
+            observability,
+            "retrieval_events_enabled",
+            True,
+        ),
+        generation_events_enabled=_bool_from_mapping(
+            observability,
+            "generation_events_enabled",
+            True,
+        ),
+        collection_guard_events_enabled=_bool_from_mapping(
+            observability,
+            "collection_guard_events_enabled",
+            True,
+        ),
+    ).validated()
+
+
+def emit_rag_event(
+    event: RagObservabilityEvent,
+    config: RagObservabilityConfig,
+) -> None:
+    """Emit a local structured RAG lifecycle event if enabled."""
+    safe_config = config.validated()
+    if not safe_config.enabled:
+        return
+    logger.bind(event=event.to_log_dict()).log(
+        safe_config.log_level,
+        "rag_lifecycle_event",
+    )
+
+
+def categorize_exception(exc: Exception) -> RagErrorCategory:
+    """Map known local exceptions to safe categories without messages."""
+    exc_name = exc.__class__.__name__
+    if isinstance(exc, httpx.TimeoutException) or exc_name == "GatewayTimeoutError":
+        return RagErrorCategory.TIMEOUT
+    if isinstance(exc, httpx.ConnectError) or exc_name == "GatewayConnectionError":
+        return RagErrorCategory.CONNECTION
+    if exc_name == "GatewayAuthenticationError":
+        return RagErrorCategory.AUTHENTICATION
+    if (
+        isinstance(exc, ValueError)
+        or exc_name == "GatewayResponseError"
+        or exc_name == "EmbeddingError"
+    ):
+        return RagErrorCategory.INVALID_RESPONSE
+    if isinstance(exc, EmbeddingDimensionMismatchError):
+        return RagErrorCategory.DIMENSION_MISMATCH
+    if isinstance(exc, httpx.HTTPStatusError):
+        return RagErrorCategory.HTTP_ERROR
+    if isinstance(exc, httpx.TransportError):
+        return RagErrorCategory.BACKEND_UNREACHABLE
+    return RagErrorCategory.UNKNOWN
+
+
+def utc_now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp with a compact Z suffix."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _bool_from_mapping(
+    values: Mapping[object, object],
+    key: str,
+    default: bool,
+) -> bool:
+    raw = values.get(key, default)
+    if not isinstance(raw, bool):
+        raise ValueError(f"rag.observability.{key} must be a boolean")
+    return raw
+
+
+def _validate_non_empty(value: str, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -6,12 +6,23 @@ import time
 from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
+from uuid import uuid4
 
 from loguru import logger
 
 from backend.rag._validation import validate_question
 from backend.rag.context_packer import RetrievedChunk
 from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.observability import (
+    RagErrorCategory,
+    RagEventKind,
+    RagObservabilityConfig,
+    RagObservabilityEvent,
+    categorize_exception,
+    emit_rag_event,
+    load_rag_observability_config,
+    utc_now_iso,
+)
 from backend.rag.run_trace import (
     RagTracingConfig,
     build_rag_run_trace,
@@ -72,10 +83,13 @@ class LocalRagPipeline:
     temperature: float | None = None
     thinking_mode: bool = False
     tracing_config: RagTracingConfig | None = None
+    observability_config: RagObservabilityConfig | None = None
 
     def __post_init__(self) -> None:
         if self.tracing_config is None:
             self.tracing_config = load_rag_tracing_config()
+        if self.observability_config is None:
+            self.observability_config = load_rag_observability_config()
 
     async def ask(
         self,
@@ -86,15 +100,45 @@ class LocalRagPipeline:
         """Run retrieval, build a prompt, and generate a local answer."""
 
         clean_question = validate_question(question)
+        query_id = uuid4().hex
         total_start = time.perf_counter()
+        collection_name = _infer_collection_name(
+            self.retriever,
+            self.tracing_config.collection_name if self.tracing_config else "unknown",
+        )
 
         retrieval_start = time.perf_counter()
-        chunks = await self.retriever.retrieve(
-            clean_question,
-            top_k=top_k,
-            filters=filters,
+        self._emit_pipeline_event(
+            RagEventKind.RETRIEVAL_STARTED,
+            query_id=query_id,
+            collection_name=collection_name,
+            status="started",
         )
+        try:
+            chunks = await self.retriever.retrieve(
+                clean_question,
+                top_k=top_k,
+                filters=filters,
+            )
+        except Exception as exc:
+            self._emit_pipeline_event(
+                RagEventKind.RETRIEVAL_FAILED,
+                query_id=query_id,
+                collection_name=collection_name,
+                latency_ms=_elapsed_ms(retrieval_start),
+                status="failed",
+                error_category=categorize_exception(exc),
+            )
+            raise
         retrieval_ms = _elapsed_ms(retrieval_start)
+        self._emit_pipeline_event(
+            RagEventKind.RETRIEVAL_FINISHED,
+            query_id=query_id,
+            collection_name=collection_name,
+            latency_ms=retrieval_ms,
+            chunk_count=len(chunks),
+            status="success",
+        )
 
         prompt_start = time.perf_counter()
         messages = self.prompt_builder.build(
@@ -105,12 +149,43 @@ class LocalRagPipeline:
         prompt_ms = _elapsed_ms(prompt_start)
 
         generation_start = time.perf_counter()
-        answer = await self.generator.chat(
-            messages,
-            temperature=self.temperature,
-            thinking_mode=self.thinking_mode,
+        gateway_alias = _infer_gateway_alias(self.generator)
+        self._emit_pipeline_event(
+            RagEventKind.GENERATION_STARTED,
+            query_id=query_id,
+            collection_name=collection_name,
+            chunk_count=len(chunks),
+            gateway_alias=gateway_alias,
+            status="started",
         )
+        try:
+            answer = await self.generator.chat(
+                messages,
+                temperature=self.temperature,
+                thinking_mode=self.thinking_mode,
+            )
+        except Exception as exc:
+            self._emit_pipeline_event(
+                RagEventKind.GENERATION_FAILED,
+                query_id=query_id,
+                collection_name=collection_name,
+                latency_ms=_elapsed_ms(generation_start),
+                chunk_count=len(chunks),
+                gateway_alias=gateway_alias,
+                status="failed",
+                error_category=categorize_exception(exc),
+            )
+            raise
         generation_ms = _elapsed_ms(generation_start)
+        self._emit_pipeline_event(
+            RagEventKind.GENERATION_FINISHED,
+            query_id=query_id,
+            collection_name=collection_name,
+            latency_ms=generation_ms,
+            chunk_count=len(chunks),
+            gateway_alias=gateway_alias,
+            status="success",
+        )
 
         latency = {
             "retrieval_ms": retrieval_ms,
@@ -130,6 +205,7 @@ class LocalRagPipeline:
             generation_ms=generation_ms,
             total_ms=latency["total_ms"],
             chunk_count=len(chunks),
+            query_id=query_id,
         )
         return RagPipelineResult(
             question=clean_question,
@@ -147,6 +223,7 @@ class LocalRagPipeline:
         generation_ms: float,
         total_ms: float,
         chunk_count: int,
+        query_id: str | None = None,
         actual_embedding_dimensions: int | None = None,
     ) -> None:
         """Emit a RagRunTrace provenance record via loguru.
@@ -181,12 +258,50 @@ class LocalRagPipeline:
             retrieval_latency_ms=retrieval_ms,
             generation_latency_ms=generation_ms,
             chunk_count=chunk_count,
+            query_id=query_id,
             gateway_alias=gateway_alias,
             total_latency_ms=total_ms,
             prompt_latency_ms=prompt_ms,
             context_chunk_count=chunk_count,
         )
         logger.bind(trace=trace.to_log_dict()).log(config.log_level, "rag_run_trace")
+
+    def _emit_pipeline_event(
+        self,
+        event_kind: RagEventKind,
+        *,
+        query_id: str,
+        collection_name: str,
+        latency_ms: float | None = None,
+        chunk_count: int | None = None,
+        gateway_alias: str | None = None,
+        status: str | None = None,
+        error_category: RagErrorCategory | None = None,
+    ) -> None:
+        config = self.observability_config
+        if config is None or not config.enabled:
+            return
+        if event_kind.value.startswith("retrieval_") and not config.retrieval_events_enabled:
+            return
+        if event_kind.value.startswith("generation_") and not config.generation_events_enabled:
+            return
+        tracing = self.tracing_config
+        event = RagObservabilityEvent(
+            event_kind=event_kind,
+            timestamp_utc=utc_now_iso(),
+            backend=tracing.embedding_backend if tracing else "unknown",
+            alias=tracing.embedding_alias if tracing else "unknown",
+            model=tracing.embedding_model if tracing else None,
+            dimensions=tracing.embedding_dimensions if tracing else None,
+            latency_ms=latency_ms,
+            chunk_count=chunk_count,
+            status=status,
+            error_category=error_category,
+            collection_name=collection_name,
+            query_id=query_id,
+            gateway_alias=gateway_alias,
+        )
+        emit_rag_event(event, config)
 
 
 def _infer_collection_name(retriever: object, fallback: str) -> str:

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -42,6 +42,14 @@ rag:
     enabled: true
     log_level: "INFO"
 
+  observability:
+    enabled: true
+    log_level: "INFO"
+    embedding_events_enabled: true
+    retrieval_events_enabled: true
+    generation_events_enabled: true
+    collection_guard_events_enabled: true
+
   retrieval:
     top_k: 5
     score_threshold: 0.3

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,7 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Gateway GW-10 RagRunTrace provenance
+**Updated by:** Codex — Gateway GW-11 RAG observability events
 
 ---
 
@@ -104,7 +104,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Done / merged |
 | GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Done / merged |
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard for embedding traceability | Done / merged |
-| GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Current |
+| GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Done / merged |
+| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -113,6 +114,7 @@ GW-07 issue: <https://github.com/franciscosalido/OPENCLAW/issues/38>
 GW-08 issue: <https://github.com/franciscosalido/OPENCLAW/issues/40>
 GW-09 issue: <https://github.com/franciscosalido/OPENCLAW/issues/42>
 GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
+GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 
 ---
 
@@ -250,7 +252,7 @@ uv run pytest tests/unit/test_gateway_embed_client.py -v
 uv run pytest tests/smoke/ -v
 ```
 
-## GW-10 Current Work
+## GW-10 Completed Work
 
 GW-10 adds `RagRunTrace`, a safe frozen dataclass for per-query provenance:
 
@@ -274,10 +276,9 @@ Trace scope:
   active expected dimensions.
 - Does not mutate Qdrant, reindex collections, or touch `openclaw_knowledge`.
 
-Future work remains separate:
-
-- GW-11: structured observability lifecycle events.
-- GW-12: memory/resource baseline.
+GW-11 current work remains separate from `RagRunTrace`: lifecycle events are
+local structured loguru records around embedding, retrieval, and generation.
+GW-12 remains the place for memory/resource baseline.
 
 Live smoke tests should skip by default unless their explicit guards are set.
 GW-07 requires `RUN_RAG_E2E_SMOKE=1`.
@@ -298,7 +299,7 @@ export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 scripts/test_rag_e2e_gateway.sh
 ```
 
-## GW-08 Current Work
+## GW-08 Completed Work
 
 GW-08 aligns new controlled RAG embedding generation with the accepted
 OpenAI-compatible embeddings contract:
@@ -370,7 +371,7 @@ Observed GW-08 latencies and parity (2026-04-30):
 | cosine similarity vs direct Ollama | 1.000000 |
 | vector dimensions | 768 |
 
-## GW-09 Current Work
+## GW-09 Completed Work
 
 GW-09 adds a traceability guard for Qdrant collection embedding metadata:
 
@@ -391,7 +392,7 @@ Key rules:
 - `strict=True` can raise on backend/model/contract/alias mismatch.
 - No chunk text, vectors, prompts, secrets, or Authorization headers are logged.
 - GW-10 remains the place for `RagRunTrace`.
-- GW-11 remains the place for structured embedding observability events.
+- GW-11 adds structured RAG observability lifecycle events separately.
 
 Validation expectations:
 
@@ -402,3 +403,40 @@ uv run mypy --strict .
 uv run pyright
 uv run pytest tests/smoke/ -v
 ```
+
+## GW-11 Current Work
+
+GW-11 adds local structured RAG lifecycle observability events:
+
+```text
+embedding/retrieval/generation stage
+  -> RagObservabilityEvent safe metadata only
+  -> logger.bind(event=...).log(...)
+```
+
+Scope:
+
+- `backend/rag/observability.py` defines event kinds, error categories, config,
+  safe serialization, emission, and exception categorization.
+- `GatewayEmbedClient` emits embedding started/finished/failed events for
+  `gateway_litellm`.
+- `OllamaEmbedder` emits embedding started/finished/failed events for
+  `direct_ollama`.
+- `LocalRagPipeline` emits retrieval and generation lifecycle events.
+- `config/rag_config.yaml` has `rag.observability` flags and log level.
+
+Safety rules:
+
+- Events contain only safe scalar metadata.
+- Events never include query text, prompt text, answer text, chunk text,
+  document text, vectors, Qdrant payloads, portfolio data, API keys,
+  Authorization headers, tokens, passwords, or secrets.
+- No return values change.
+- Retry/backoff/concurrency semantics are unchanged.
+- Qdrant is not mutated and `openclaw_knowledge` is not touched.
+
+Out of scope:
+
+- OpenTelemetry, Prometheus, Grafana, dashboards, distributed tracing,
+  profiling, soak tests, and memory/resource baselines.
+- GW-12 remains the memory/resource baseline follow-up.

--- a/docs/RAG_OBSERVABILITY_EVENTS.md
+++ b/docs/RAG_OBSERVABILITY_EVENTS.md
@@ -1,0 +1,107 @@
+# RAG Observability Events
+
+GW-11 adds safe local lifecycle events for RAG operations.
+
+These events are loguru structured logs only. They are not OpenTelemetry,
+remote telemetry, distributed tracing, profiling, dashboards, Prometheus,
+Grafana, soak testing, or memory/resource baselines.
+
+## Purpose
+
+`RagObservabilityEvent` records safe metadata for lifecycle stages:
+
+- embedding calls
+- retrieval
+- generation
+- collection guard warnings or errors when a caller already has that context
+
+`RagRunTrace` and `RagObservabilityEvent` are different:
+
+- `RagRunTrace` is the final per-query provenance record emitted after a RAG
+  query completes.
+- `RagObservabilityEvent` is a lifecycle event emitted around internal stages.
+
+## Event Kinds
+
+- `embedding_call_started`
+- `embedding_call_finished`
+- `embedding_call_failed`
+- `retrieval_started`
+- `retrieval_finished`
+- `retrieval_failed`
+- `generation_started`
+- `generation_finished`
+- `generation_failed`
+- `collection_guard_warning`
+- `collection_guard_error`
+
+## Safe Fields
+
+Events may include only safe scalar metadata:
+
+- event kind
+- timestamp
+- backend
+- alias
+- model
+- dimensions
+- latency
+- chunk count
+- batch size
+- status
+- error category
+- collection name
+- query id
+- gateway alias
+
+## Forbidden Content
+
+Events must never include:
+
+- query text
+- prompt text
+- answer text
+- chunk or document text
+- vectors or embedding values
+- Qdrant payloads
+- portfolio data
+- API keys
+- Authorization headers
+- tokens
+- passwords
+- secrets
+
+Serialization uses an explicit allowlist and omits `None` values.
+
+## Config
+
+```yaml
+rag:
+  observability:
+    enabled: true
+    log_level: "INFO"
+    embedding_events_enabled: true
+    retrieval_events_enabled: true
+    generation_events_enabled: true
+    collection_guard_events_enabled: true
+```
+
+Allowed log levels are `DEBUG`, `INFO`, and `WARNING`.
+
+## Current Integration
+
+GW-11 emits embedding lifecycle events from:
+
+- `GatewayEmbedClient` with `backend="gateway_litellm"`
+- `OllamaEmbedder` with `backend="direct_ollama"`
+
+It also emits retrieval and generation lifecycle events from
+`LocalRagPipeline` when enabled.
+
+Return values, retry/backoff/concurrency behavior, Qdrant collections, and
+default embedding selection are unchanged.
+
+## Future Work
+
+GW-12 remains the place for memory/resource baseline work. OpenTelemetry or
+remote observability is not part of GW-11.

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -73,5 +73,6 @@ semantics.
 
 ## Future Work
 
-- GW-11 will add structured observability lifecycle events.
+- GW-11 adds structured observability lifecycle events separately in
+  `RagObservabilityEvent`.
 - GW-12 will add memory/resource baseline work.

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -11,6 +11,9 @@ GW-07 adds optional synthetic RAG E2E smoke for the current production-safe path
 direct Ollama embeddings, temporary Qdrant collection, and LiteLLM generation.
 GW-08 adds controlled RAG embedding migration for new ingest/test paths through
 `quimera_embed` and keeps `direct_ollama` as rollback.
+GW-09 adds read-only collection metadata drift detection.
+GW-10 adds the final safe per-query `RagRunTrace` provenance record.
+GW-11 adds local structured RAG lifecycle events with safe metadata only.
 The default runtime path is:
 
 ```text
@@ -331,7 +334,47 @@ rag:
 ```
 
 Allowed log levels are `DEBUG`, `INFO`, and `WARNING`. GW-10 is provenance
-only; GW-11 is reserved for structured observability lifecycle events.
+only; GW-11 lifecycle events remain separate from `RagRunTrace`.
+
+## RAG Observability Events
+
+GW-11 adds local structured lifecycle events emitted with loguru:
+
+```text
+logger.bind(event=event.to_log_dict()).log(log_level, "rag_lifecycle_event")
+```
+
+Events cover embedding calls, retrieval, and generation. They are not
+OpenTelemetry, remote telemetry, distributed tracing, profiling, dashboards,
+Prometheus, Grafana, soak tests, or memory/resource baselines.
+
+Config:
+
+```yaml
+rag:
+  observability:
+    enabled: true
+    log_level: "INFO"
+    embedding_events_enabled: true
+    retrieval_events_enabled: true
+    generation_events_enabled: true
+    collection_guard_events_enabled: true
+```
+
+Allowed log levels are `DEBUG`, `INFO`, and `WARNING`.
+
+Event serialization uses an explicit allowlist and omits `None` values. Events
+may include safe metadata such as event kind, timestamp, backend, alias, model,
+dimensions, latency, chunk count, batch size, status, error category,
+collection name, query id, and gateway alias.
+
+Events never include query text, prompt text, final answer text, chunk or
+document text, vectors, embedding values, Qdrant payloads, portfolio data, API
+keys, Authorization headers, tokens, passwords, or secrets.
+
+`RagRunTrace` remains the final per-query provenance record. GW-11 lifecycle
+events are separate and do not change return values, retry/backoff/concurrency
+behavior, Qdrant collections, or default embedding selection.
 
 ## What Changed
 
@@ -362,6 +405,8 @@ only; GW-11 is reserved for structured observability lifecycle events.
   LiteLLM only for answer generation.
 - GW-07 does not touch production Qdrant collections or `openclaw_knowledge`.
 - GW-08 does not touch production Qdrant collections or `openclaw_knowledge`.
+- GW-11 does not add OpenTelemetry, remote telemetry, distributed tracing,
+  profiling, dashboards, or memory/resource baselines.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -2,7 +2,7 @@
 
 > Start each Gateway cycle by reading this file before touching Git.
 
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-01
 **Repository:** OpenClaw
 **Product:** Quimera
 **Sprint:** Gateway-0 / LiteLLM
@@ -48,13 +48,13 @@ unavoidable, use `git push --force-with-lease`.
 Current active branch:
 
 ```text
-feat/rag-run-trace-provenance
+feat/rag-observability-events
 ```
 
 Current issue:
 
 ```text
-https://github.com/franciscosalido/OPENCLAW/issues/44
+https://github.com/franciscosalido/OPENCLAW/issues/46
 ```
 
 Gateway baseline already merged:
@@ -67,7 +67,8 @@ GW-06 local_embed evaluation and GW06C embeddings contract are merged.
 GW-07 synthetic RAG E2E is merged in 814b59d.
 GW-08 controlled embedding migration is merged in 1a3bf32.
 GW-09 collection metadata guard is merged in 254a840.
-GW-10 branches from the post-GW09 baseline.
+GW-10 safe RagRunTrace provenance is merged in 7b2c81b.
+GW-11 branches from the post-GW10 baseline.
 ```
 
 Gateway PR state:
@@ -85,7 +86,8 @@ Gateway PR state:
 | GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | Merged |
 | GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Merged in `1a3bf32` |
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard for embedding traceability | Merged in `254a840` |
-| GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Current |
+| GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Merged in `7b2c81b` |
+| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Current |
 
 ---
 
@@ -227,7 +229,7 @@ GW-07:
 - Use `GatewayChatClient`/`LocalGenerator` through LiteLLM for generation.
 - Do not touch `openclaw_knowledge`.
 
-## GW-07 Current Work
+## GW-07 Completed Work
 
 Objective:
 
@@ -345,7 +347,7 @@ export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
 scripts/test_rag_e2e_gateway.sh
 ```
 
-## GW-08 Current Work
+## GW-08 Completed Work
 
 Objective:
 
@@ -420,7 +422,7 @@ Observed results:
 | cosine similarity vs direct Ollama | 1.000000 |
 | vector dimensions | 768 |
 
-## GW-09 Current Work
+## GW-09 Completed Work
 
 Objective:
 
@@ -446,7 +448,7 @@ Out of scope:
 - Changing the active embedder/model.
 - Automatic healing.
 - `RagRunTrace` (GW-10).
-- Structured embedding observability events (GW-11).
+- Structured RAG observability lifecycle events are handled in GW-11.
 
 Safety notes:
 
@@ -455,7 +457,7 @@ Safety notes:
 - It must not log payload text, vectors, prompts, secrets, or Authorization
   headers.
 
-## GW-10 Current Work
+## GW-10 Completed Work
 
 Objective:
 
@@ -473,7 +475,7 @@ Scope:
 Out of scope:
 
 - OpenTelemetry, Prometheus, Grafana, dashboards, soak tests, and profiling.
-- GW-11 structured observability lifecycle events.
+- GW-11 adds structured observability lifecycle events separately.
 - GW-12 memory/resource baseline.
 - Qdrant mutation, reindexing, collection updates, and `openclaw_knowledge`.
 
@@ -484,3 +486,36 @@ Safety notes:
   vectors, payloads, portfolio data, private documents, API keys,
   Authorization headers, or secrets.
 - Dimension mismatch raises `EmbeddingDimensionMismatchError`.
+
+## GW-11 Current Work
+
+Objective:
+
+Add safe local structured lifecycle events for RAG operations without changing
+runtime behavior.
+
+Scope:
+
+- New `backend/rag/observability.py` module.
+- Frozen `RagObservabilityEvent` dataclass with explicit allowlist
+  serialization.
+- `RagEventKind` and `RagErrorCategory` enums.
+- `RagObservabilityConfig` loaded from `rag.observability`.
+- Embedding lifecycle events in `GatewayEmbedClient` and `OllamaEmbedder`.
+- Retrieval and generation lifecycle events in `LocalRagPipeline`.
+
+Out of scope:
+
+- OpenTelemetry, Prometheus, Grafana, dashboards, distributed tracing,
+  profiling, soak tests, and memory/resource baseline.
+- Qdrant mutation, reindexing, collection updates, and `openclaw_knowledge`.
+- Any default embedder change or retry/backoff/concurrency change.
+
+Safety notes:
+
+- Events contain safe scalar metadata only.
+- Events must not include query text, prompt text, answer text, chunk text,
+  document text, vectors, Qdrant payloads, portfolio data, API keys,
+  Authorization headers, tokens, passwords, or secrets.
+- `RagRunTrace` remains the final per-query provenance record; GW-11 lifecycle
+  events are separate.

--- a/tests/unit/test_embeddings_observability.py
+++ b/tests/unit/test_embeddings_observability.py
@@ -80,6 +80,63 @@ class OllamaEmbedderObservabilityTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(events[1]["error_category"], "invalid_response")
         self.assertNotIn("texto que nao pode aparecer", str(events))
 
+    async def test_ollama_embed_batch_emits_only_batch_level_events(self) -> None:
+        events: list[dict[str, object]] = []
+        requested_inputs: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            payload = request.read().decode("utf-8")
+            requested_inputs.append(payload)
+            value = float(len(requested_inputs))
+            return httpx.Response(200, json={"embeddings": [[value, value + 0.1]]})
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            async with httpx.AsyncClient(
+                base_url="http://ollama.test",
+                transport=httpx.MockTransport(handler),
+            ) as client:
+                embedder = OllamaEmbedder(
+                    client=client,
+                    expected_dimensions=2,
+                    max_concurrency=1,
+                    observability_config=RagObservabilityConfig(enabled=True),
+                )
+                vectors = await embedder.embed_batch(
+                    [
+                        "texto um sigiloso",
+                        "texto dois sigiloso",
+                        "texto tres sigiloso",
+                    ]
+                )
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(vectors, [[1.0, 1.1], [2.0, 2.1], [3.0, 3.1]])
+        self.assertEqual(len(requested_inputs), 3)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["embedding_call_started", "embedding_call_finished"],
+        )
+        self.assertEqual(events[0]["batch_size"], 3)
+        self.assertEqual(events[1]["batch_size"], 3)
+        joined = str(events)
+        self.assertNotIn("texto um sigiloso", joined)
+        self.assertNotIn("texto dois sigiloso", joined)
+        self.assertNotIn("texto tres sigiloso", joined)
+        self.assertNotIn("embeddings", joined.lower())
+        self.assertNotIn("authorization", joined.lower())
+        self.assertNotIn("api_key", joined.lower())
+        self.assertNotIn("prompt", joined.lower())
+        self.assertNotIn("answer", joined.lower())
+        self.assertNotIn("chunk", joined.lower())
+
     async def test_ollama_retry_behavior_remains_unchanged(self) -> None:
         attempts = 0
         sleeps: list[float] = []

--- a/tests/unit/test_embeddings_observability.py
+++ b/tests/unit/test_embeddings_observability.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from backend.rag.embeddings import EmbeddingError, OllamaEmbedder
+from backend.rag.observability import RagObservabilityConfig
+
+
+class OllamaEmbedderObservabilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_ollama_embed_success_emits_started_and_finished_events(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            async with httpx.AsyncClient(
+                base_url="http://ollama.test",
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(200, json={"embeddings": [[0.1, 0.2]]})
+                ),
+            ) as client:
+                embedder = OllamaEmbedder(
+                    client=client,
+                    expected_dimensions=2,
+                    observability_config=RagObservabilityConfig(enabled=True),
+                )
+                vector = await embedder.embed("texto sintetico confidencial")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(vector, [0.1, 0.2])
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["embedding_call_started", "embedding_call_finished"],
+        )
+        self.assertEqual(events[0]["backend"], "direct_ollama")
+        self.assertEqual(events[0]["alias"], "nomic-embed-text")
+        self.assertEqual(events[1]["status"], "success")
+        self.assertNotIn("texto sintetico confidencial", str(events))
+
+    async def test_ollama_embed_failure_emits_failed_event(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            async with httpx.AsyncClient(
+                base_url="http://ollama.test",
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(200, json={"embeddings": [[0.1]]})
+                ),
+            ) as client:
+                embedder = OllamaEmbedder(
+                    client=client,
+                    expected_dimensions=2,
+                    observability_config=RagObservabilityConfig(enabled=True),
+                )
+                with self.assertRaises(EmbeddingError):
+                    await embedder.embed("texto que nao pode aparecer")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["embedding_call_started", "embedding_call_failed"],
+        )
+        self.assertEqual(events[1]["status"], "failed")
+        self.assertEqual(events[1]["error_category"], "invalid_response")
+        self.assertNotIn("texto que nao pode aparecer", str(events))
+
+    async def test_ollama_retry_behavior_remains_unchanged(self) -> None:
+        attempts = 0
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                return httpx.Response(503, json={"error": "model loading"})
+            return httpx.Response(200, json={"embeddings": [[0.5, 0.6]]})
+
+        async with httpx.AsyncClient(
+            base_url="http://ollama.test",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            embedder = OllamaEmbedder(
+                client=client,
+                max_retries=3,
+                backoff_seconds=1.0,
+                sleep=fake_sleep,
+                expected_dimensions=2,
+                observability_config=RagObservabilityConfig(enabled=False),
+            )
+            vector = await embedder.embed("chunk")
+
+        self.assertEqual(vector, [0.5, 0.6])
+        self.assertEqual(attempts, 3)
+        self.assertEqual(sleeps, [1.0, 2.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_embed_observability.py
+++ b/tests/unit/test_gateway_embed_observability.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from backend.gateway.client import DEFAULT_LLM_BASE_URL, GatewayRuntimeConfig
+from backend.gateway.embed_client import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    GatewayEmbedClient,
+)
+from backend.gateway.errors import GatewayConnectionError
+from backend.rag.observability import RagObservabilityConfig
+
+
+def _embedding_response() -> dict[str, object]:
+    return {
+        "data": [
+            {
+                "index": 0,
+                "embedding": [0.1] * DEFAULT_EMBEDDING_DIMENSIONS,
+            }
+        ]
+    }
+
+
+class GatewayEmbedObservabilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_gateway_embed_success_emits_started_and_finished_events(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            async with httpx.AsyncClient(
+                base_url=DEFAULT_LLM_BASE_URL,
+                transport=httpx.MockTransport(
+                    lambda _request: httpx.Response(200, json=_embedding_response())
+                ),
+            ) as client:
+                gateway = GatewayEmbedClient(
+                    config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                    client=client,
+                    observability_config=RagObservabilityConfig(
+                        enabled=True,
+                        log_level="INFO",
+                    ),
+                )
+                vector = await gateway.embed("texto sensivel sintetico")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(len(vector), DEFAULT_EMBEDDING_DIMENSIONS)
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["embedding_call_started", "embedding_call_finished"],
+        )
+        self.assertEqual(events[0]["backend"], "gateway_litellm")
+        self.assertEqual(events[0]["alias"], "quimera_embed")
+        self.assertEqual(events[1]["status"], "success")
+        self.assertEqual(events[1]["batch_size"], 1)
+        joined = str(events)
+        self.assertNotIn("texto sensivel sintetico", joined)
+        self.assertNotIn("secret-test-key", joined)
+
+    async def test_gateway_embed_failure_emits_failed_safe_category(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("secret connection detail")
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        async def fake_sleep(_seconds: float) -> None:
+            return None
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            async with httpx.AsyncClient(
+                base_url=DEFAULT_LLM_BASE_URL,
+                transport=httpx.MockTransport(handler),
+            ) as client:
+                gateway = GatewayEmbedClient(
+                    config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                    client=client,
+                    max_retries=0,
+                    sleep=fake_sleep,
+                    observability_config=RagObservabilityConfig(enabled=True),
+                )
+                with self.assertRaises(GatewayConnectionError):
+                    await gateway.embed("texto que nao deve ir ao log")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(
+            [event["event_kind"] for event in events],
+            ["embedding_call_started", "embedding_call_failed"],
+        )
+        self.assertEqual(events[1]["status"], "failed")
+        self.assertEqual(events[1]["error_category"], "connection")
+        joined = str(events)
+        self.assertNotIn("texto que nao deve ir ao log", joined)
+        self.assertNotIn("secret-test-key", joined)
+        self.assertNotIn("secret connection detail", joined)
+
+    async def test_gateway_embed_retry_behavior_remains_unchanged(self) -> None:
+        calls = 0
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                return httpx.Response(503)
+            return httpx.Response(200, json=_embedding_response())
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayEmbedClient(
+                config=GatewayRuntimeConfig(api_key="dev-key"),
+                client=client,
+                sleep=fake_sleep,
+                observability_config=RagObservabilityConfig(enabled=False),
+            )
+            vector = await gateway.embed("texto sintetico")
+
+        self.assertEqual(len(vector), DEFAULT_EMBEDDING_DIMENSIONS)
+        self.assertEqual(calls, 3)
+        self.assertEqual(sleeps, [1.0, 2.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_observability_config.py
+++ b/tests/unit/test_rag_observability_config.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from backend.rag.observability import (
+    RagEventKind,
+    RagObservabilityConfig,
+    RagObservabilityEvent,
+    emit_rag_event,
+    load_rag_observability_config,
+)
+
+
+class RagObservabilityConfigTests(unittest.TestCase):
+    def test_config_accepts_supported_log_levels(self) -> None:
+        for level in ("DEBUG", "INFO", "WARNING", "info"):
+            config = RagObservabilityConfig(log_level=level).validated()
+            self.assertIn(config.log_level, {"DEBUG", "INFO", "WARNING"})
+
+    def test_config_rejects_invalid_log_level(self) -> None:
+        with self.assertRaises(ValueError):
+            RagObservabilityConfig(log_level="TRACE").validated()
+
+    def test_load_config_reads_rag_observability_yaml(self) -> None:
+        config_path = Path("tests/tmp_rag_observability_config.yaml")
+        config_path.write_text(
+            """
+rag:
+  observability:
+    enabled: true
+    log_level: "DEBUG"
+    embedding_events_enabled: true
+    retrieval_events_enabled: false
+    generation_events_enabled: true
+    collection_guard_events_enabled: false
+""",
+            encoding="utf-8",
+        )
+        try:
+            config = load_rag_observability_config(config_path)
+        finally:
+            config_path.unlink()
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.log_level, "DEBUG")
+        self.assertTrue(config.embedding_events_enabled)
+        self.assertFalse(config.retrieval_events_enabled)
+        self.assertTrue(config.generation_events_enabled)
+        self.assertFalse(config.collection_guard_events_enabled)
+
+    def test_emit_rag_event_emits_loguru_bound_event(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            emit_rag_event(
+                RagObservabilityEvent(
+                    event_kind=RagEventKind.RETRIEVAL_STARTED,
+                    timestamp_utc="2026-05-01T00:00:00Z",
+                    backend="gateway_litellm_current",
+                    alias="quimera_embed",
+                    status="started",
+                ),
+                RagObservabilityConfig(enabled=True, log_level="INFO"),
+            )
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["event_kind"], "retrieval_started")
+        self.assertEqual(events[0]["status"], "started")
+
+    def test_emit_rag_event_emits_nothing_when_disabled(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            emit_rag_event(
+                RagObservabilityEvent(
+                    event_kind=RagEventKind.RETRIEVAL_STARTED,
+                    timestamp_utc="2026-05-01T00:00:00Z",
+                    backend="gateway_litellm_current",
+                    alias="quimera_embed",
+                    status="started",
+                ),
+                RagObservabilityConfig(enabled=False),
+            )
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_observability_event.py
+++ b/tests/unit/test_rag_observability_event.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import dataclasses
+import unittest
+
+from backend.rag.observability import (
+    FORBIDDEN_OBSERVABILITY_KEYS,
+    RagErrorCategory,
+    RagEventKind,
+    RagObservabilityEvent,
+)
+
+
+def _event(**overrides: object) -> RagObservabilityEvent:
+    values: dict[str, object] = {
+        "event_kind": RagEventKind.EMBEDDING_CALL_STARTED,
+        "timestamp_utc": "2026-05-01T00:00:00Z",
+        "backend": "gateway_litellm",
+        "alias": "quimera_embed",
+    }
+    values.update(overrides)
+    return RagObservabilityEvent(**values)  # type: ignore[arg-type]
+
+
+class RagObservabilityEventTests(unittest.TestCase):
+    def test_event_dataclass_is_frozen(self) -> None:
+        event = _event()
+
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            event.alias = "other"  # type: ignore[misc]
+
+    def test_to_log_dict_uses_allowlist_and_converts_enums(self) -> None:
+        data = _event(
+            event_kind=RagEventKind.EMBEDDING_CALL_FAILED,
+            error_category=RagErrorCategory.TIMEOUT,
+            latency_ms=12.5,
+            batch_size=2,
+            status="failed",
+        ).to_log_dict()
+
+        self.assertEqual(data["event_kind"], "embedding_call_failed")
+        self.assertEqual(data["error_category"], "timeout")
+        self.assertEqual(data["latency_ms"], 12.5)
+        self.assertEqual(data["batch_size"], 2)
+
+    def test_to_log_dict_excludes_none_values(self) -> None:
+        data = _event().to_log_dict()
+
+        self.assertNotIn("latency_ms", data)
+        self.assertNotIn("error_category", data)
+        self.assertNotIn("collection_name", data)
+
+    def test_forbidden_content_keys_are_absent(self) -> None:
+        data = _event(
+            model="nomic-embed-text",
+            dimensions=768,
+            collection_name="synthetic_collection",
+        ).to_log_dict()
+
+        lowered_keys = {key.lower() for key in data}
+
+        self.assertTrue(FORBIDDEN_OBSERVABILITY_KEYS.isdisjoint(lowered_keys))
+
+    def test_negative_latency_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _event(latency_ms=-0.1)
+
+    def test_negative_chunk_count_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _event(chunk_count=-1)
+
+    def test_invalid_batch_size_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _event(batch_size=0)
+
+    def test_invalid_dimensions_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _event(dimensions=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_pipeline_observability.py
+++ b/tests/unit/test_rag_pipeline_observability.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from loguru import logger
+
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.observability import RagObservabilityConfig
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.run_trace import RagTracingConfig
+
+
+class FakeStore:
+    collection_name = "synthetic_observability_collection"
+
+
+class FakeRetriever:
+    store = FakeStore()
+
+    async def retrieve(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[RetrievedChunk]:
+        return [
+            RetrievedChunk(
+                id="obs_doc:0",
+                score=0.91,
+                doc_id="obs_doc",
+                chunk_index=0,
+                text="chunk text must never appear in lifecycle events",
+                token_count=8,
+                rank=1,
+                payload={"secret": "do-not-log"},
+            )
+        ]
+
+
+class FakeGenerator:
+    model = "local_rag"
+
+    async def chat(
+        self,
+        messages: Sequence[dict[str, str]],
+        temperature: float | None = None,
+        thinking_mode: bool = False,
+    ) -> str:
+        return "Resposta sintetica com citacao [obs_doc#0]."
+
+
+def _tracing_config(enabled: bool = True) -> RagTracingConfig:
+    return RagTracingConfig(
+        enabled=enabled,
+        log_level="INFO",
+        collection_name="configured_collection",
+        embedding_backend="gateway_litellm_current",
+        embedding_model="nomic-embed-text",
+        embedding_alias="quimera_embed",
+        embedding_dimensions=768,
+    ).validated()
+
+
+class RagPipelineObservabilityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pipeline_emits_retrieval_and_generation_events(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            pipeline = LocalRagPipeline(
+                retriever=FakeRetriever(),
+                generator=FakeGenerator(),
+                prompt_builder=PromptBuilder(),
+                tracing_config=_tracing_config(),
+                observability_config=RagObservabilityConfig(enabled=True),
+            )
+            await pipeline.ask("Pergunta sintetica segura?")
+        finally:
+            logger.remove(sink_id)
+
+        kinds = [event["event_kind"] for event in events]
+        self.assertEqual(
+            kinds,
+            [
+                "retrieval_started",
+                "retrieval_finished",
+                "generation_started",
+                "generation_finished",
+            ],
+        )
+        self.assertTrue(all(event["query_id"] == events[0]["query_id"] for event in events))
+        self.assertEqual(events[1]["chunk_count"], 1)
+        self.assertEqual(events[3]["gateway_alias"], "local_rag")
+        joined = str(events)
+        self.assertNotIn("Pergunta sintetica segura", joined)
+        self.assertNotIn("chunk text must never appear", joined)
+        self.assertNotIn("do-not-log", joined)
+        self.assertNotIn("Resposta sintetica", joined)
+
+    async def test_pipeline_observability_disabled_emits_no_events(self) -> None:
+        events: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            event = message.record["extra"].get("event")
+            if isinstance(event, dict):
+                events.append(event)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            pipeline = LocalRagPipeline(
+                retriever=FakeRetriever(),
+                generator=FakeGenerator(),
+                prompt_builder=PromptBuilder(),
+                tracing_config=_tracing_config(enabled=False),
+                observability_config=RagObservabilityConfig(enabled=False),
+            )
+            await pipeline.ask("Pergunta sintetica segura?")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds safe local structured RAG lifecycle observability events for GW-11.

This PR introduces `RagObservabilityEvent` as a metadata-only lifecycle event separate from the final per-query `RagRunTrace` provenance record.

Implemented lifecycle coverage:

- Gateway embedding calls through `GatewayEmbedClient`
- Direct Ollama embedding calls through `OllamaEmbedder`
- Retrieval start/finish/failure in `LocalRagPipeline`
- Generation start/finish/failure in `LocalRagPipeline`

Closes #46.

## Scope

Included:

- `backend/rag/observability.py`
- `RagEventKind` and `RagErrorCategory`
- Frozen `RagObservabilityEvent`
- Explicit allowlist `to_log_dict()` serialization
- `RagObservabilityConfig` loaded from `rag.observability`
- Safe loguru emission via `logger.bind(event=...).log(...)`
- Exception categorization without logging exception messages
- Unit tests for event safety, config, gateway embeddings, direct embeddings and pipeline lifecycle events
- Documentation for GW-11 and the distinction from `RagRunTrace`

Excluded:

- OpenTelemetry
- Prometheus/Grafana/dashboards
- Distributed tracing
- Profiling, soak tests or memory/resource baseline
- Qdrant mutation or reindexing
- Default embedder changes
- Retry/backoff/concurrency behavior changes
- Remote providers, FastAPI, MCP or quant tools

## Security

- No secrets committed
- `.env` untouched
- No remote providers enabled
- No query text logged
- No prompt text logged
- No answer text logged
- No chunk/document text logged
- No vectors or Qdrant payloads logged
- No API keys, Authorization headers, tokens, passwords or secrets logged

## Validation

```bash
git diff --check
uv run pytest tests/unit/test_rag_observability_event.py -v
uv run pytest tests/unit/test_rag_observability_config.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Results:

- `uv run pytest -v`: 214 passed, 7 skipped
- `uv run mypy --strict .`: success
- `uv run pyright`: 0 errors
- `uv run pytest tests/smoke/ -v`: 5 passed, 7 skipped
- `git diff --check`: OK

## Notes

`RagRunTrace` remains the final per-query provenance record. GW-11 lifecycle events are local structured logs only and do not alter return values or runtime retry/backoff/concurrency semantics.
