### PR TITLE
chore(gateway): finalize Gateway-0 operational readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,11 +101,11 @@ Do not read the whole repo. Do not open node_modules, .venv, dist, caches, or la
 
 ---
 
-## Current Sprint: Gateway-0 — LiteLLM Local Gateway
+## Current Sprint: Gateway-0 — LiteLLM Local Gateway Final Readiness
 
 **Goal:** Route all OpenClaw runtime model calls through LiteLLM at `localhost:4000/v1` while preserving existing RAG/Qdrant behavior.
 
-**Semantic aliases:** `local_chat` (30s) · `local_think` (120s) · `local_rag` (60s) · `local_json` (30s) · `local_embed` (30s placeholder)
+**Semantic aliases:** `local_chat` (30s) · `local_think` (120s) · `local_rag` (60s) · `local_json` (30s) · `quimera_embed` (30s canonical embeddings) · `local_embed` (30s compatibility)
 
 ### RAG-0 Sprint — COMPLETE ✅
 
@@ -121,7 +121,7 @@ Do not read the whole repo. Do not open node_modules, .venv, dist, caches, or la
 | RAG-06 | feat/rag-cli-smoke | ✅ MERGED | synthetic ingest/query CLI + preflight + smoke |
 | RAG-07 | feat/rag-docs-runbook | ✅ MERGED | ADR + runbook + shared validation + health tests |
 
-### Gateway-0 Sprint — IN PROGRESS 🔄
+### Gateway-0 Sprint — FINAL READINESS 🔄
 
 | PR | Branch | Status | Scope |
 |---|---|---|---|
@@ -131,10 +131,18 @@ Do not read the whole repo. Do not open node_modules, .venv, dist, caches, or la
 | GW-04 | feat/gateway-runtime-smoke | ✅ MERGED | validate_chat_messages, observability, optional smoke |
 | GW-05a | feat/gateway-per-alias-timeouts | ✅ MERGED | Per-alias timeout configuration |
 | GW-05b | feat/gateway-live-smoke-timeouts | ✅ MERGED | Live smoke + timeout observability (128/128, 7/7 smoke) |
-| GW-06 | TBD | ⏳ NEXT | Evaluate embeddings via local_embed |
-| GW-07 | TBD | ⏳ Planned | Synthetic RAG E2E through gateway |
-| GW-08 | TBD | ⏳ Planned | Runbook hardening |
-| GW-09 | TBD | ⏳ Planned | MCP/tooling evaluation |
+| GW-06 | feat/gateway-local-embed-evaluation | ✅ MERGED | Evaluate embeddings via local_embed |
+| GW06C | feat/adr-openai-compatible-embeddings-contract | ✅ MERGED | quimera_embed canonical embeddings ADR |
+| GW-07 | feat/gateway-rag-e2e-synthetic | ✅ MERGED | Synthetic RAG E2E through gateway |
+| GW-08 | feat/rag-controlled-embedding-migration | ✅ MERGED | Controlled embedding migration to quimera_embed |
+| GW-09 | feat/rag-collection-metadata-guard | ✅ MERGED | Collection metadata drift guard |
+| GW-10 | feat/rag-run-trace-provenance | ✅ MERGED | RagRunTrace safe provenance |
+| GW-11 | feat/rag-observability-events | ✅ MERGED | Local structured RAG lifecycle events |
+| GW-12 | feat/gateway-operational-readiness | 🔄 CURRENT FINAL PR | Final runbook, readiness checks, ADR boundary |
+
+Gateway-0 remains local-only. Remote providers, FastAPI, MCP, quant tools,
+OpenTelemetry, profiling, dashboards, production ingestion and
+`openclaw_knowledge` mutation require a future issue and explicit ADR/sprint.
 
 ### Merge Criteria (every PR)
 

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -100,10 +100,10 @@ RAG-0 is **local only**. No remote AI fallback in this sprint.
 - Product name: Quimera.
 - Repository name: OpenClaw.
 - Model gateway: LiteLLM at `http://127.0.0.1:4000/v1` (Gateway-0 — local only).
-- Semantic aliases: `local_chat`, `local_think`, `local_rag`, `local_json`, `local_embed`.
-- Local LLM runtime: Ollama (via LiteLLM gateway for chat; direct for embeddings until Gateway-1).
+- Semantic aliases: `local_chat`, `local_think`, `local_rag`, `local_json`, `quimera_embed`, `local_embed`.
+- Local LLM runtime: Ollama through LiteLLM for chat and controlled gateway embeddings.
 - Primary local generation model: `qwen3:14b` (vendor name confined to LiteLLM config — application code uses aliases).
-- Embedding model: `nomic-embed-text` (direct Ollama until a tested embedding-gateway PR).
+- Embedding model: `nomic-embed-text`; application-facing alias is `quimera_embed`, with `direct_ollama` rollback retained.
 - Vector database: Qdrant.
 - Mathematical co-processor: deterministic Python modules.
 - Remote AI: disabled. Sanitized fallback only after explicit sprint approval.
@@ -119,6 +119,8 @@ Runtime env vars (must be set locally before running OpenClaw):
 | `QUIMERA_LLM_REASONING_MODEL` | `local_think` | Semantic alias |
 | `QUIMERA_LLM_RAG_MODEL` | `local_rag` | Semantic alias |
 | `QUIMERA_LLM_JSON_MODEL` | `local_json` | Semantic alias |
+| `QUIMERA_LLM_EMBED_MODEL` | `quimera_embed` | Canonical embedding alias |
+| `QUIMERA_RAG_EMBEDDING_BACKEND` | `gateway_litellm` | Use `direct_ollama` for rollback |
 
 ---
 
@@ -150,7 +152,7 @@ SyntheticDocument
 | RAG-06 | `feat/rag-cli-smoke` | Synthetic ingest/query CLI + preflight + smoke | ✅ Merged |
 | RAG-07 | `feat/rag-docs-runbook` | Runbook + ADR + shared validation + health tests | ✅ Merged |
 
-### Sprint Gateway-0 — IN PROGRESS 🔄
+### Sprint Gateway-0 — FINAL READINESS 🔄
 
 Runtime path base merged to `main`:
 
