### PR TITLE
feat(gateway): add local-first routing policy prelude

### DIFF
--- a/backend/gateway/__init__.py
+++ b/backend/gateway/__init__.py
@@ -42,6 +42,17 @@ from backend.gateway.errors import (
     GatewayTimeoutError,
 )
 from backend.gateway.health import check_gateway_services, check_litellm_gateway
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouteBlockReason,
+    RouteDecisionKind,
+    RouterDecision,
+    TaskRiskLevel,
+    TokenBudgetClass,
+    TokenEconomyRecord,
+    build_token_economy_record,
+    decide_route,
+)
 
 __all__ = [
     # Config
@@ -64,6 +75,16 @@ __all__ = [
     # Health
     "check_gateway_services",
     "check_litellm_gateway",
+    # Gateway-1 routing policy
+    "RemoteEscalationPolicy",
+    "RouteBlockReason",
+    "RouteDecisionKind",
+    "RouterDecision",
+    "TaskRiskLevel",
+    "TokenBudgetClass",
+    "TokenEconomyRecord",
+    "build_token_economy_record",
+    "decide_route",
     # Errors
     "GatewayAuthenticationError",
     "GatewayConnectionError",

--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -1,0 +1,438 @@
+"""Local-first Gateway-1 routing policy primitives.
+
+This module is intentionally offline and side-effect free. It never reads API
+keys, never calls remote providers, and never serializes prompt or response
+content. Gateway-1 can use these records to discuss routing decisions before
+any future remote provider is enabled by ADR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from uuid import uuid4
+
+
+class RouteDecisionKind(str, Enum):
+    """Allowed high-level routing decisions."""
+
+    LOCAL = "local"
+    REMOTE_CANDIDATE = "remote_candidate"
+    BLOCKED = "blocked"
+
+
+class RouteBlockReason(str, Enum):
+    """Safe routing block reasons."""
+
+    REMOTE_DISABLED = "remote_disabled"
+    SENSITIVE_CONTEXT = "sensitive_context"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    UNSUPPORTED_TASK = "unsupported_task"
+    POLICY_DENIED = "policy_denied"
+    UNKNOWN = "unknown"
+
+
+class TaskRiskLevel(str, Enum):
+    """Coarse task risk levels used by routing policy."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class TokenBudgetClass(str, Enum):
+    """Estimated token budget class for policy decisions."""
+
+    TINY = "tiny"
+    NORMAL = "normal"
+    EXPENSIVE = "expensive"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class RemoteEscalationPolicy:
+    """Local-first remote escalation policy.
+
+    ``remote_enabled`` defaults to ``False`` and must stay false until a future
+    ADR explicitly authorizes remote provider activation.
+    """
+
+    remote_enabled: bool = False
+    monthly_budget_usd: float | None = None
+    per_request_token_limit: int | None = None
+    allowed_remote_providers: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.monthly_budget_usd is not None and self.monthly_budget_usd < 0:
+            raise ValueError("monthly_budget_usd cannot be negative")
+        if (
+            self.per_request_token_limit is not None
+            and self.per_request_token_limit < 0
+        ):
+            raise ValueError("per_request_token_limit cannot be negative")
+        for provider in self.allowed_remote_providers:
+            _validate_non_empty(provider, "allowed_remote_providers")
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    """Safe metadata-only record of a gateway routing decision."""
+
+    decision_id: str
+    timestamp_utc: str
+    route: RouteDecisionKind
+    reason: str
+    risk_level: TaskRiskLevel
+    token_budget_class: TokenBudgetClass
+    remote_allowed: bool
+    remote_candidate_provider: str | None
+    requires_sanitization: bool
+    estimated_prompt_tokens: int | None = None
+    estimated_completion_tokens: int | None = None
+    estimated_remote_tokens: int | None = None
+    estimated_remote_tokens_avoided: int | None = None
+
+    def __post_init__(self) -> None:
+        _validate_non_empty(self.decision_id, "decision_id")
+        _validate_non_empty(self.timestamp_utc, "timestamp_utc")
+        _validate_non_empty(self.reason, "reason")
+        if self.remote_candidate_provider is not None:
+            _validate_non_empty(
+                self.remote_candidate_provider,
+                "remote_candidate_provider",
+            )
+        _validate_optional_non_negative(
+            self.estimated_prompt_tokens,
+            "estimated_prompt_tokens",
+        )
+        _validate_optional_non_negative(
+            self.estimated_completion_tokens,
+            "estimated_completion_tokens",
+        )
+        _validate_optional_non_negative(
+            self.estimated_remote_tokens,
+            "estimated_remote_tokens",
+        )
+        _validate_optional_non_negative(
+            self.estimated_remote_tokens_avoided,
+            "estimated_remote_tokens_avoided",
+        )
+
+    def to_log_dict(self) -> dict[str, object]:
+        """Return safe allowlisted metadata for structured logs."""
+        data: dict[str, object] = {
+            "decision_id": self.decision_id,
+            "timestamp_utc": self.timestamp_utc,
+            "route": self.route.value,
+            "reason": self.reason,
+            "risk_level": self.risk_level.value,
+            "token_budget_class": self.token_budget_class.value,
+            "remote_allowed": self.remote_allowed,
+            "requires_sanitization": self.requires_sanitization,
+        }
+        optional_values: dict[str, object | None] = {
+            "remote_candidate_provider": self.remote_candidate_provider,
+            "estimated_prompt_tokens": self.estimated_prompt_tokens,
+            "estimated_completion_tokens": self.estimated_completion_tokens,
+            "estimated_remote_tokens": self.estimated_remote_tokens,
+            "estimated_remote_tokens_avoided": self.estimated_remote_tokens_avoided,
+        }
+        for key, value in optional_values.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+@dataclass(frozen=True)
+class TokenEconomyRecord:
+    """Safe token economy estimate tied to one routing decision."""
+
+    decision_id: str
+    provider_used: str
+    route: str
+    local_tokens_estimated: int | None
+    remote_tokens_estimated: int | None
+    remote_tokens_avoided_estimated: int | None
+    cost_estimate_mode: str
+    timestamp_utc: str
+
+    def __post_init__(self) -> None:
+        _validate_non_empty(self.decision_id, "decision_id")
+        _validate_non_empty(self.provider_used, "provider_used")
+        _validate_non_empty(self.route, "route")
+        _validate_non_empty(self.cost_estimate_mode, "cost_estimate_mode")
+        _validate_non_empty(self.timestamp_utc, "timestamp_utc")
+        _validate_optional_non_negative(
+            self.local_tokens_estimated,
+            "local_tokens_estimated",
+        )
+        _validate_optional_non_negative(
+            self.remote_tokens_estimated,
+            "remote_tokens_estimated",
+        )
+        _validate_optional_non_negative(
+            self.remote_tokens_avoided_estimated,
+            "remote_tokens_avoided_estimated",
+        )
+
+    def to_log_dict(self) -> dict[str, object]:
+        """Return safe allowlisted token economy metadata."""
+        data: dict[str, object] = {
+            "decision_id": self.decision_id,
+            "provider_used": self.provider_used,
+            "route": self.route,
+            "cost_estimate_mode": self.cost_estimate_mode,
+            "timestamp_utc": self.timestamp_utc,
+        }
+        optional_values: dict[str, int | None] = {
+            "local_tokens_estimated": self.local_tokens_estimated,
+            "remote_tokens_estimated": self.remote_tokens_estimated,
+            "remote_tokens_avoided_estimated": self.remote_tokens_avoided_estimated,
+        }
+        for key, value in optional_values.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+def decide_route(
+    *,
+    task_type: str,
+    estimated_prompt_tokens: int,
+    estimated_completion_tokens: int,
+    contains_sensitive_context: bool,
+    high_value_task: bool,
+    policy: RemoteEscalationPolicy,
+) -> RouterDecision:
+    """Decide whether a task remains local, is blocked, or is a remote candidate.
+
+    The function is deterministic and never performs I/O. A remote candidate is
+    only returned when remote routing is explicitly enabled and at least one
+    provider is explicitly allowed.
+    """
+    clean_task_type = _validate_non_empty(task_type, "task_type")
+    _validate_non_negative(estimated_prompt_tokens, "estimated_prompt_tokens")
+    _validate_non_negative(estimated_completion_tokens, "estimated_completion_tokens")
+    total_tokens = estimated_prompt_tokens + estimated_completion_tokens
+    budget_class = _token_budget_class(total_tokens)
+    risk_level = _risk_level(
+        contains_sensitive_context=contains_sensitive_context,
+        high_value_task=high_value_task,
+        budget_class=budget_class,
+    )
+
+    if _budget_exceeded(total_tokens, policy.per_request_token_limit):
+        return _decision(
+            route=RouteDecisionKind.BLOCKED,
+            reason=RouteBlockReason.BUDGET_EXCEEDED.value,
+            risk_level=risk_level,
+            token_budget_class=TokenBudgetClass.BLOCKED,
+            remote_allowed=False,
+            remote_candidate_provider=None,
+            requires_sanitization=contains_sensitive_context,
+            estimated_prompt_tokens=estimated_prompt_tokens,
+            estimated_completion_tokens=estimated_completion_tokens,
+            estimated_remote_tokens=total_tokens,
+            estimated_remote_tokens_avoided=total_tokens,
+        )
+
+    if contains_sensitive_context:
+        return _decision(
+            route=RouteDecisionKind.LOCAL,
+            reason=RouteBlockReason.SENSITIVE_CONTEXT.value,
+            risk_level=TaskRiskLevel.HIGH,
+            token_budget_class=budget_class,
+            remote_allowed=False,
+            remote_candidate_provider=None,
+            requires_sanitization=True,
+            estimated_prompt_tokens=estimated_prompt_tokens,
+            estimated_completion_tokens=estimated_completion_tokens,
+            estimated_remote_tokens=total_tokens,
+            estimated_remote_tokens_avoided=total_tokens,
+        )
+
+    if _is_unsupported_task(clean_task_type):
+        return _decision(
+            route=RouteDecisionKind.BLOCKED,
+            reason=RouteBlockReason.UNSUPPORTED_TASK.value,
+            risk_level=TaskRiskLevel.HIGH,
+            token_budget_class=TokenBudgetClass.BLOCKED,
+            remote_allowed=False,
+            remote_candidate_provider=None,
+            requires_sanitization=False,
+            estimated_prompt_tokens=estimated_prompt_tokens,
+            estimated_completion_tokens=estimated_completion_tokens,
+            estimated_remote_tokens=total_tokens,
+            estimated_remote_tokens_avoided=total_tokens,
+        )
+
+    if high_value_task or budget_class is TokenBudgetClass.EXPENSIVE:
+        provider = (
+            policy.allowed_remote_providers[0]
+            if policy.allowed_remote_providers
+            else None
+        )
+        if policy.remote_enabled and provider is not None:
+            return _decision(
+                route=RouteDecisionKind.REMOTE_CANDIDATE,
+                reason="remote_candidate_policy_match",
+                risk_level=risk_level,
+                token_budget_class=budget_class,
+                remote_allowed=True,
+                remote_candidate_provider=provider,
+                requires_sanitization=True,
+                estimated_prompt_tokens=estimated_prompt_tokens,
+                estimated_completion_tokens=estimated_completion_tokens,
+                estimated_remote_tokens=total_tokens,
+                estimated_remote_tokens_avoided=None,
+            )
+        reason = (
+            RouteBlockReason.REMOTE_DISABLED.value
+            if not policy.remote_enabled
+            else RouteBlockReason.POLICY_DENIED.value
+        )
+        return _decision(
+            route=RouteDecisionKind.BLOCKED,
+            reason=reason,
+            risk_level=risk_level,
+            token_budget_class=budget_class,
+            remote_allowed=False,
+            remote_candidate_provider=provider,
+            requires_sanitization=True,
+            estimated_prompt_tokens=estimated_prompt_tokens,
+            estimated_completion_tokens=estimated_completion_tokens,
+            estimated_remote_tokens=total_tokens,
+            estimated_remote_tokens_avoided=total_tokens,
+        )
+
+    return _decision(
+        route=RouteDecisionKind.LOCAL,
+        reason="local_first_default",
+        risk_level=risk_level,
+        token_budget_class=budget_class,
+        remote_allowed=False,
+        remote_candidate_provider=None,
+        requires_sanitization=False,
+        estimated_prompt_tokens=estimated_prompt_tokens,
+        estimated_completion_tokens=estimated_completion_tokens,
+        estimated_remote_tokens=total_tokens,
+        estimated_remote_tokens_avoided=total_tokens,
+    )
+
+
+def build_token_economy_record(
+    decision: RouterDecision,
+    *,
+    provider_used: str = "local",
+    cost_estimate_mode: str = "estimated_not_billed",
+) -> TokenEconomyRecord:
+    """Build a safe token economy estimate from a routing decision."""
+    local_tokens = None
+    if decision.route is RouteDecisionKind.LOCAL:
+        local_tokens = _sum_optional(
+            decision.estimated_prompt_tokens,
+            decision.estimated_completion_tokens,
+        )
+    return TokenEconomyRecord(
+        decision_id=decision.decision_id,
+        provider_used=provider_used,
+        route=decision.route.value,
+        local_tokens_estimated=local_tokens,
+        remote_tokens_estimated=decision.estimated_remote_tokens,
+        remote_tokens_avoided_estimated=decision.estimated_remote_tokens_avoided,
+        cost_estimate_mode=cost_estimate_mode,
+        timestamp_utc=utc_now_iso(),
+    )
+
+
+def utc_now_iso() -> str:
+    """Return an ISO-8601 UTC timestamp with Z suffix."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _decision(
+    *,
+    route: RouteDecisionKind,
+    reason: str,
+    risk_level: TaskRiskLevel,
+    token_budget_class: TokenBudgetClass,
+    remote_allowed: bool,
+    remote_candidate_provider: str | None,
+    requires_sanitization: bool,
+    estimated_prompt_tokens: int,
+    estimated_completion_tokens: int,
+    estimated_remote_tokens: int | None,
+    estimated_remote_tokens_avoided: int | None,
+) -> RouterDecision:
+    return RouterDecision(
+        decision_id=uuid4().hex,
+        timestamp_utc=utc_now_iso(),
+        route=route,
+        reason=reason,
+        risk_level=risk_level,
+        token_budget_class=token_budget_class,
+        remote_allowed=remote_allowed,
+        remote_candidate_provider=remote_candidate_provider,
+        requires_sanitization=requires_sanitization,
+        estimated_prompt_tokens=estimated_prompt_tokens,
+        estimated_completion_tokens=estimated_completion_tokens,
+        estimated_remote_tokens=estimated_remote_tokens,
+        estimated_remote_tokens_avoided=estimated_remote_tokens_avoided,
+    )
+
+
+def _token_budget_class(total_tokens: int) -> TokenBudgetClass:
+    if total_tokens <= 1_000:
+        return TokenBudgetClass.TINY
+    if total_tokens <= 8_000:
+        return TokenBudgetClass.NORMAL
+    return TokenBudgetClass.EXPENSIVE
+
+
+def _risk_level(
+    *,
+    contains_sensitive_context: bool,
+    high_value_task: bool,
+    budget_class: TokenBudgetClass,
+) -> TaskRiskLevel:
+    if (
+        contains_sensitive_context
+        or high_value_task
+        or budget_class is TokenBudgetClass.EXPENSIVE
+    ):
+        return TaskRiskLevel.HIGH
+    if budget_class is TokenBudgetClass.NORMAL:
+        return TaskRiskLevel.MEDIUM
+    return TaskRiskLevel.LOW
+
+
+def _budget_exceeded(total_tokens: int, limit: int | None) -> bool:
+    return limit is not None and limit > 0 and total_tokens > limit
+
+
+def _is_unsupported_task(task_type: str) -> bool:
+    return task_type.strip().lower() in {"trade_execution", "brokerage_login"}
+
+
+def _sum_optional(left: int | None, right: int | None) -> int | None:
+    if left is None or right is None:
+        return None
+    return left + right
+
+
+def _validate_non_empty(value: str, field_name: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise ValueError(f"{field_name} cannot be empty")
+    return clean
+
+
+def _validate_non_negative(value: int, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} cannot be negative")
+
+
+def _validate_optional_non_negative(value: int | None, field_name: str) -> None:
+    if value is not None:
+        _validate_non_negative(value, field_name)

--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -222,6 +222,32 @@ def decide_route(
         budget_class=budget_class,
     )
 
+    # Decision priority ladder — intentional ordering:
+    #
+    # 1. budget_exceeded  → BLOCKED
+    #    Checked first because it is a hard operational gate that applies
+    #    regardless of content sensitivity. A budget-exhausted task would
+    #    otherwise fall through to the sensitive_context branch and produce
+    #    LOCAL instead of BLOCKED, silently allowing unbounded local usage.
+    #    BLOCKED is strictly more restrictive than LOCAL, so placing this
+    #    first is the conservative choice.
+    #
+    # 2. sensitive_context → LOCAL
+    #    Sensitive content is forced local, not blocked. LOCAL is the safe
+    #    outcome here: the task is allowed to run, but only on-device.
+    #    Checked after budget so that a budget-exceeded + sensitive task is
+    #    rejected outright rather than silently routed locally.
+    #
+    # 3. unsupported_task  → BLOCKED
+    #    Hard prohibition on trade_execution and brokerage_login.
+    #    Placed after content checks because task-type is a structural block
+    #    that does not interact with budget or sensitivity.
+    #
+    # 4. high_value / expensive → REMOTE_CANDIDATE or BLOCKED
+    #    Only reaches remote if policy explicitly enables it and at least one
+    #    provider is configured. Default policy disables this path entirely.
+    #
+    # 5. default           → LOCAL (local_first_default)
     if _budget_exceeded(total_tokens, policy.per_request_token_limit):
         return _decision(
             route=RouteDecisionKind.BLOCKED,

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -82,6 +82,9 @@ gateway:
     remote_enabled: false
     default_route: "local"
     log_decisions: true
+    # allow_remote_candidates: reserved for a future routing consumer.
+    # Not read by RemoteEscalationPolicy or decide_route() in Gateway-1.
+    # Enabling remote candidates requires an explicit ADR. See ADR-0020.
     allow_remote_candidates: true
     allowed_remote_providers: []
     per_request_token_limit: 0

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -76,3 +76,12 @@ rag:
     Cite sources in the format [doc_id#chunk_index].
     For calculations, use deterministic Python logic.
     Never request or reveal real portfolio data, credentials, or private documents.
+
+gateway:
+  routing:
+    remote_enabled: false
+    default_route: "local"
+    log_decisions: true
+    allow_remote_candidates: true
+    allowed_remote_providers: []
+    per_request_token_limit: 0

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -122,6 +122,15 @@ Runtime env vars (must be set locally before running OpenClaw):
 | `QUIMERA_LLM_EMBED_MODEL` | `quimera_embed` | Canonical embedding alias |
 | `QUIMERA_RAG_EMBEDDING_BACKEND` | `gateway_litellm` | Use `direct_ollama` for rollback |
 
+Gateway-1 routing policy defaults:
+
+| Field | Default | Notes |
+|---|---|---|
+| `gateway.routing.remote_enabled` | `false` | No remote calls allowed |
+| `gateway.routing.default_route` | `local` | Local-first baseline |
+| `gateway.routing.allowed_remote_providers` | `[]` | Empty until future ADR |
+| `gateway.routing.per_request_token_limit` | `0` | No budget gate enforced yet |
+
 ---
 
 ## 4. Sprint History and Current State
@@ -178,6 +187,30 @@ OpenClaw / LocalGenerator
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard | ✅ Merged |
 | GW-10 | `feat/rag-run-trace-provenance` | `RagRunTrace` provenance | ✅ Merged |
 | GW-11 | `feat/rag-observability-events` | Local structured RAG lifecycle events | ✅ Merged |
+
+### Sprint Gateway-1 — CURRENT
+
+Gateway-1 starts after Gateway-0 readiness. GW-13 adds routing policy
+primitives only:
+
+```text
+task metadata + token estimates
+  -> local-first routing policy
+  -> RouterDecision / TokenEconomyRecord
+  -> no remote call
+```
+
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | 🚧 Current |
+
+GW-13 rules:
+
+- Remote providers remain disabled.
+- Remote candidates are metadata only, not execution.
+- No secrets, no API keys, no remote calls.
+- No runtime model routing change.
+- No Qdrant mutation or `openclaw_knowledge` access.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,14 +5,19 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Gateway GW-12 operational readiness
+**Updated by:** Codex — Gateway GW-13 routing policy prelude
 
 ---
 
-## Active Sprint: Gateway-0 / LiteLLM Final Readiness
+## Active Sprint: Gateway-1 / Local-First Routing Prelude
 
-**Goal:** make LiteLLM the local-only model gateway for OpenClaw runtime model
-calls while preserving existing RAG/Qdrant behavior.
+**Goal:** add safe, offline local-first routing decision primitives and token
+economy records for future routing policy work. Remote providers remain
+disabled and no runtime model routing changes are made in GW-13.
+
+Gateway-0 is complete on `main`. Gateway-1 starts from issue
+[#51](https://github.com/franciscosalido/OPENCLAW/issues/51) and branch
+`feat/gateway1-routing-policy-prelude`.
 
 Current runtime path:
 
@@ -107,6 +112,7 @@ unavoidable, use `git push --force-with-lease`.
 | GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Done / merged |
 | GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -117,10 +123,36 @@ GW-09 issue: <https://github.com/franciscosalido/OPENCLAW/issues/42>
 GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
 GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
+GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
+
+## GW-13 Current Work
+
+GW-13 opens Gateway-1 with safe routing policy records only.
+
+Deliverables:
+
+- `backend/gateway/routing_policy.py` with frozen decision and token economy
+  dataclasses.
+- `config/rag_config.yaml` `gateway.routing` defaults with
+  `remote_enabled: false` and no allowed remote providers.
+- `docs/GATEWAY1_ROUTING_POLICY.md`.
+- `docs/ADR/0020-controlled-remote-escalation-policy.md` with status Proposed.
+- `docs/sprints/GATEWAY1_SPRINT_HANDOFF.md`.
+- `tests/unit/test_gateway_routing_policy.py`.
+
+Rules:
+
+- No remote providers.
+- No remote calls.
+- No API keys.
+- No runtime model routing change.
+- No Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge` access.
+- Token economy is estimated only, not billed.
+- Remote escalation requires future sanitization and an explicit Accepted ADR.
 
 ---
 

--- a/docs/ADR/0020-controlled-remote-escalation-policy.md
+++ b/docs/ADR/0020-controlled-remote-escalation-policy.md
@@ -1,0 +1,59 @@
+# ADR-0020: Controlled Remote Escalation Policy
+
+**Status:** Proposed  
+**Date:** 2026-05-01
+
+## Context
+
+Gateway-0 delivered a local-only model gateway with LiteLLM, Ollama/Qwen,
+`quimera_embed`, Qdrant RAG, provenance tracing, lifecycle observability, and
+operational readiness checks.
+
+Gateway-1 may eventually need policy decisions about whether a request remains
+local, is blocked, or becomes a candidate for remote escalation. Remote
+providers are not enabled in GW-13.
+
+## Decision
+
+Introduce local-first routing decision primitives and token economy records.
+These records are safe metadata only. They do not authorize remote calls.
+
+The default remote escalation policy is:
+
+- `remote_enabled: false`;
+- no allowed remote providers;
+- no remote API keys;
+- no remote calls.
+
+## Rules
+
+- Sensitive context must never be remote-allowed by default.
+- High-value or expensive tasks are blocked while remote routing is disabled.
+- Token economy is estimated and not billed.
+- Routing serialization uses an explicit allowlist.
+- Prompt, query, answer, chunk, vector, payload and secret content are never
+  serialized.
+- Remote provider enablement requires a future Accepted ADR.
+
+## Consequences
+
+Gateway-1 can discuss routing choices and estimated token avoidance without
+changing runtime model routing or adding providers.
+
+Future work must add sanitization, budget enforcement, explicit provider
+approval and security review before any remote calls are possible.
+
+## Out of Scope
+
+- Remote provider enablement.
+- Remote API calls.
+- API key configuration.
+- LiteLLM remote provider aliases.
+- FastAPI, MCP, quant tools, dashboards, OpenTelemetry, or distributed tracing.
+- Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge` access.
+
+## Revision Policy
+
+This ADR must move from Proposed to Accepted before Gateway-1 enables any
+remote escalation path. Any provider-specific routing requires its own
+reviewable follow-up.

--- a/docs/GATEWAY1_ROUTING_POLICY.md
+++ b/docs/GATEWAY1_ROUTING_POLICY.md
@@ -1,0 +1,77 @@
+# Gateway-1 Routing Policy Prelude
+
+Gateway-0 is closed. Gateway-1 begins with local-first routing policy
+primitives only: no remote providers, no remote calls, no API keys, and no
+runtime routing changes.
+
+## Decision Shape
+
+`backend/gateway/routing_policy.py` defines safe metadata records:
+
+- `RouterDecision`: whether a request remains `local`, is a
+  `remote_candidate`, or is `blocked`.
+- `TokenEconomyRecord`: estimated local/remote token accounting for the
+  decision.
+- `RemoteEscalationPolicy`: explicit policy inputs. Its default is
+  `remote_enabled=False` and `allowed_remote_providers=()`.
+
+The module is deterministic and offline. It does not read environment secrets,
+does not call a provider, and does not serialize prompt, query, answer, chunks,
+vectors, payloads or credentials.
+
+## Current Policy
+
+The Gateway-1 prelude keeps the system local-first:
+
+- Small and low-risk tasks route local.
+- Sensitive context never becomes remote-allowed.
+- High-value or expensive tasks may be recorded as remote candidates only if a
+  future policy explicitly enables remote routing and lists a provider.
+- With remote disabled, high-value or expensive tasks are blocked with
+  `remote_disabled`.
+- Budget overflow is blocked with `budget_exceeded`.
+
+Remote candidate records are planning metadata, not permission to call remote
+APIs.
+
+## Token Economy
+
+Token economy values are estimates only. They are not billing records.
+
+`TokenEconomyRecord` may record:
+
+- estimated local tokens;
+- estimated remote tokens;
+- estimated remote tokens avoided.
+
+The default `cost_estimate_mode` is `estimated_not_billed`.
+
+## Configuration
+
+`config/rag_config.yaml` contains:
+
+```yaml
+gateway:
+  routing:
+    remote_enabled: false
+    default_route: local
+    log_decisions: true
+    allow_remote_candidates: true
+    allowed_remote_providers: []
+    per_request_token_limit: 0
+```
+
+This config is declarative only in GW-13. It does not change model routing.
+
+## Future Requirements
+
+Before any future remote call:
+
+- an explicit ADR must be accepted;
+- sanitization must exist and be tested;
+- remote provider configuration must be reviewed;
+- budget policy must be enforced;
+- secrets must remain outside committed files.
+
+Gateway-1 starts with records and tests so future routing work has a safe
+contract to build on.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,0 +1,45 @@
+# Gateway-1 Sprint Handoff
+
+**Last updated:** 2026-05-01  
+**Current branch:** `feat/gateway1-routing-policy-prelude`  
+**Issue:** [#51](https://github.com/franciscosalido/OPENCLAW/issues/51)
+
+Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
+token economy records only.
+
+## GW-13 Current Work
+
+Scope:
+
+- Add `backend/gateway/routing_policy.py`.
+- Add offline routing decision records.
+- Add token economy estimate records.
+- Add declarative `gateway.routing` config with remote disabled.
+- Add deterministic unit tests.
+- Add ADR-0020 as Proposed.
+
+Out of scope:
+
+- Remote provider enablement.
+- Remote calls.
+- API keys.
+- Runtime model routing changes.
+- LiteLLM remote provider config.
+- Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge`.
+
+## Safety Contract
+
+- Remote providers remain disabled.
+- `allowed_remote_providers` is empty by default.
+- `remote_candidate` is only metadata for future review.
+- Token economy is estimated, not billed.
+- Serialized records must not include query, prompt, answer, chunks, vectors,
+  payloads, API keys, Authorization headers or secrets.
+
+## Planned Follow-ups
+
+| Item | Scope |
+|---|---|
+| GW-14 | Sanitization policy before any remote escalation |
+| GW-15 | Budget enforcement and approval flow |
+| GW-16 | Provider-specific ADR if remote routing is ever proposed |

--- a/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY_SPRINT_HANDOFF.md
@@ -552,3 +552,25 @@ Final rule:
 After GW-12 merges, Gateway-0 is complete on `main`. Any remote provider,
 OpenTelemetry/profiling, production ingestion or `openclaw_knowledge` work
 requires a new issue and explicit future ADR/sprint.
+
+## Gateway-1 Prelude
+
+GW-13 starts Gateway-1 on branch `feat/gateway1-routing-policy-prelude` and
+issue #51.
+
+Scope:
+
+- Local-first routing decision primitives.
+- Token economy estimate records.
+- Proposed ADR-0020 for controlled remote escalation policy.
+- Declarative config with remote disabled and no allowed providers.
+
+Out of scope:
+
+- Remote provider enablement.
+- Remote API calls.
+- Runtime model routing changes.
+- Sanitization implementation.
+- Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge` access.
+
+Gateway-1 handoff continues in `docs/sprints/GATEWAY1_SPRINT_HANDOFF.md`.

--- a/tests/unit/test_gateway_routing_policy.py
+++ b/tests/unit/test_gateway_routing_policy.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import inspect
+import unittest
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from backend.gateway import routing_policy
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouteBlockReason,
+    RouteDecisionKind,
+    TaskRiskLevel,
+    TokenBudgetClass,
+    TokenEconomyRecord,
+    build_token_economy_record,
+    decide_route,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAG_CONFIG = REPO_ROOT / "config" / "rag_config.yaml"
+FORBIDDEN_SERIALIZED_KEYS = {
+    "query",
+    "prompt",
+    "answer",
+    "chunks",
+    "vectors",
+    "payload",
+    "api_key",
+    "authorization",
+    "secret",
+    "token_value",
+    "password",
+    "headers",
+}
+
+
+def _routing_config() -> dict[str, Any]:
+    raw = yaml.safe_load(RAG_CONFIG.read_text(encoding="utf-8"))
+    assert isinstance(raw, dict)
+    gateway = raw["gateway"]
+    assert isinstance(gateway, dict)
+    routing = gateway["routing"]
+    assert isinstance(routing, dict)
+    return cast(dict[str, Any], routing)
+
+
+class GatewayRoutingPolicyTests(unittest.TestCase):
+    def test_default_config_disables_remote_providers(self) -> None:
+        config = _routing_config()
+
+        self.assertFalse(config["remote_enabled"])
+        self.assertEqual(config["default_route"], "local")
+        self.assertEqual(config["allowed_remote_providers"], [])
+        self.assertEqual(config["per_request_token_limit"], 0)
+
+    def test_default_policy_disables_remote(self) -> None:
+        policy = RemoteEscalationPolicy()
+
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+
+    def test_small_low_risk_task_routes_local(self) -> None:
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=120,
+            estimated_completion_tokens=80,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.LOCAL)
+        self.assertEqual(decision.reason, "local_first_default")
+        self.assertEqual(decision.risk_level, TaskRiskLevel.LOW)
+        self.assertEqual(decision.token_budget_class, TokenBudgetClass.TINY)
+        self.assertFalse(decision.remote_allowed)
+        self.assertEqual(decision.estimated_remote_tokens_avoided, 200)
+
+    def test_high_value_task_is_blocked_when_remote_disabled(self) -> None:
+        decision = decide_route(
+            task_type="portfolio_review",
+            estimated_prompt_tokens=2_000,
+            estimated_completion_tokens=800,
+            contains_sensitive_context=False,
+            high_value_task=True,
+            policy=RemoteEscalationPolicy(remote_enabled=False),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
+        self.assertEqual(decision.reason, RouteBlockReason.REMOTE_DISABLED.value)
+        self.assertFalse(decision.remote_allowed)
+        self.assertTrue(decision.requires_sanitization)
+        self.assertEqual(decision.estimated_remote_tokens_avoided, 2_800)
+
+    def test_high_value_task_can_be_remote_candidate_when_explicitly_enabled(self) -> None:
+        decision = decide_route(
+            task_type="architecture_review",
+            estimated_prompt_tokens=2_000,
+            estimated_completion_tokens=1_000,
+            contains_sensitive_context=False,
+            high_value_task=True,
+            policy=RemoteEscalationPolicy(
+                remote_enabled=True,
+                allowed_remote_providers=("future_provider",),
+            ),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.REMOTE_CANDIDATE)
+        self.assertTrue(decision.remote_allowed)
+        self.assertEqual(decision.remote_candidate_provider, "future_provider")
+        self.assertIsNone(decision.estimated_remote_tokens_avoided)
+
+    def test_sensitive_context_never_routes_remote(self) -> None:
+        decision = decide_route(
+            task_type="question_answering",
+            estimated_prompt_tokens=600,
+            estimated_completion_tokens=300,
+            contains_sensitive_context=True,
+            high_value_task=True,
+            policy=RemoteEscalationPolicy(
+                remote_enabled=True,
+                allowed_remote_providers=("future_provider",),
+            ),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.LOCAL)
+        self.assertEqual(decision.reason, RouteBlockReason.SENSITIVE_CONTEXT.value)
+        self.assertFalse(decision.remote_allowed)
+        self.assertIsNone(decision.remote_candidate_provider)
+        self.assertTrue(decision.requires_sanitization)
+
+    def test_budget_exceeded_blocks(self) -> None:
+        decision = decide_route(
+            task_type="large_review",
+            estimated_prompt_tokens=5_000,
+            estimated_completion_tokens=2_000,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(per_request_token_limit=1_000),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
+        self.assertEqual(decision.reason, RouteBlockReason.BUDGET_EXCEEDED.value)
+        self.assertEqual(decision.token_budget_class, TokenBudgetClass.BLOCKED)
+        self.assertEqual(decision.estimated_remote_tokens_avoided, 7_000)
+
+    def test_unsupported_task_blocks(self) -> None:
+        decision = decide_route(
+            task_type="trade_execution",
+            estimated_prompt_tokens=20,
+            estimated_completion_tokens=20,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
+        self.assertEqual(decision.reason, RouteBlockReason.UNSUPPORTED_TASK.value)
+
+    def test_decision_is_frozen(self) -> None:
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=10,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        with self.assertRaises(FrozenInstanceError):
+            decision.reason = "changed"  # type: ignore[misc]
+
+    def test_decision_to_log_dict_excludes_forbidden_fields(self) -> None:
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=10,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        data = decision.to_log_dict()
+
+        self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint({key.lower() for key in data}))
+        self.assertEqual(data["route"], "local")
+        self.assertEqual(data["risk_level"], "low")
+
+    def test_token_economy_record_estimates_remote_tokens_avoided(self) -> None:
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=100,
+            estimated_completion_tokens=50,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        record = build_token_economy_record(decision)
+        data = record.to_log_dict()
+
+        self.assertIsInstance(record, TokenEconomyRecord)
+        self.assertEqual(record.local_tokens_estimated, 150)
+        self.assertEqual(record.remote_tokens_avoided_estimated, 150)
+        self.assertEqual(data["cost_estimate_mode"], "estimated_not_billed")
+        self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint({key.lower() for key in data}))
+
+    def test_invalid_inputs_raise(self) -> None:
+        with self.assertRaises(ValueError):
+            RemoteEscalationPolicy(monthly_budget_usd=-1.0)
+        with self.assertRaises(ValueError):
+            RemoteEscalationPolicy(per_request_token_limit=-1)
+        with self.assertRaises(ValueError):
+            decide_route(
+                task_type="summary",
+                estimated_prompt_tokens=-1,
+                estimated_completion_tokens=1,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(),
+            )
+
+    def test_module_does_not_read_secrets_or_call_network(self) -> None:
+        source = inspect.getsource(routing_policy)
+
+        for forbidden in ("os.environ", "getenv", "httpx", "requests", "urllib", "socket"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Starts Gateway-1 with safe local-first routing policy primitives and token economy records.

Closes #51.

## Scope

Included:

- `backend/gateway/routing_policy.py` with frozen `RouterDecision`, `TokenEconomyRecord`, and `RemoteEscalationPolicy` records
- Deterministic offline `decide_route(...)` helper
- Explicit allowlist serialization for routing/token economy logs
- `gateway.routing` config with remote disabled and no allowed remote providers
- Gateway-1 routing policy guide
- ADR-0020 as Proposed
- Gateway-1 sprint handoff and memory updates
- Unit tests for default local routing, blocking, token economy, serialization safety, and offline/no-secret behavior

Excluded:

- Remote provider enablement
- Remote calls
- API keys
- Runtime model routing changes
- LiteLLM remote provider config
- Sanitization implementation
- Qdrant mutation/reindexing/ingestion
- FastAPI, MCP, quant tools, dashboards or OpenTelemetry

## Security

- Remote providers remain disabled
- `allowed_remote_providers` is empty by default
- No API keys are read
- No network calls are made
- No prompt/query/answer/chunks/vectors/payloads/secrets are serialized
- Token economy is estimated only, not billed

## Validation

```bash
git diff --check
uv run pytest tests/unit/test_gateway_routing_policy.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Results:

- `tests/unit/test_gateway_routing_policy.py`: 13 passed
- `uv run pytest -v`: 244 passed, 7 skipped
- `uv run mypy --strict .`: success, 62 source files
- `uv run pyright`: 0 errors
- `uv run pytest tests/smoke/ -v`: 5 passed, 7 skipped