@@ -161,28 +163,31 @@ OpenClaw / LocalGenerator
   -> Ollama / Qwen local
 ```
 
-| PR | Commit | Scope | Status |
+| PR | Branch | Scope | Status |
 |---|---|---|---|
-| GW-01 | `e7509fa` | Pydantic schema, health checks, stable error taxonomy | ✅ Merged (#23) |
-| GW-02 | `8b62e21` | infra/litellm/, start script, supply-chain guards | ✅ Merged (#23) |
-| GW-03 | `10708fa` | `GatewayChatClient`, route `LocalGenerator` → LiteLLM, validation-before-resource fix | ✅ Merged (#23) |
-| GW-04 | `b5947bd` | `validate_chat_messages`, observability, optional smoke (skipado) | ✅ Merged (#23) |
-| fix | `2d8a8b5` | `test_litellm_infra_scripts.py` follow-up | ✅ Merged (#24) |
-| GW-05 | — | Live smoke real com LiteLLM + Ollama rodando | ⏳ Próximo |
-| GW-06 | — | Embeddings via LiteLLM / `local_embed` | ⏳ Planejado |
-| GW-07 | — | RAG E2E sintético completo via gateway | ⏳ Planejado |
-| GW-08 | — | Runbook hardening para gateway | ⏳ Planejado |
-| GW-09 | — | MCP/tooling evaluation | ⏳ Planejado |
+| GW-01 | `feat/gateway-prep-contracts` | Contracts, ADR, aliases | ✅ Merged |
+| GW-02 | `feat/gateway-install-health` | Local LiteLLM operational setup | ✅ Merged |
+| GW-03 | `feat/gateway-route-opencraw-litellm` | Runtime chat/generation through LiteLLM | ✅ Merged |
+| GW-04 | `feat/gateway-runtime-smoke` | Shared validation, optional smoke | ✅ Merged |
+| GW-05a | `feat/gateway-per-alias-timeouts` | Per-alias timeout contracts | ✅ Merged |
+| GW-05b | `feat/gateway-live-smoke-timeouts` | Live gateway smoke with timeout observability | ✅ Merged |
+| GW-06 | `feat/gateway-local-embed-evaluation` | `local_embed` evaluation | ✅ Merged |
+| GW06C | `feat/adr-openai-compatible-embeddings-contract` | `quimera_embed` ADR contract | ✅ Merged |
+| GW-07 | `feat/gateway-rag-e2e-synthetic` | Synthetic RAG E2E through gateway path | ✅ Merged |
+| GW-08 | `feat/rag-controlled-embedding-migration` | Controlled embedding migration to `quimera_embed` | ✅ Merged |
+| GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard | ✅ Merged |
+| GW-10 | `feat/rag-run-trace-provenance` | `RagRunTrace` provenance | ✅ Merged |
+| GW-11 | `feat/rag-observability-events` | Local structured RAG lifecycle events | ✅ Merged |
+| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | 🔄 Current final PR |
 
-**Base validada:** 115/115 pytest, 2 skipped (smoke live — intencionalmente skipado sem serviços), mypy 0, pyright 0.
-**Working tree:** limpo. Todos os branches Gateway deletados.
+**Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
+`quimera_embed` canonical embedding alias, `RagRunTrace` provenance,
+`RagObservabilityEvent` lifecycle logs, and `scripts/check_gateway_readiness.sh`.
 
-### GW-05 — Acceptance criteria (próximo PR)
-
-- Smoke real: `RUN_LITELLM_SMOKE=1` com LiteLLM + Ollama ativos deve passar os 4 aliases.
-- `scripts/test_opencraw_litellm_runtime.sh` executado end-to-end com serviços locais.
-- Per-alias timeout: `local_think` (120s) separado de `local_chat` (30s) — hoje compartilham `timeout_seconds` global.
-- Nenhum dado real, sem remote, sem FastAPI, sem MCP.
+**Out of scope after Gateway-0:** remote providers, FastAPI, MCP, quant tools,
+OpenTelemetry, profiling, dashboards, production ingestion and
+`openclaw_knowledge` mutation. Each requires a new issue and explicit future
+ADR/sprint.
 
 Before starting a new PR:
 

--- a/docs/04_MEM/GATEWAY0_STATUS.md
+++ b/docs/04_MEM/GATEWAY0_STATUS.md
@@ -1,5 +1,12 @@
 # Gateway-0 Sprint — Status para Retomada
 
+> **Superseded status note (2026-05-01):** this file preserves an old
+> recovery snapshot from 2026-04-26. The current Gateway-0 source of truth is
+> `docs/sprints/GATEWAY_SPRINT_HANDOFF.md`,
+> `docs/04_MEM/current_state.md`, and `docs/GATEWAY_FINAL_RUNBOOK.md`.
+> Gateway-0 is in GW-12 final operational readiness; GW-01 through GW-11 are
+> merged, and GW-12 closes the sprint with runbook/readiness/boundary docs.
+
 > Arquivo gerado ao fim da sessão 2026-04-26.
 > Leia este arquivo antes de qualquer operação git amanhã.
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,11 +5,11 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Gateway GW-11 RAG observability events
+**Updated by:** Codex — Gateway GW-12 operational readiness
 
 ---
 
-## Active Sprint: Gateway-0 / LiteLLM
+## Active Sprint: Gateway-0 / LiteLLM Final Readiness
 
 **Goal:** make LiteLLM the local-only model gateway for OpenClaw runtime model
 calls while preserving existing RAG/Qdrant behavior.
@@ -105,7 +105,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Done / merged |
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard for embedding traceability | Done / merged |
 | GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Done / merged |
-| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Current |
+| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
+| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Current final PR |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -115,6 +116,11 @@ GW-08 issue: <https://github.com/franciscosalido/OPENCLAW/issues/40>
 GW-09 issue: <https://github.com/franciscosalido/OPENCLAW/issues/42>
 GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
 GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
+GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
+
+After GW-12 merges, Gateway-0 PRs GW-01 through GW-12 are complete on `main`.
+The next sprint must start from a new explicit issue, ADR if architecture
+changes, and `git pull --ff-only origin main`.
 
 ---
 
@@ -134,7 +140,30 @@ Unknown aliases and `None` fall back to the global `timeout_seconds`.
 
 ---
 
-## Next Planned Work
+## GW-12 Current Work
+
+GW-12 closes Gateway-0 as an operational readiness PR, not a feature PR.
+
+Deliverables:
+
+- `docs/GATEWAY_FINAL_RUNBOOK.md`.
+- `scripts/check_gateway_readiness.sh` with static default mode and explicit
+  `--live`.
+- `tests/unit/test_gateway_readiness_script.py`.
+- `tests/unit/test_gateway_final_baseline.py`.
+- `docs/ADR/0019-gateway-0-sprint-boundary.md`.
+- Final updates to shared context, setup, runtime and handoff docs.
+
+Rules:
+
+- No runtime architecture change.
+- No remote providers.
+- No FastAPI, MCP, quant tools, OpenTelemetry, Prometheus, Grafana,
+  dashboards, profiling, or mandatory soak tests.
+- No Qdrant mutation, no reindexing, no `openclaw_knowledge` access.
+- Live proof remains opt-in and must not become CI.
+
+## Historical Work
 
 GW-05b:
 
@@ -404,7 +433,7 @@ uv run pyright
 uv run pytest tests/smoke/ -v
 ```
 
-## GW-11 Current Work
+## GW-11 Completed Work
 
 GW-11 adds local structured RAG lifecycle observability events:
 

--- a/docs/04_MEM/decisions.md
+++ b/docs/04_MEM/decisions.md
@@ -283,3 +283,15 @@ substitution without rewriting the caller layer.
 **Consequence:** GW-06 evaluation (cosine similarity 1.0, 768d parity)
 provides the evidence base for a future migration, but GW06C does not migrate
 production RAG embeddings and does not reindex Qdrant.
+
+---
+
+## ADR-019 — Gateway-0 Sprint Boundary
+
+**Date:** 2026-05-01 | **Status:** Accepted
+
+**Decision:** Gateway-0 closes as a local-only operational baseline: LiteLLM is the model gateway, Qdrant remains the vector store, `quimera_embed` is the canonical embedding alias, `RagRunTrace` is safe per-query provenance, and `RagObservabilityEvent` is local lifecycle logging.
+
+**Boundary:** No remote providers, FastAPI, MCP, quant tools, OpenTelemetry, profiling, dashboards, production ingestion, real portfolio data, or `openclaw_knowledge` mutation are included in Gateway-0.
+
+**Future rule:** remote providers, OpenTelemetry/profiling, and any production `openclaw_knowledge` ingestion require a new issue and explicit ADR/sprint.

--- a/docs/04_MEM/next_actions.md
+++ b/docs/04_MEM/next_actions.md
@@ -2,19 +2,21 @@
 
 > This file drives the next session. Check it off as you complete items.
 
-**Last updated:** 2026-04-26
+**Last updated:** 2026-05-01
 
 ---
 
-## Right Now — Normalize Gateway GitHub Workflow
+## Right Now — Finish GW-12 Gateway Operational Readiness
 
+- [ ] Read `docs/GATEWAY_FINAL_RUNBOOK.md`.
 - [ ] Read `docs/sprints/GATEWAY_SPRINT_HANDOFF.md`.
-- [ ] Run `git status --short --branch`.
-- [ ] Verify GitHub issues and PRs for GW-01, GW-02, GW-03, and GW-04.
-- [ ] Backfill missing issues before implementation or PR work.
-- [ ] Preserve current local Gateway work before switching branches.
-- [ ] Sync local `main` with `git pull --ff-only origin main` only after the
-      current work is preserved or intentionally split.
+- [ ] Run `scripts/check_gateway_readiness.sh`.
+- [ ] Run unit baseline gates:
+      `uv run pytest tests/unit/test_gateway_readiness_script.py tests/unit/test_gateway_final_baseline.py -v`.
+- [ ] Run full gates: `uv run pytest -v`, `uv run mypy --strict .`,
+      `uv run pyright`, `uv run pytest tests/smoke/ -v`.
+- [ ] Open PR for `feat/gateway-operational-readiness`.
+- [ ] Merge only in GitHub after review approval.
 
 ---
 
@@ -22,10 +24,7 @@
 
 | PR | Issue title | Branch |
 |---|---|---|
-| GW-01 | `[Gateway-01] LiteLLM gateway contracts and semantic aliases` | `feat/gateway-prep-contracts` |
-| GW-02 | `[Gateway-02] Local-only LiteLLM install and health scripts` | `feat/gateway-install-health` |
-| GW-03 | `[Gateway-03] Route OpenClaw runtime chat through LiteLLM` | `feat/gateway-route-opencraw-litellm` |
-| GW-04 | `[Gateway-04] Optional LiteLLM runtime smoke and observability` | `feat/gateway-runtime-smoke` |
+| GW-12 | `[GW-12] Finalize Gateway-0 operational readiness, runbook, checks and handoff` | `feat/gateway-operational-readiness` |
 
 ---
 

--- a/docs/ADR/0019-gateway-0-sprint-boundary.md
+++ b/docs/ADR/0019-gateway-0-sprint-boundary.md
@@ -1,0 +1,83 @@
+# ADR-0019: Gateway-0 Sprint Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+Gateway-0 delivered the local-first model gateway foundation for
+Quimera/OpenClaw. The sprint established LiteLLM as the local model gateway,
+kept Qdrant as the vector store, and added safe provenance and local
+observability without enabling remote providers or broad service architecture.
+
+## Decision
+
+Gateway-0 is accepted as a local-only operational baseline.
+
+Delivered components:
+
+- LiteLLM local gateway at `http://127.0.0.1:4000/v1`.
+- Ollama/Qwen local chat aliases: `local_chat`, `local_think`, `local_rag`,
+  and `local_json`.
+- `quimera_embed` as canonical embedding alias through OpenAI-compatible
+  `/v1/embeddings`.
+- `local_embed` as compatibility embedding alias.
+- Qdrant as the RAG vector store.
+- Controlled embedding migration with `direct_ollama` rollback.
+- Synthetic RAG E2E smoke with temporary collections only.
+- Collection metadata guard for embedding provenance drift.
+- `RagRunTrace` as safe per-query provenance.
+- `RagObservabilityEvent` as local lifecycle event metadata.
+- Healthcheck/readiness scripts as operational gates.
+
+## Boundaries
+
+Gateway-0 is local only.
+
+No remote provider is enabled. Future remote providers require an explicit ADR.
+
+FastAPI, MCP and quant tools are out of Gateway-0 scope.
+
+Real portfolio data, real documents, private files and Level 0 data are out of
+scope for Gateway-0 tests and smoke commands.
+
+`openclaw_knowledge` ingestion, mutation, reindexing or cleanup requires an
+explicit future sprint.
+
+## Architecture Rules
+
+- Application callers use semantic aliases, not vendor model names.
+- LiteLLM owns model-provider compatibility for gateway calls.
+- Qdrant owns vector storage; LiteLLM is not a vector database.
+- Vector metadata must preserve real embedding provider/model/dimensions.
+- Vectors from different embedding models, dimensions, providers or backends
+  must not be mixed silently in the same collection.
+- Readiness checks must be local-only and must not print secrets.
+- Live smoke must remain opt-in and must not become mandatory CI.
+
+## Observability Rules
+
+`RagRunTrace` is the final safe per-query provenance record.
+
+`RagObservabilityEvent` is a local lifecycle event for internal stages.
+
+Neither may include query text, prompt text, answer text, chunk text, document
+text, vectors, Qdrant payloads, portfolio data, API keys, Authorization
+headers, tokens, passwords or secrets.
+
+## Future Work Requiring ADR Or Sprint
+
+- Remote model providers.
+- OpenTelemetry, distributed tracing, profiling or remote observability.
+- FastAPI service layer.
+- MCP/tooling integration.
+- Quant tool management.
+- Production `openclaw_knowledge` ingestion or reindexing.
+- Any automatic collection healing or destructive Qdrant operation.
+
+## Consequences
+
+Gateway-0 closes with an operable local baseline. Future work can build on a
+documented gateway, embedding, provenance and readiness foundation without
+changing the local-only safety boundary by accident.

--- a/docs/GATEWAY_FINAL_RUNBOOK.md
+++ b/docs/GATEWAY_FINAL_RUNBOOK.md
@@ -1,0 +1,331 @@
+# Gateway-0 Final Runbook
+
+Gateway-0 is the local-only Quimera/OpenClaw model gateway baseline.
+
+It closes the implementation/configuration/observability sprint with a
+repeatable operational path for local chat, RAG generation, embeddings,
+readiness checks, rollback and troubleshooting.
+
+## Architecture Summary
+
+```text
+OpenClaw runtime generation
+  -> GatewayChatClient
+  -> LiteLLM http://127.0.0.1:4000/v1
+  -> Ollama / Qwen local
+
+RAG embeddings for new controlled paths
+  -> RagEmbedder factory
+  -> gateway_litellm
+  -> GatewayEmbedClient
+  -> LiteLLM /v1/embeddings
+  -> quimera_embed
+  -> Ollama / nomic-embed-text local
+
+RAG vectors
+  -> Qdrant http://127.0.0.1:6333
+```
+
+Gateway-0 is local only. Remote providers are disabled and require a future ADR
+before activation.
+
+## Official Boot Order
+
+1. Ollama
+2. Qdrant
+3. LiteLLM
+4. Healthcheck
+5. Gateway smoke
+6. Optional RAG smoke
+
+## Expected Local Endpoints
+
+| Service | Endpoint |
+|---|---|
+| Ollama | `http://127.0.0.1:11434` |
+| LiteLLM | `http://127.0.0.1:4000/v1` |
+| Qdrant | `http://127.0.0.1:6333` |
+
+## Required Aliases
+
+- `local_chat`
+- `local_think`
+- `local_rag`
+- `local_json`
+- `quimera_embed`
+- `local_embed`
+
+`quimera_embed` is the canonical application-facing embedding alias.
+`local_embed` remains a compatibility alias.
+
+## Required Environment Variables
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+export QUIMERA_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export QDRANT_URL="http://127.0.0.1:6333"
+```
+
+Do not commit real secrets. `.env` is not required and must not be modified by
+Gateway-0 readiness scripts.
+
+## Start And Stop Ollama
+
+Start:
+
+```bash
+ollama serve
+```
+
+Pull required models:
+
+```bash
+ollama pull qwen3:14b
+ollama pull nomic-embed-text
+ollama list
+```
+
+Check:
+
+```bash
+curl -fsS http://127.0.0.1:11434/api/tags
+```
+
+Stop:
+
+```bash
+pkill -f "ollama serve"
+```
+
+If Ollama is managed by a desktop/service manager, stop it through that
+manager instead.
+
+## Start And Stop Qdrant
+
+Start:
+
+```bash
+docker compose -f docker/docker-compose.qdrant.yml up -d
+```
+
+Check:
+
+```bash
+curl -fsS http://127.0.0.1:6333/healthz
+```
+
+Stop:
+
+```bash
+docker compose -f docker/docker-compose.qdrant.yml down
+```
+
+Do not delete, recreate, or reindex `openclaw_knowledge` without an explicit
+future sprint.
+
+## Start And Stop LiteLLM
+
+Install once:
+
+```bash
+cd infra/litellm
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Start:
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export QWEN_MODEL="qwen3:14b"
+export EMBED_MODEL="nomic-embed-text"
+./start_litellm.sh
+```
+
+Stop:
+
+```bash
+ps aux | grep '[l]itellm'
+kill <pid>
+```
+
+If LiteLLM is running in the foreground, use `Ctrl-C`.
+
+## Readiness Commands
+
+Static, CI-safe readiness:
+
+```bash
+scripts/check_gateway_readiness.sh
+```
+
+Live local readiness:
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/check_gateway_readiness.sh --live
+```
+
+Default mode is static and does not require network, secrets, live services,
+Qdrant mutation, or access to `openclaw_knowledge`.
+
+## Smoke Commands
+
+Gateway runtime smoke:
+
+```bash
+scripts/test_opencraw_litellm_runtime.sh
+RUN_LITELLM_SMOKE=1 uv run pytest tests/smoke/test_gateway_runtime_smoke.py -v
+```
+
+Embedding smoke:
+
+```bash
+scripts/test_local_embed_litellm.sh
+RUN_LITELLM_EMBED_SMOKE=1 uv run pytest tests/smoke/test_gateway_embed_smoke.py -v
+```
+
+Synthetic RAG E2E smoke:
+
+```bash
+scripts/test_rag_e2e_gateway.sh
+RUN_RAG_E2E_SMOKE=1 uv run pytest tests/smoke/test_rag_e2e_gateway_smoke.py -v
+```
+
+GW-08 controlled embedding migration smoke:
+
+```bash
+scripts/test_gw08_embedding_migration.sh
+RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1 \
+RUN_GW08_EMBEDDING_PARITY_SMOKE=1 \
+uv run pytest tests/smoke/test_rag_gateway_embedding_migration_smoke.py -v -s
+```
+
+Smoke tests are skipped by default. Live proof is explicit and must not become
+a normal CI requirement.
+
+## Rollback Commands
+
+Rollback controlled embeddings to direct Ollama:
+
+```bash
+export QUIMERA_RAG_EMBEDDING_BACKEND="direct_ollama"
+```
+
+Return to gateway embeddings:
+
+```bash
+unset QUIMERA_RAG_EMBEDDING_BACKEND
+```
+
+Restart LiteLLM after alias/config changes:
+
+```bash
+cd infra/litellm
+source .venv/bin/activate
+./start_litellm.sh
+```
+
+No automatic reindexing is performed. Existing collections must not mix vectors
+from different embedding models, dimensions, providers, or backends.
+
+## Interpreting RagRunTrace
+
+`RagRunTrace` is emitted once per completed RAG query as:
+
+```text
+logger.bind(trace=trace.to_log_dict()).log(log_level, "rag_run_trace")
+```
+
+It records safe provenance metadata: query id, timestamp, collection,
+embedding backend/model/alias/dimensions, chunk count, gateway alias, and
+latencies. It never records query text, prompts, answers, chunks, vectors,
+payloads, portfolio data, API keys, Authorization headers, tokens, passwords
+or secrets.
+
+## Interpreting RagObservabilityEvent
+
+`RagObservabilityEvent` is emitted for lifecycle stages as:
+
+```text
+logger.bind(event=event.to_log_dict()).log(log_level, "rag_lifecycle_event")
+```
+
+It records safe scalar metadata for embedding, retrieval, generation and
+guard-related lifecycle stages. It is not OpenTelemetry, distributed tracing,
+remote telemetry, profiling or a dashboard.
+
+## Security Checklist
+
+- `.env` untouched.
+- No secrets committed.
+- No Authorization headers printed.
+- No real portfolio data or private documents in prompts or logs.
+- Remote provider aliases disabled.
+- URLs must be loopback: `127.0.0.1` or `localhost`.
+- Qdrant production collections are not mutated by readiness checks.
+- `openclaw_knowledge` is not ingested, reindexed, deleted or recreated by
+  Gateway-0 readiness.
+- Live smoke uses synthetic data only.
+
+## No Remote Provider Policy
+
+Gateway-0 is local only. Active configs must not contain OpenAI, Anthropic,
+Gemini, Google, OpenRouter, xAI or Azure provider model prefixes or remote API
+key environment markers.
+
+Future remote providers require:
+
+- explicit ADR;
+- sanitization policy;
+- budget controls;
+- audit logging;
+- Level 0 data exclusion.
+
+## Troubleshooting Matrix
+
+| Symptom | Likely cause | Check / Fix |
+|---|---|---|
+| LiteLLM down | Proxy not started | `cd infra/litellm && ./start_litellm.sh` |
+| Ollama down | Ollama service stopped | `ollama serve`; `curl -fsS http://127.0.0.1:11434/api/tags` |
+| Qdrant down | Docker service stopped | `docker compose -f docker/docker-compose.qdrant.yml up -d` |
+| Missing Qwen model | `qwen3:14b` not pulled | `ollama pull qwen3:14b`; `ollama list` |
+| Missing nomic embed model | `nomic-embed-text` not pulled | `ollama pull nomic-embed-text`; `ollama list` |
+| Wrong key | `QUIMERA_LLM_API_KEY` differs from `LITELLM_MASTER_KEY` | Re-export both in the same shell; do not print them |
+| Missing alias | LiteLLM did not reload config | restart LiteLLM and run `infra/litellm/test_models.sh` |
+| Remote URL rejected | URL is not loopback | use `http://127.0.0.1:<port>` or `http://localhost:<port>` |
+| Embedding dimension mismatch | collection/model/config drift | stop ingest, inspect metadata, reindex only in explicit future sprint |
+| Qdrant metadata drift | existing collection predates migration or backend changed | collection guard warns; do not mix vectors silently |
+| Smoke skipped by default | guard env var not set | set the explicit `RUN_*_SMOKE=1` guard |
+| Healthcheck remote marker failure | active config contains remote provider marker | remove active remote provider; comments alone are allowed |
+
+## Housekeeping Commands
+
+Inspect stale GitHub work manually:
+
+```bash
+gh pr list --state open
+gh issue list --state open
+```
+
+Close obsolete PRs or issues only after human confirmation:
+
+```bash
+gh pr close <number>
+gh issue close <number>
+```
+
+Readiness scripts must never close PRs or issues automatically.
+
+## Supply Chain Note
+
+`infra/litellm/requirements.txt` excludes LiteLLM `1.82.7` and `1.82.8` and
+requires the post-incident `1.83.x` line or newer compatible `1.x` release.
+GW-12 does not introduce new dependencies or provider SDK changes.

--- a/docs/GATEWAY_SETUP.md
+++ b/docs/GATEWAY_SETUP.md
@@ -48,6 +48,7 @@ Both configs define these semantic aliases:
 - `local_think`
 - `local_rag`
 - `local_json`
+- `quimera_embed`
 - `local_embed`
 
 The operational aliases point only to local Ollama models. No remote provider is
@@ -175,6 +176,8 @@ GW-05a adds runtime request timeout budgets per semantic alias without changing
 RAG, Qdrant, embeddings, or prompt construction.
 GW-05b adds live smoke timing validation and `timeout_s` gateway observability
 without changing RAG, Qdrant, embeddings, or prompt construction.
+GW-12 closes the Gateway-0 sprint with `docs/GATEWAY_FINAL_RUNBOOK.md`,
+`scripts/check_gateway_readiness.sh`, static baseline tests and ADR-0019.
 
 Application runtime environment:
 
@@ -195,7 +198,34 @@ Runtime timeout contract:
 | `local_think` | 120.0s | Longer local reasoning calls |
 | `local_rag` | 60.0s | RAG answer synthesis |
 | `local_json` | 30.0s | Structured local responses |
-| `local_embed` | 30.0s | Placeholder only; embeddings remain direct/local |
+| `quimera_embed` | 30.0s | Canonical local embedding alias |
+| `local_embed` | 30.0s | Compatibility embedding alias |
+
+## Final Readiness
+
+Static readiness is CI-safe and requires no live services:
+
+```bash
+scripts/check_gateway_readiness.sh
+```
+
+Live readiness is explicit and local-only:
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/check_gateway_readiness.sh --live
+```
+
+The final runbook is:
+
+```text
+docs/GATEWAY_FINAL_RUNBOOK.md
+```
+
+Gateway-0 remains local-only. Remote providers require a future ADR. FastAPI,
+MCP, quant tools, OpenTelemetry/profiling and production
+`openclaw_knowledge` ingestion are out of scope for Gateway-0.
 
 Live smoke repeat is opt-in:
 

--- a/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
+++ b/docs/guides/OPENCLAW_LITELLM_RUNTIME.md
@@ -14,6 +14,8 @@ GW-08 adds controlled RAG embedding migration for new ingest/test paths through
 GW-09 adds read-only collection metadata drift detection.
 GW-10 adds the final safe per-query `RagRunTrace` provenance record.
 GW-11 adds local structured RAG lifecycle events with safe metadata only.
+GW-12 finalizes Gateway-0 operational readiness with the final runbook,
+readiness script, baseline tests and sprint boundary ADR.
 The default runtime path is:
 
 ```text
@@ -29,11 +31,37 @@ export QUIMERA_LLM_MODEL="local_chat"
 export QUIMERA_LLM_REASONING_MODEL="local_think"
 export QUIMERA_LLM_RAG_MODEL="local_rag"
 export QUIMERA_LLM_JSON_MODEL="local_json"
-export QUIMERA_LLM_EMBED_MODEL="local_embed"
+export QUIMERA_LLM_EMBED_MODEL="quimera_embed"
 ```
 
 `QUIMERA_LLM_API_KEY` should match the local `LITELLM_MASTER_KEY` used to start
 LiteLLM. Do not commit either value.
+
+## Final Gateway-0 Readiness
+
+Use the final runbook for day-to-day operation:
+
+```text
+docs/GATEWAY_FINAL_RUNBOOK.md
+```
+
+Run static readiness without live services:
+
+```bash
+scripts/check_gateway_readiness.sh
+```
+
+Run live readiness only when Ollama, Qdrant and LiteLLM are already running:
+
+```bash
+export LITELLM_MASTER_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_API_KEY="${LITELLM_MASTER_KEY}"
+scripts/check_gateway_readiness.sh --live
+```
+
+Gateway-0 remains local-only. Remote providers, FastAPI, MCP, quant tools,
+OpenTelemetry, profiling, dashboards and production `openclaw_knowledge`
+ingestion require future explicit ADR/sprint approval.
 
 ## Start Ollama
 
@@ -387,8 +415,9 @@ behavior, Qdrant collections, or default embedding selection.
 - Gateway calls emit minimal debug observability: alias, base URL host, latency,
   effective timeout budget, success/failure status, and error category. API
   keys and prompt text are not logged.
-- GW-05a resolves request timeouts per alias: `local_chat` 30s, `local_think`
-  120s, `local_rag` 60s, `local_json` 30s, and `local_embed` 30s placeholder.
+- GW-05a/GW06C/GW-08 resolve request timeouts per alias: `local_chat` 30s,
+  `local_think` 120s, `local_rag` 60s, `local_json` 30s,
+  `quimera_embed` 30s, and `local_embed` 30s compatibility.
   Unknown aliases and `None` still fall back to the global `timeout_seconds`.
 
 ## What Did Not Change
@@ -407,6 +436,8 @@ behavior, Qdrant collections, or default embedding selection.
 - GW-08 does not touch production Qdrant collections or `openclaw_knowledge`.
 - GW-11 does not add OpenTelemetry, remote telemetry, distributed tracing,
   profiling, dashboards, or memory/resource baselines.
+- GW-12 does not change runtime behavior; it adds runbook, readiness checks,
+  final baseline tests and sprint boundary documentation.
 - Remote providers remain disabled.
 - FastAPI remains postponed.
 - MCP and tooling integration remain future direction, not implemented in

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -48,13 +48,13 @@ unavoidable, use `git push --force-with-lease`.
 Current active branch:
 
 ```text
-feat/rag-observability-events
+feat/gateway-operational-readiness
 ```
 
 Current issue:
 
 ```text
-https://github.com/franciscosalido/OPENCLAW/issues/46
+https://github.com/franciscosalido/OPENCLAW/issues/48
 ```
 
 Gateway baseline already merged:
@@ -68,7 +68,8 @@ GW-07 synthetic RAG E2E is merged in 814b59d.
 GW-08 controlled embedding migration is merged in 1a3bf32.
 GW-09 collection metadata guard is merged in 254a840.
 GW-10 safe RagRunTrace provenance is merged in 7b2c81b.
-GW-11 branches from the post-GW10 baseline.
+GW-11 structured RAG observability events are merged in 2ba87b8.
+GW-12 final operational readiness branches from the post-GW11 baseline.
 ```
 
 Gateway PR state:
@@ -87,7 +88,8 @@ Gateway PR state:
 | GW-08 | `feat/rag-controlled-embedding-migration` | Controlled RAG embedding migration to `quimera_embed` | Merged in `1a3bf32` |
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard for embedding traceability | Merged in `254a840` |
 | GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Merged in `7b2c81b` |
-| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Current |
+| GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Merged in `2ba87b8` |
+| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness script, baseline tests, sprint boundary ADR | Current final PR |
 
 ---
 
@@ -476,7 +478,7 @@ Out of scope:
 
 - OpenTelemetry, Prometheus, Grafana, dashboards, soak tests, and profiling.
 - GW-11 adds structured observability lifecycle events separately.
-- GW-12 memory/resource baseline.
+- GW-12 final operational readiness and sprint boundary.
 - Qdrant mutation, reindexing, collection updates, and `openclaw_knowledge`.
 
 Safety notes:
@@ -487,7 +489,7 @@ Safety notes:
   Authorization headers, or secrets.
 - Dimension mismatch raises `EmbeddingDimensionMismatchError`.
 
-## GW-11 Current Work
+## GW-11 Completed Work
 
 Objective:
 
@@ -519,3 +521,34 @@ Safety notes:
   Authorization headers, tokens, passwords, or secrets.
 - `RagRunTrace` remains the final per-query provenance record; GW-11 lifecycle
   events are separate.
+
+## GW-12 Current Work
+
+Objective:
+
+Finalize Gateway-0 operational readiness, runbook, checks, sprint boundary ADR
+and handoff.
+
+Scope:
+
+- `docs/GATEWAY_FINAL_RUNBOOK.md`.
+- `scripts/check_gateway_readiness.sh`.
+- Static readiness checks by default; explicit `--live` for local services.
+- Final baseline tests across RAG config and LiteLLM configs.
+- Smoke skip-by-default audit.
+- Safe serialization audit for `RagRunTrace` and `RagObservabilityEvent`.
+- ADR-0019 documenting the Gateway-0 sprint boundary.
+
+Out of scope:
+
+- New runtime architecture.
+- OpenTelemetry, Prometheus, Grafana, dashboards, distributed tracing,
+  profiling, mandatory soak tests or new dependencies.
+- FastAPI, MCP, quant tools or remote providers.
+- Qdrant mutation, reindexing, `openclaw_knowledge` access or real data.
+
+Final rule:
+
+After GW-12 merges, Gateway-0 is complete on `main`. Any remote provider,
+OpenTelemetry/profiling, production ingestion or `openclaw_knowledge` work
+requires a new issue and explicit future ADR/sprint.

--- a/scripts/check_gateway_readiness.sh
+++ b/scripts/check_gateway_readiness.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="static"
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+ok() {
+  printf 'OK: %s\n' "$1"
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check_gateway_readiness.sh [--live]
+
+Default mode is static and does not require network, live services, secrets, or
+Qdrant access. --live performs explicit local service checks.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "${1:-}" = "--live" ]; then
+  MODE="live"
+elif [ "${1:-}" != "" ]; then
+  fail "Unknown argument '${1}'. Use --live or --help."
+fi
+
+require_file() {
+  [ -f "${ROOT_DIR}/$1" ] || fail "Required file missing: $1"
+  ok "found $1"
+}
+
+require_executable() {
+  [ -x "${ROOT_DIR}/$1" ] || fail "Required executable missing: $1"
+  ok "executable $1"
+}
+
+is_local_url() {
+  case "$1" in
+    http://127.0.0.1:*|http://localhost:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_local_url() {
+  local name="$1"
+  local value="$2"
+  if ! is_local_url "${value}"; then
+    fail "${name} must be local-only. Got '${value}'."
+  fi
+  ok "${name} is local-only"
+}
+
+active_config() {
+  sed '/^[[:space:]]*#/d' "${ROOT_DIR}/$1"
+}
+
+require_alias() {
+  local file="$1"
+  local alias="$2"
+  if ! grep -Eq "model_name:[[:space:]]*${alias}([[:space:]]*)$" "${ROOT_DIR}/${file}"; then
+    fail "Alias '${alias}' missing from ${file}"
+  fi
+  ok "${file} defines ${alias}"
+}
+
+reject_remote_markers() {
+  local file="$1"
+  local active
+  active="$(active_config "${file}")"
+  if printf '%s\n' "${active}" | grep -Eiq \
+      'OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|GOOGLE_API_KEY|OPENROUTER_API_KEY|XAI_API_KEY|AZURE_API_KEY'; then
+    fail "Remote provider API key marker found in active config ${file}"
+  fi
+  if printf '%s\n' "${active}" | grep -Eiq \
+      'model:[[:space:]]*(openai|anthropic|gemini|google|openrouter|xai|azure)/'; then
+    fail "Remote provider model found in active config ${file}"
+  fi
+  ok "${file} has no active remote provider markers"
+}
+
+require_grep() {
+  local file="$1"
+  local pattern="$2"
+  local label="$3"
+  grep -Eq "${pattern}" "${ROOT_DIR}/${file}" || fail "${label} missing in ${file}"
+  ok "${label}"
+}
+
+check_static() {
+  require_file "config/rag_config.yaml"
+  require_file "config/litellm_config.yaml"
+  require_file "infra/litellm/litellm_config.yaml"
+  require_file "infra/litellm/requirements.txt"
+  require_file "docs/GATEWAY_FINAL_RUNBOOK.md"
+  require_file "docs/ADR/0019-gateway-0-sprint-boundary.md"
+  require_executable "infra/litellm/healthcheck.sh"
+  require_executable "scripts/test_opencraw_litellm_runtime.sh"
+  require_executable "scripts/test_local_embed_litellm.sh"
+  require_executable "scripts/test_rag_e2e_gateway.sh"
+  require_executable "scripts/test_gw08_embedding_migration.sh"
+
+  for config in "config/litellm_config.yaml" "infra/litellm/litellm_config.yaml"; do
+    for alias in local_chat local_think local_rag local_json quimera_embed local_embed; do
+      require_alias "${config}" "${alias}"
+    done
+    reject_remote_markers "${config}"
+  done
+
+  require_grep "config/rag_config.yaml" 'tracing:[[:space:]]*$' "rag.tracing section"
+  require_grep "config/rag_config.yaml" 'observability:[[:space:]]*$' "rag.observability section"
+  require_grep "config/rag_config.yaml" 'active_backend:[[:space:]]*"gateway_litellm"' "gateway_litellm active backend"
+  require_grep "config/rag_config.yaml" 'embedding_alias:[[:space:]]*"quimera_embed"' "quimera_embed embedding alias"
+  require_grep "config/rag_config.yaml" 'embedding_dimensions:[[:space:]]*768' "768 embedding dimensions"
+  require_grep "config/rag_config.yaml" 'reindex_required_on_model_change:[[:space:]]*true' "reindex-required metadata"
+
+  require_grep "infra/litellm/requirements.txt" '!=1\.82\.7' "LiteLLM 1.82.7 exclusion"
+  require_grep "infra/litellm/requirements.txt" '!=1\.82\.8' "LiteLLM 1.82.8 exclusion"
+
+  require_grep "tests/smoke/test_gateway_runtime_smoke.py" 'RUN_LITELLM_SMOKE' "runtime smoke guard"
+  require_grep "tests/smoke/test_gateway_embed_smoke.py" 'RUN_LITELLM_EMBED_SMOKE' "embedding smoke guard"
+  require_grep "tests/smoke/test_rag_e2e_gateway_smoke.py" 'RUN_RAG_E2E_SMOKE' "RAG E2E smoke guard"
+  require_grep "tests/smoke/test_rag_gateway_embedding_migration_smoke.py" 'RUN_GW08_EMBEDDING_MIGRATION_SMOKE' "GW08 migration smoke guard"
+  require_grep "tests/smoke/test_rag_gateway_embedding_migration_smoke.py" 'RUN_GW08_EMBEDDING_PARITY_SMOKE' "GW08 parity smoke guard"
+
+  require_local_url "QUIMERA_LLM_BASE_URL" "${QUIMERA_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+  require_local_url "OLLAMA_API_BASE" "${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+  require_local_url "QDRANT_URL" "${QDRANT_URL:-http://127.0.0.1:6333}"
+
+  ok "Gateway-0 static readiness checks passed"
+}
+
+json_contains_alias() {
+  local json_file="$1"
+  local alias="$2"
+  grep -q "\"${alias}\"" "${json_file}" || fail "LiteLLM /models did not expose ${alias}"
+  ok "LiteLLM exposes ${alias}"
+}
+
+check_live() {
+  command -v curl >/dev/null 2>&1 || fail "curl is required for --live" 127
+  command -v python3 >/dev/null 2>&1 || fail "python3 is required for --live" 127
+  [ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required for --live"
+  [ -n "${QUIMERA_LLM_API_KEY:-}" ] || fail "QUIMERA_LLM_API_KEY is required for --live"
+
+  local llm_base="${QUIMERA_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+  local ollama_base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+  local qdrant_url="${QDRANT_URL:-http://127.0.0.1:6333}"
+
+  require_local_url "QUIMERA_LLM_BASE_URL" "${llm_base}"
+  require_local_url "OLLAMA_API_BASE" "${ollama_base}"
+  require_local_url "QDRANT_URL" "${qdrant_url}"
+
+  curl -fsS --max-time 5 "${qdrant_url%/}/healthz" >/dev/null || fail "Qdrant is not reachable at ${qdrant_url}"
+  ok "Qdrant healthz reachable"
+  curl -fsS --max-time 5 "${ollama_base%/}/api/tags" >/dev/null || fail "Ollama is not reachable at ${ollama_base}"
+  ok "Ollama tags reachable"
+
+  local models_json
+  models_json="$(mktemp)"
+  curl -fsS --max-time 10 \
+    -H "Authorization: Bearer ${QUIMERA_LLM_API_KEY}" \
+    "${llm_base%/}/models" > "${models_json}" || fail "LiteLLM /v1/models is not reachable"
+  for alias in local_chat local_think local_rag local_json quimera_embed local_embed; do
+    json_contains_alias "${models_json}" "${alias}"
+  done
+  rm -f "${models_json}"
+
+  local embed_json
+  embed_json="$(mktemp)"
+  curl -fsS --max-time 30 \
+    -H "Authorization: Bearer ${QUIMERA_LLM_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"quimera_embed","input":"texto sintetico curto para readiness"}' \
+    "${llm_base%/}/embeddings" > "${embed_json}" || fail "quimera_embed embedding call failed"
+  local dims
+  dims="$(python3 - "${embed_json}" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+print(len(body["data"][0]["embedding"]))
+PY
+)"
+  rm -f "${embed_json}"
+  [ "${dims}" = "768" ] || fail "quimera_embed returned ${dims} dimensions, expected 768"
+  ok "quimera_embed returns 768 dimensions"
+
+  (cd "${ROOT_DIR}/infra/litellm" && ./healthcheck.sh)
+  ok "Gateway-0 live readiness checks passed"
+}
+
+check_static
+if [ "${MODE}" = "live" ]; then
+  check_live
+fi

--- a/tests/unit/test_gateway_final_baseline.py
+++ b/tests/unit/test_gateway_final_baseline.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from backend.rag.observability import RagEventKind, RagObservabilityEvent
+from backend.rag.run_trace import RagRunTrace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAG_CONFIG = REPO_ROOT / "config" / "rag_config.yaml"
+CONTRACT_LITELLM_CONFIG = REPO_ROOT / "config" / "litellm_config.yaml"
+OPERATIONAL_LITELLM_CONFIG = REPO_ROOT / "infra" / "litellm" / "litellm_config.yaml"
+REQUIREMENTS = REPO_ROOT / "infra" / "litellm" / "requirements.txt"
+SMOKE_DIR = REPO_ROOT / "tests" / "smoke"
+
+REQUIRED_ALIASES = {
+    "local_chat",
+    "local_think",
+    "local_rag",
+    "local_json",
+    "quimera_embed",
+    "local_embed",
+}
+CHAT_ALIASES = {"local_chat", "local_think", "local_rag", "local_json"}
+EMBED_ALIASES = {"quimera_embed", "local_embed"}
+REMOTE_MODEL_PREFIX = re.compile(
+    r"^(openai|anthropic|gemini|google|openrouter|xai|azure)/",
+    re.IGNORECASE,
+)
+FORBIDDEN_SERIALIZED_KEYS = {
+    "query",
+    "question",
+    "prompt",
+    "answer",
+    "response",
+    "chunk",
+    "chunk_text",
+    "chunks",
+    "document",
+    "documents",
+    "vector",
+    "vectors",
+    "embedding_values",
+    "payload",
+    "qdrant_payload",
+    "portfolio",
+    "carteira",
+    "api_key",
+    "authorization",
+    "secret",
+    "token",
+    "password",
+    "headers",
+}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict)
+    return cast(dict[str, Any], raw)
+
+
+def _aliases(path: Path) -> dict[str, dict[str, Any]]:
+    raw = _load_yaml(path)
+    model_list = raw["model_list"]
+    assert isinstance(model_list, list)
+    return {
+        str(item["model_name"]): cast(dict[str, Any], item)
+        for item in model_list
+        if isinstance(item, dict)
+    }
+
+
+class GatewayFinalBaselineTests(unittest.TestCase):
+    def test_required_aliases_exist_in_both_litellm_configs(self) -> None:
+        for path in (CONTRACT_LITELLM_CONFIG, OPERATIONAL_LITELLM_CONFIG):
+            with self.subTest(path=path):
+                self.assertEqual(set(_aliases(path)), REQUIRED_ALIASES)
+
+    def test_aliases_point_to_local_ollama_models(self) -> None:
+        contract_aliases = _aliases(CONTRACT_LITELLM_CONFIG)
+        operational_aliases = _aliases(OPERATIONAL_LITELLM_CONFIG)
+
+        for alias in CHAT_ALIASES:
+            contract_model = contract_aliases[alias]["litellm_params"]["model"]
+            operational_model = operational_aliases[alias]["litellm_params"]["model"]
+            self.assertTrue(str(contract_model).startswith("ollama_chat/"))
+            self.assertEqual(operational_model, "os.environ/LITELLM_LOCAL_CHAT_MODEL")
+        for alias in EMBED_ALIASES:
+            contract_model = contract_aliases[alias]["litellm_params"]["model"]
+            operational_model = operational_aliases[alias]["litellm_params"]["model"]
+            self.assertEqual(contract_model, "ollama/nomic-embed-text")
+            self.assertEqual(operational_model, "os.environ/LITELLM_LOCAL_EMBED_MODEL")
+
+    def test_no_remote_provider_aliases_are_active(self) -> None:
+        for path in (CONTRACT_LITELLM_CONFIG, OPERATIONAL_LITELLM_CONFIG):
+            aliases = _aliases(path)
+            for alias, item in aliases.items():
+                with self.subTest(path=path, alias=alias):
+                    params = item["litellm_params"]
+                    model = str(params["model"])
+                    self.assertFalse(REMOTE_MODEL_PREFIX.match(model))
+                    self.assertNotIn("api_key", params)
+                    self.assertEqual(item["model_info"]["provider"], "ollama")
+
+    def test_rag_config_records_final_gateway_embedding_baseline(self) -> None:
+        raw = _load_yaml(RAG_CONFIG)
+        rag = raw["rag"]
+        embedding = rag["embedding"]
+
+        self.assertIn("tracing", rag)
+        self.assertIn("observability", rag)
+        self.assertEqual(embedding["active_backend"], "gateway_litellm")
+        self.assertEqual(embedding["embedding_backend"], "gateway_litellm_current")
+        self.assertEqual(embedding["legacy_embedding_backend"], "direct_ollama")
+        self.assertEqual(embedding["embedding_alias"], "quimera_embed")
+        self.assertEqual(embedding["gateway_embedding_alias"], "quimera_embed")
+        self.assertEqual(embedding["gateway_compatibility_alias"], "local_embed")
+        self.assertEqual(embedding["embedding_model"], "nomic-embed-text")
+        self.assertEqual(embedding["embedding_dimensions"], 768)
+        self.assertTrue(embedding["reindex_required_on_model_change"])
+
+    def test_smoke_tests_remain_guarded_by_explicit_env_vars(self) -> None:
+        guards = {
+            "RUN_LITELLM_SMOKE": SMOKE_DIR / "test_gateway_runtime_smoke.py",
+            "RUN_LITELLM_EMBED_SMOKE": SMOKE_DIR / "test_gateway_embed_smoke.py",
+            "RUN_RAG_E2E_SMOKE": SMOKE_DIR / "test_rag_e2e_gateway_smoke.py",
+            "RUN_GW08_EMBEDDING_MIGRATION_SMOKE": (
+                SMOKE_DIR / "test_rag_gateway_embedding_migration_smoke.py"
+            ),
+            "RUN_GW08_EMBEDDING_PARITY_SMOKE": (
+                SMOKE_DIR / "test_rag_gateway_embedding_migration_smoke.py"
+            ),
+        }
+
+        for guard, path in guards.items():
+            with self.subTest(guard=guard):
+                self.assertIn(guard, path.read_text(encoding="utf-8"))
+
+    def test_trace_and_event_serialization_exclude_forbidden_keys(self) -> None:
+        trace = RagRunTrace(
+            query_id="query-id",
+            timestamp_utc="2026-05-01T00:00:00Z",
+            collection_name="synthetic_collection",
+            embedding_backend="gateway_litellm_current",
+            embedding_model="nomic-embed-text",
+            embedding_alias="quimera_embed",
+            embedding_dimensions=768,
+            retrieval_latency_ms=1.0,
+            generation_latency_ms=2.0,
+            chunk_count=1,
+        )
+        event = RagObservabilityEvent(
+            event_kind=RagEventKind.EMBEDDING_CALL_FINISHED,
+            timestamp_utc="2026-05-01T00:00:00Z",
+            backend="gateway_litellm",
+            alias="quimera_embed",
+            dimensions=768,
+            latency_ms=1.0,
+            batch_size=1,
+            status="success",
+        )
+
+        for payload in (trace.to_log_dict(), event.to_log_dict()):
+            with self.subTest(payload=payload):
+                lowered_keys = {key.lower() for key in payload}
+                self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint(lowered_keys))
+
+    def test_litellm_requirements_exclude_known_bad_versions(self) -> None:
+        text = REQUIREMENTS.read_text(encoding="utf-8")
+
+        self.assertIn("!=1.82.7", text)
+        self.assertIn("!=1.82.8", text)
+        self.assertNotIn("openai==", text.lower())
+        self.assertNotIn("anthropic==", text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_readiness_script.py
+++ b/tests/unit/test_gateway_readiness_script.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_gateway_readiness.sh"
+
+
+def _run_script(env_updates: dict[str, str | None] | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key, value in (env_updates or {}).items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    return subprocess.run(
+        [str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class GatewayReadinessScriptTests(unittest.TestCase):
+    def test_script_is_executable(self) -> None:
+        self.assertTrue(SCRIPT.stat().st_mode & stat.S_IXUSR)
+
+    def test_script_uses_strict_shell_mode(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("set -euo pipefail", text)
+
+    def test_default_mode_does_not_require_live_services(self) -> None:
+        result = _run_script(
+            {
+                "QUIMERA_LLM_BASE_URL": None,
+                "OLLAMA_API_BASE": None,
+                "QDRANT_URL": None,
+                "LITELLM_MASTER_KEY": None,
+                "QUIMERA_LLM_API_KEY": None,
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Gateway-0 static readiness checks passed", result.stdout)
+        self.assertNotIn("/api/tags", result.stdout)
+        self.assertNotIn("/healthz", result.stdout)
+
+    def test_refuses_remote_quimera_llm_base_url(self) -> None:
+        result = _run_script({"QUIMERA_LLM_BASE_URL": "https://api.example.com/v1"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("QUIMERA_LLM_BASE_URL must be local-only", result.stderr)
+
+    def test_refuses_remote_ollama_api_base(self) -> None:
+        result = _run_script({"OLLAMA_API_BASE": "https://ollama.example.com"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("OLLAMA_API_BASE must be local-only", result.stderr)
+
+    def test_refuses_remote_qdrant_url(self) -> None:
+        result = _run_script({"QDRANT_URL": "https://qdrant.example.com"})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("QDRANT_URL must be local-only", result.stderr)
+
+    def test_script_checks_required_aliases_and_quimera_embed(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+
+        for alias in (
+            "local_chat",
+            "local_think",
+            "local_rag",
+            "local_json",
+            "quimera_embed",
+            "local_embed",
+        ):
+            with self.subTest(alias=alias):
+                self.assertIn(alias, text)
+
+    def test_script_has_live_opt_in(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("--live", text)
+        self.assertIn('MODE="static"', text)
+
+    def test_script_does_not_print_secrets(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertNotRegex(text, re.compile(r"echo .*KEY", re.IGNORECASE))
+        self.assertNotRegex(text, re.compile(r"printf .*KEY", re.IGNORECASE))
+        self.assertNotIn("set -x", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_litellm_infra_scripts.py
+++ b/tests/unit/test_litellm_infra_scripts.py
@@ -74,6 +74,7 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
             INFRA_DIR / "test_models.sh",
             INFRA_DIR / "test_local_chat.sh",
             REPO_ROOT / "scripts" / "check_litellm_gateway.sh",
+            REPO_ROOT / "scripts" / "check_gateway_readiness.sh",
             REPO_ROOT / "scripts" / "test_opencraw_litellm_runtime.sh",
             REPO_ROOT / "scripts" / "test_gw08_embedding_migration.sh",
         ):


### PR DESCRIPTION
## Summary

GW-12 finalizes Gateway-0 operational readiness.

This PR closes the Gateway-0 sprint by adding the final runbook, readiness checks, config baseline tests, smoke skip-by-default audit, rollback/troubleshooting documentation, ADR boundary, and final handoff updates.

It does not add new runtime architecture, does not enable remote providers, and does not mutate Qdrant or real collections.

## What changed

- Added `docs/GATEWAY_FINAL_RUNBOOK.md`
- Added `scripts/check_gateway_readiness.sh`
- Added final gateway readiness/static checks
- Added final config baseline tests
- Added smoke skip-by-default audit
- Added ADR-019 Gateway-0 sprint boundary
- Updated Gateway sprint handoff/current state/agent context
- Documented final validated Gateway-0 baseline
- Documented rollback, boot order and troubleshooting
- Documented next sprint boundary

## Operational validation performed

The following local operational checks were executed successfully:

```bash
scripts/check_gateway_readiness.sh --live
infra/litellm/healthcheck.sh
scripts/test_opencraw_litellm_runtime.sh
scripts/test_local_embed_litellm.sh
scripts/test_rag_e2e_gateway.sh
RUN_GW08_EMBEDDING_MIGRATION_SMOKE=1 RUN_GW08_EMBEDDING_PARITY_SMOKE=1 uv run pytest tests/smoke/ -v -s
