### PR TITLE
feat(gateway): add routing audit and token economy calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Thumbs.db
 
 # Logs
 logs/
+logs/*.jsonl
 *.log
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)

--- a/backend/gateway/__init__.py
+++ b/backend/gateway/__init__.py
@@ -43,15 +43,20 @@ from backend.gateway.errors import (
 )
 from backend.gateway.health import check_gateway_services, check_litellm_gateway
 from backend.gateway.routing_policy import (
+    DEFAULT_RAG_CONFIG_PATH,
     RemoteEscalationPolicy,
     RouteBlockReason,
     RouteDecisionKind,
     RouterDecision,
+    RoutingDecisionLogger,
     TaskRiskLevel,
+    TokenBudgetAccumulator,
     TokenBudgetClass,
     TokenEconomyRecord,
     build_token_economy_record,
     decide_route,
+    estimate_prompt_tokens,
+    load_routing_policy,
 )
 
 __all__ = [
@@ -76,15 +81,20 @@ __all__ = [
     "check_gateway_services",
     "check_litellm_gateway",
     # Gateway-1 routing policy
+    "DEFAULT_RAG_CONFIG_PATH",
     "RemoteEscalationPolicy",
     "RouteBlockReason",
     "RouteDecisionKind",
     "RouterDecision",
+    "RoutingDecisionLogger",
     "TaskRiskLevel",
+    "TokenBudgetAccumulator",
     "TokenBudgetClass",
     "TokenEconomyRecord",
     "build_token_economy_record",
     "decide_route",
+    "estimate_prompt_tokens",
+    "load_routing_policy",
     # Errors
     "GatewayAuthenticationError",
     "GatewayConnectionError",

--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -8,10 +8,22 @@ any future remote provider is enabled by ADR.
 
 from __future__ import annotations
 
+import hashlib
+import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
+from math import ceil
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
+
+import yaml
+
+
+DEFAULT_RAG_CONFIG_PATH = Path("config/rag_config.yaml")
+DEFAULT_BLOCKED_TASK_TYPES = ("trade_execution", "brokerage_login")
 
 
 class RouteDecisionKind(str, Enum):
@@ -62,6 +74,8 @@ class RemoteEscalationPolicy:
     monthly_budget_usd: float | None = None
     per_request_token_limit: int | None = None
     allowed_remote_providers: tuple[str, ...] = ()
+    blocked_task_types: tuple[str, ...] = DEFAULT_BLOCKED_TASK_TYPES
+    allowed_task_types: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.monthly_budget_usd is not None and self.monthly_budget_usd < 0:
@@ -73,6 +87,10 @@ class RemoteEscalationPolicy:
             raise ValueError("per_request_token_limit cannot be negative")
         for provider in self.allowed_remote_providers:
             _validate_non_empty(provider, "allowed_remote_providers")
+        for task_type in self.blocked_task_types:
+            _validate_non_empty(task_type, "blocked_task_types")
+        for task_type in self.allowed_task_types:
+            _validate_non_empty(task_type, "allowed_task_types")
 
 
 @dataclass(frozen=True)
@@ -88,6 +106,7 @@ class RouterDecision:
     remote_allowed: bool
     remote_candidate_provider: str | None
     requires_sanitization: bool
+    task_type: str | None = None
     estimated_prompt_tokens: int | None = None
     estimated_completion_tokens: int | None = None
     estimated_remote_tokens: int | None = None
@@ -102,6 +121,8 @@ class RouterDecision:
                 self.remote_candidate_provider,
                 "remote_candidate_provider",
             )
+        if self.task_type is not None:
+            _validate_non_empty(self.task_type, "task_type")
         _validate_optional_non_negative(
             self.estimated_prompt_tokens,
             "estimated_prompt_tokens",
@@ -133,6 +154,7 @@ class RouterDecision:
         }
         optional_values: dict[str, object | None] = {
             "remote_candidate_provider": self.remote_candidate_provider,
+            "task_type": self.task_type,
             "estimated_prompt_tokens": self.estimated_prompt_tokens,
             "estimated_completion_tokens": self.estimated_completion_tokens,
             "estimated_remote_tokens": self.estimated_remote_tokens,
@@ -142,6 +164,25 @@ class RouterDecision:
             if value is not None:
                 data[key] = value
         return data
+
+    def decision_fingerprint(self) -> str:
+        """Return a stable hash from safe policy-relevant fields only."""
+        payload: dict[str, object | None] = {
+            "route": self.route.value,
+            "reason": self.reason,
+            "risk_level": self.risk_level.value,
+            "token_budget_class": self.token_budget_class.value,
+            "remote_allowed": self.remote_allowed,
+            "remote_candidate_provider": self.remote_candidate_provider,
+            "requires_sanitization": self.requires_sanitization,
+            "task_type": self.task_type,
+            "estimated_prompt_tokens": self.estimated_prompt_tokens,
+            "estimated_completion_tokens": self.estimated_completion_tokens,
+            "estimated_remote_tokens": self.estimated_remote_tokens,
+            "estimated_remote_tokens_avoided": self.estimated_remote_tokens_avoided,
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -194,6 +235,161 @@ class TokenEconomyRecord:
             if value is not None:
                 data[key] = value
         return data
+
+
+class TokenBudgetAccumulator:
+    """In-memory session token estimate accumulator."""
+
+    def __init__(self) -> None:
+        self._totals = {
+            "estimated_prompt_tokens": 0,
+            "estimated_completion_tokens": 0,
+            "estimated_remote_tokens": 0,
+            "estimated_remote_tokens_avoided": 0,
+        }
+
+    def add(self, decision: RouterDecision | TokenEconomyRecord) -> None:
+        """Add safe token estimate fields from one decision or record."""
+        if isinstance(decision, RouterDecision):
+            values = {
+                "estimated_prompt_tokens": decision.estimated_prompt_tokens,
+                "estimated_completion_tokens": decision.estimated_completion_tokens,
+                "estimated_remote_tokens": decision.estimated_remote_tokens,
+                "estimated_remote_tokens_avoided": (
+                    decision.estimated_remote_tokens_avoided
+                ),
+            }
+        else:
+            values = {
+                "estimated_prompt_tokens": None,
+                "estimated_completion_tokens": None,
+                "estimated_remote_tokens": decision.remote_tokens_estimated,
+                "estimated_remote_tokens_avoided": (
+                    decision.remote_tokens_avoided_estimated
+                ),
+            }
+        for key, value in values.items():
+            if value is None:
+                continue
+            _validate_non_negative(value, key)
+            self._totals[key] += value
+
+    def total(self) -> dict[str, int]:
+        """Return accumulated session totals."""
+        return dict(self._totals)
+
+    def reset(self) -> None:
+        """Reset accumulated session totals."""
+        for key in self._totals:
+            self._totals[key] = 0
+
+
+class RoutingDecisionLogger:
+    """Append safe routing decisions to a local JSONL audit file."""
+
+    def __init__(
+        self,
+        base_path: Path | str,
+        *,
+        rotate_daily: bool = True,
+        enabled: bool = True,
+    ) -> None:
+        self.base_path = Path(base_path)
+        self.rotate_daily = rotate_daily
+        self.enabled = enabled
+
+    def append(self, decision: RouterDecision | TokenEconomyRecord) -> Path | None:
+        """Append one safe JSON object and return the file path written."""
+        if not self.enabled:
+            return None
+        path = self._log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = decision.to_log_dict()
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, sort_keys=True) + "\n")
+        return path
+
+    def _log_path(self) -> Path:
+        stem_path = self.base_path.with_suffix("")
+        if self.rotate_daily:
+            date = datetime.now(UTC).date().isoformat()
+            return stem_path.with_name(f"{stem_path.name}_{date}").with_suffix(
+                ".jsonl"
+            )
+        return stem_path.with_suffix(".jsonl")
+
+
+def load_routing_policy(
+    config_path: Path | str = DEFAULT_RAG_CONFIG_PATH,
+) -> RemoteEscalationPolicy:
+    """Load a safe local-first routing policy from ``config/rag_config.yaml``."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if raw is None:
+        return RemoteEscalationPolicy()
+    if not isinstance(raw, Mapping):
+        raise ValueError("routing config root must be a mapping")
+    gateway = raw.get("gateway", {})
+    if gateway is None:
+        gateway = {}
+    if not isinstance(gateway, Mapping):
+        raise ValueError("gateway config must be a mapping")
+    routing = gateway.get("routing", {})
+    if routing is None:
+        routing = {}
+    if not isinstance(routing, Mapping):
+        raise ValueError("gateway.routing config must be a mapping")
+
+    remote_enabled = _read_bool(routing, "remote_enabled", default=False)
+    monthly_budget_usd = _read_optional_float(routing, "monthly_budget_usd")
+    per_request_token_limit = _read_optional_int(
+        routing,
+        "per_request_token_limit",
+    )
+    allowed_remote_providers = _read_string_tuple(
+        routing,
+        "allowed_remote_providers",
+        default=(),
+    )
+    blocked_task_types = _read_string_tuple(
+        routing,
+        "blocked_task_types",
+        default=DEFAULT_BLOCKED_TASK_TYPES,
+    )
+    allowed_task_types = _read_string_tuple(
+        routing,
+        "allowed_task_types",
+        default=(),
+    )
+
+    return RemoteEscalationPolicy(
+        remote_enabled=remote_enabled,
+        monthly_budget_usd=monthly_budget_usd,
+        per_request_token_limit=per_request_token_limit,
+        allowed_remote_providers=allowed_remote_providers,
+        blocked_task_types=blocked_task_types,
+        allowed_task_types=allowed_task_types,
+    )
+
+
+def estimate_prompt_tokens(
+    text: str,
+    *,
+    chars_per_token: int = 4,
+    min_tokens: int = 1,
+) -> int:
+    """Estimate prompt tokens using a conservative local heuristic.
+
+    This is an estimate for local policy decisions, not a billing record.
+    """
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if chars_per_token <= 0:
+        raise ValueError("chars_per_token must be greater than zero")
+    if min_tokens < 0:
+        raise ValueError("min_tokens cannot be negative")
+    stripped = text.strip()
+    estimated = ceil(len(stripped) / chars_per_token) if stripped else 0
+    return max(estimated, min_tokens)
 
 
 def decide_route(
@@ -257,6 +453,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=contains_sensitive_context,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -272,13 +469,14 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=True,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
             estimated_remote_tokens_avoided=total_tokens,
         )
 
-    if _is_unsupported_task(clean_task_type):
+    if _is_unsupported_task(clean_task_type, policy):
         return _decision(
             route=RouteDecisionKind.BLOCKED,
             reason=RouteBlockReason.UNSUPPORTED_TASK.value,
@@ -287,6 +485,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=False,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -308,6 +507,7 @@ def decide_route(
                 remote_allowed=True,
                 remote_candidate_provider=provider,
                 requires_sanitization=True,
+                task_type=clean_task_type,
                 estimated_prompt_tokens=estimated_prompt_tokens,
                 estimated_completion_tokens=estimated_completion_tokens,
                 estimated_remote_tokens=total_tokens,
@@ -326,6 +526,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=provider,
             requires_sanitization=True,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -340,6 +541,7 @@ def decide_route(
         remote_allowed=False,
         remote_candidate_provider=None,
         requires_sanitization=False,
+        task_type=clean_task_type,
         estimated_prompt_tokens=estimated_prompt_tokens,
         estimated_completion_tokens=estimated_completion_tokens,
         estimated_remote_tokens=total_tokens,
@@ -386,6 +588,7 @@ def _decision(
     remote_allowed: bool,
     remote_candidate_provider: str | None,
     requires_sanitization: bool,
+    task_type: str,
     estimated_prompt_tokens: int,
     estimated_completion_tokens: int,
     estimated_remote_tokens: int | None,
@@ -401,6 +604,7 @@ def _decision(
         remote_allowed=remote_allowed,
         remote_candidate_provider=remote_candidate_provider,
         requires_sanitization=requires_sanitization,
+        task_type=task_type,
         estimated_prompt_tokens=estimated_prompt_tokens,
         estimated_completion_tokens=estimated_completion_tokens,
         estimated_remote_tokens=estimated_remote_tokens,
@@ -437,8 +641,13 @@ def _budget_exceeded(total_tokens: int, limit: int | None) -> bool:
     return limit is not None and limit > 0 and total_tokens > limit
 
 
-def _is_unsupported_task(task_type: str) -> bool:
-    return task_type.strip().lower() in {"trade_execution", "brokerage_login"}
+def _is_unsupported_task(task_type: str, policy: RemoteEscalationPolicy) -> bool:
+    clean_task_type = task_type.strip().lower()
+    blocked = {item.strip().lower() for item in policy.blocked_task_types}
+    allowed = {item.strip().lower() for item in policy.allowed_task_types}
+    if clean_task_type in blocked:
+        return True
+    return bool(allowed) and clean_task_type not in allowed
 
 
 def _sum_optional(left: int | None, right: int | None) -> int | None:
@@ -462,3 +671,50 @@ def _validate_non_negative(value: int, field_name: str) -> None:
 def _validate_optional_non_negative(value: int | None, field_name: str) -> None:
     if value is not None:
         _validate_non_negative(value, field_name)
+
+
+def _read_bool(
+    mapping: Mapping[str, Any],
+    key: str,
+    *,
+    default: bool,
+) -> bool:
+    value = mapping.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be a boolean")
+    return value
+
+
+def _read_optional_int(mapping: Mapping[str, Any], key: str) -> int | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be an integer")
+    return value
+
+
+def _read_optional_float(mapping: Mapping[str, Any], key: str) -> float | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be a number")
+    return float(value)
+
+
+def _read_string_tuple(
+    mapping: Mapping[str, Any],
+    key: str,
+    *,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = mapping.get(key, list(default))
+    if not isinstance(value, list):
+        raise ValueError(f"gateway.routing.{key} must be a list")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"gateway.routing.{key} must contain only strings")
+        result.append(_validate_non_empty(item, key))
+    return tuple(result)

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -82,9 +82,17 @@ gateway:
     remote_enabled: false
     default_route: "local"
     log_decisions: true
-    # allow_remote_candidates: reserved for a future routing consumer.
-    # Not read by RemoteEscalationPolicy or decide_route() in Gateway-1.
-    # Enabling remote candidates requires an explicit ADR. See ADR-0020.
+    decision_log_path: "logs/routing_decisions"
+    decision_log_rotate_daily: true
+    # allow_remote_candidates records planning metadata only.
+    # Enabling remote execution requires a future accepted ADR.
     allow_remote_candidates: true
     allowed_remote_providers: []
     per_request_token_limit: 0
+    blocked_task_types:
+      - "trade_execution"
+      - "brokerage_login"
+    allowed_task_types: []
+    token_estimation:
+      chars_per_token: 4
+      min_tokens: 1

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -189,6 +189,7 @@ OpenClaw / LocalGenerator
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard | ✅ Merged |
 | GW-10 | `feat/rag-run-trace-provenance` | `RagRunTrace` provenance | ✅ Merged |
 | GW-11 | `feat/rag-observability-events` | Local structured RAG lifecycle events | ✅ Merged |
+| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
 
 ### Sprint Gateway-1 — CURRENT
 
@@ -214,10 +215,14 @@ GW-13 rules:
 - No secrets, no API keys, no remote calls.
 - No runtime model routing change.
 - No Qdrant mutation or `openclaw_knowledge` access.
-- GW-14 adds local JSONL audit records, heuristic token estimation and
-  in-memory token budget accumulation. These are policy artifacts only, not
-  billing or runtime routing.
-| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
+
+GW-14 rules:
+
+- Config-driven routing audit and token economy calibration.
+- Local JSONL audit records, heuristic token estimation, in-memory token budget accumulation.
+- Policy artifacts only — not billing, not runtime routing.
+- `remote_enabled` remains false. `allowed_remote_providers` remains empty.
+- No remote calls, no runtime routing change, no Qdrant mutation.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -130,6 +130,8 @@ Gateway-1 routing policy defaults:
 | `gateway.routing.default_route` | `local` | Local-first baseline |
 | `gateway.routing.allowed_remote_providers` | `[]` | Empty until future ADR |
 | `gateway.routing.per_request_token_limit` | `0` | No budget gate enforced yet |
+| `gateway.routing.decision_log_path` | `logs/routing_decisions` | Local JSONL audit base path |
+| `gateway.routing.blocked_task_types` | `trade_execution`, `brokerage_login` | Config-driven local blocks |
 
 ---
 
@@ -202,7 +204,8 @@ task metadata + token estimates
 
 | PR | Branch | Scope | Status |
 |---|---|---|---|
-| GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | 🚧 Current |
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | 🚧 Current |
 
 GW-13 rules:
 
@@ -211,6 +214,9 @@ GW-13 rules:
 - No secrets, no API keys, no remote calls.
 - No runtime model routing change.
 - No Qdrant mutation or `openclaw_knowledge` access.
+- GW-14 adds local JSONL audit records, heuristic token estimation and
+  in-memory token budget accumulation. These are policy artifacts only, not
+  billing or runtime routing.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,7 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Gateway GW-13 routing policy prelude
+**Updated by:** Codex — Gateway GW-14 routing audit and token economy
 
 ---
 
@@ -13,11 +13,13 @@
 
 **Goal:** add safe, offline local-first routing decision primitives and token
 economy records for future routing policy work. Remote providers remain
-disabled and no runtime model routing changes are made in GW-13.
+disabled and no runtime model routing changes are made in Gateway-1 policy
+work.
 
-Gateway-0 is complete on `main`. Gateway-1 starts from issue
-[#51](https://github.com/franciscosalido/OPENCLAW/issues/51) and branch
-`feat/gateway1-routing-policy-prelude`.
+Gateway-0 is complete on `main`. Gateway-1 started from issue
+[#51](https://github.com/franciscosalido/OPENCLAW/issues/51). GW-14 continues
+from issue [#53](https://github.com/franciscosalido/OPENCLAW/issues/53) on
+branch `feat/gateway1-routing-audit-token-economy`.
 
 Current runtime path:
 
@@ -112,7 +114,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Done / merged |
 | GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
-| GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Current |
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -124,12 +127,13 @@ GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
 GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
+GW-14 issue: <https://github.com/franciscosalido/OPENCLAW/issues/53>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
 
-## GW-13 Current Work
+## GW-13 Completed Work
 
 GW-13 opens Gateway-1 with safe routing policy records only.
 
@@ -153,6 +157,29 @@ Rules:
 - No Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge` access.
 - Token economy is estimated only, not billed.
 - Remote escalation requires future sanitization and an explicit Accepted ADR.
+
+## GW-14 Current Work
+
+GW-14 connects Gateway-1 routing primitives to config and local audit records.
+
+Deliverables:
+
+- `load_routing_policy()` reads `gateway.routing` from `config/rag_config.yaml`.
+- `estimate_prompt_tokens()` adds heuristic token estimation without a
+  tokenizer dependency.
+- `TokenBudgetAccumulator` tracks session-local estimates in memory only.
+- `RoutingDecisionLogger` writes safe append-only JSONL audit records under
+  `logs/`.
+- `RouterDecision.decision_fingerprint()` hashes safe policy-relevant fields.
+- Task type blocking/allowing is config-driven.
+
+Rules:
+
+- `remote_enabled` remains false.
+- `allowed_remote_providers` remains empty.
+- No remote calls, no remote provider API keys, no runtime routing change.
+- JSONL audit files are local artifacts and must not be committed.
+- Local fallback on timeout and health-aware routing are deferred.
 
 ---
 

--- a/docs/GATEWAY1_ROUTING_POLICY.md
+++ b/docs/GATEWAY1_ROUTING_POLICY.md
@@ -1,4 +1,4 @@
-# Gateway-1 Routing Policy Prelude
+# Gateway-1 Routing Policy
 
 Gateway-0 is closed. Gateway-1 begins with local-first routing policy
 primitives only: no remote providers, no remote calls, no API keys, and no
@@ -14,6 +14,8 @@ runtime routing changes.
   decision.
 - `RemoteEscalationPolicy`: explicit policy inputs. Its default is
   `remote_enabled=False` and `allowed_remote_providers=()`.
+- `RoutingDecisionLogger`: append-only local JSONL audit writer.
+- `TokenBudgetAccumulator`: in-memory session token estimate accumulator.
 
 The module is deterministic and offline. It does not read environment secrets,
 does not call a provider, and does not serialize prompt, query, answer, chunks,
@@ -30,6 +32,9 @@ The Gateway-1 prelude keeps the system local-first:
 - With remote disabled, high-value or expensive tasks are blocked with
   `remote_disabled`.
 - Budget overflow is blocked with `budget_exceeded`.
+- Config-driven `blocked_task_types` default to `trade_execution` and
+  `brokerage_login`.
+- Empty `allowed_task_types` means all non-blocked task types are allowed.
 
 Remote candidate records are planning metadata, not permission to call remote
 APIs.
@@ -46,6 +51,30 @@ Token economy values are estimates only. They are not billing records.
 
 The default `cost_estimate_mode` is `estimated_not_billed`.
 
+Prompt token estimation uses a local heuristic:
+
+```text
+ceil(len(text.strip()) / chars_per_token), bounded by min_tokens
+```
+
+No tokenizer dependency is introduced.
+
+`TokenBudgetAccumulator` is session-scoped and in-memory only. It does not
+persist data and does not use a global singleton.
+
+## Local JSONL Audit
+
+`RoutingDecisionLogger` writes one safe JSON object per line to a local file.
+With daily rotation enabled, the path is:
+
+```text
+logs/routing_decisions_YYYY-MM-DD.jsonl
+```
+
+These files are local audit artifacts and must not be committed. They never
+include prompt, query, answer, chunks, vectors, payloads, API keys,
+Authorization headers or secrets.
+
 ## Configuration
 
 `config/rag_config.yaml` contains:
@@ -56,12 +85,29 @@ gateway:
     remote_enabled: false
     default_route: local
     log_decisions: true
+    decision_log_path: logs/routing_decisions
+    decision_log_rotate_daily: true
     allow_remote_candidates: true
     allowed_remote_providers: []
     per_request_token_limit: 0
+    blocked_task_types:
+      - trade_execution
+      - brokerage_login
+    allowed_task_types: []
+    token_estimation:
+      chars_per_token: 4
+      min_tokens: 1
 ```
 
-This config is declarative only in GW-13. It does not change model routing.
+This config is declarative and policy-only. It does not change chat/RAG runtime
+execution.
+
+## Deferred
+
+- Local fallback on timeout is not implemented in GW-14.
+- Health-aware runtime routing is not implemented in GW-14.
+- Sanitization must be implemented before any remote provider can be enabled.
+- Remote provider enablement requires a future Accepted ADR.
 
 ## Future Requirements
 
@@ -73,5 +119,5 @@ Before any future remote call:
 - budget policy must be enforced;
 - secrets must remain outside committed files.
 
-Gateway-1 starts with records and tests so future routing work has a safe
-contract to build on.
+Gateway-1 starts with records, config and tests so future routing work has a
+safe contract to build on.

--- a/docs/GATEWAY1_TOKEN_ECONOMY.md
+++ b/docs/GATEWAY1_TOKEN_ECONOMY.md
@@ -1,0 +1,49 @@
+# Gateway-1 Token Economy
+
+Gateway-1 token economy is local, heuristic and non-billing.
+
+## Scope
+
+GW-14 records estimated token usage for routing decisions. It does not call
+remote providers, does not read API keys, and does not use a tokenizer
+dependency.
+
+## Estimation
+
+Prompt token estimation uses:
+
+```text
+ceil(len(text.strip()) / chars_per_token)
+```
+
+The result is bounded by `min_tokens`.
+
+Defaults:
+
+- `chars_per_token: 4`
+- `min_tokens: 1`
+
+These estimates are useful for routing policy and local audit records. They are
+not billing records and should not be treated as exact provider usage.
+
+## Session Accumulation
+
+`TokenBudgetAccumulator` is in-memory only. It can add:
+
+- `RouterDecision`
+- `TokenEconomyRecord`
+
+It tracks:
+
+- estimated prompt tokens;
+- estimated completion tokens;
+- estimated remote tokens;
+- estimated remote tokens avoided.
+
+No global singleton is created and no persistence is performed.
+
+## Safety
+
+Token economy records must not include prompt text, query text, answers,
+chunks, vectors, payloads, portfolio data, API keys, Authorization headers or
+secrets.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -7,7 +7,7 @@
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
 
-## GW-13 Current Work
+## GW-13 Completed Work
 
 Scope:
 
@@ -43,3 +43,33 @@ Out of scope:
 | GW-14 | Sanitization policy before any remote escalation |
 | GW-15 | Budget enforcement and approval flow |
 | GW-16 | Provider-specific ADR if remote routing is ever proposed |
+
+## GW-14 Current Work
+
+Branch: `feat/gateway1-routing-audit-token-economy`
+Issue: [#53](https://github.com/franciscosalido/OPENCLAW/issues/53)
+
+Scope:
+
+- Load `RemoteEscalationPolicy` from `config/rag_config.yaml`.
+- Add local JSONL routing decision audit records.
+- Add heuristic prompt token estimation.
+- Add in-memory `TokenBudgetAccumulator`.
+- Add config-driven blocked/allowed task type registry.
+- Add stable `RouterDecision.decision_fingerprint()`.
+- Add deterministic unit and integration tests.
+
+Out of scope:
+
+- Remote providers, API keys or remote calls.
+- Runtime chat/RAG routing changes.
+- Local fallback on timeout.
+- Health-aware runtime routing.
+- Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge`.
+
+Safety:
+
+- `remote_enabled` remains false.
+- `allowed_remote_providers` remains empty.
+- JSONL audit files are local and ignored by git.
+- Token economy is estimated, not billed.

--- a/tests/integration/test_routing_policy_config_integration.py
+++ b/tests/integration/test_routing_policy_config_integration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouteDecisionKind,
+    decide_route,
+    load_routing_policy,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAG_CONFIG = REPO_ROOT / "config" / "rag_config.yaml"
+
+
+class RoutingPolicyConfigIntegrationTests(unittest.TestCase):
+    def test_load_real_rag_config_keeps_remote_disabled(self) -> None:
+        policy = load_routing_policy(RAG_CONFIG)
+
+        self.assertIsInstance(policy, RemoteEscalationPolicy)
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+
+    def test_default_config_produces_only_local_or_blocked_decisions(self) -> None:
+        policy = load_routing_policy(RAG_CONFIG)
+        cases = [
+            ("summary", 100, 50, False, False),
+            ("portfolio_review", 2_000, 1_000, False, True),
+            ("trade_execution", 20, 20, False, False),
+        ]
+
+        for task_type, prompt_tokens, completion_tokens, sensitive, high_value in cases:
+            with self.subTest(task_type=task_type):
+                decision = decide_route(
+                    task_type=task_type,
+                    estimated_prompt_tokens=prompt_tokens,
+                    estimated_completion_tokens=completion_tokens,
+                    contains_sensitive_context=sensitive,
+                    high_value_task=high_value,
+                    policy=policy,
+                )
+                self.assertIn(
+                    decision.route,
+                    {RouteDecisionKind.LOCAL, RouteDecisionKind.BLOCKED},
+                )
+                self.assertFalse(decision.remote_allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway_routing_policy.py
+++ b/tests/unit/test_gateway_routing_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import tempfile
 import unittest
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -18,6 +19,8 @@ from backend.gateway.routing_policy import (
     TokenEconomyRecord,
     build_token_economy_record,
     decide_route,
+    estimate_prompt_tokens,
+    load_routing_policy,
 )
 
 
@@ -57,6 +60,60 @@ class GatewayRoutingPolicyTests(unittest.TestCase):
         self.assertEqual(config["default_route"], "local")
         self.assertEqual(config["allowed_remote_providers"], [])
         self.assertEqual(config["per_request_token_limit"], 0)
+        self.assertEqual(config["decision_log_path"], "logs/routing_decisions")
+        self.assertTrue(config["decision_log_rotate_daily"])
+        self.assertEqual(
+            config["blocked_task_types"],
+            ["trade_execution", "brokerage_login"],
+        )
+        self.assertEqual(config["allowed_task_types"], [])
+        self.assertEqual(config["token_estimation"]["chars_per_token"], 4)
+        self.assertEqual(config["token_estimation"]["min_tokens"], 1)
+
+    def test_load_routing_policy_reads_config_and_returns_safe_defaults(self) -> None:
+        policy = load_routing_policy(RAG_CONFIG)
+
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+        self.assertEqual(policy.per_request_token_limit, 0)
+        self.assertEqual(
+            policy.blocked_task_types,
+            ("trade_execution", "brokerage_login"),
+        )
+        self.assertEqual(policy.allowed_task_types, ())
+
+    def test_load_routing_policy_defaults_when_gateway_section_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text("rag: {}\n", encoding="utf-8")
+
+            policy = load_routing_policy(path)
+
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+        self.assertEqual(policy.blocked_task_types, ("trade_execution", "brokerage_login"))
+
+    def test_load_routing_policy_rejects_invalid_config_types(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text("gateway:\n  routing: []\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                load_routing_policy(path)
+
+    def test_estimate_prompt_tokens_uses_conservative_heuristic(self) -> None:
+        self.assertEqual(estimate_prompt_tokens("abcd"), 1)
+        self.assertEqual(estimate_prompt_tokens("abcde"), 2)
+        self.assertEqual(estimate_prompt_tokens("   "), 1)
+        self.assertEqual(estimate_prompt_tokens("   ", min_tokens=0), 0)
+
+    def test_estimate_prompt_tokens_validates_inputs(self) -> None:
+        with self.assertRaises(TypeError):
+            estimate_prompt_tokens(123)  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            estimate_prompt_tokens("abc", chars_per_token=0)
+        with self.assertRaises(ValueError):
+            estimate_prompt_tokens("abc", min_tokens=-1)
 
     def test_default_policy_disables_remote(self) -> None:
         policy = RemoteEscalationPolicy()
@@ -162,6 +219,32 @@ class GatewayRoutingPolicyTests(unittest.TestCase):
         self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
         self.assertEqual(decision.reason, RouteBlockReason.UNSUPPORTED_TASK.value)
 
+    def test_blocked_task_types_from_policy_are_honored(self) -> None:
+        decision = decide_route(
+            task_type="custom_blocked",
+            estimated_prompt_tokens=20,
+            estimated_completion_tokens=20,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(blocked_task_types=("custom_blocked",)),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
+        self.assertEqual(decision.reason, RouteBlockReason.UNSUPPORTED_TASK.value)
+
+    def test_allowed_task_types_blocks_unlisted_tasks(self) -> None:
+        decision = decide_route(
+            task_type="not_allowed",
+            estimated_prompt_tokens=20,
+            estimated_completion_tokens=20,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(allowed_task_types=("summary",)),
+        )
+
+        self.assertEqual(decision.route, RouteDecisionKind.BLOCKED)
+        self.assertEqual(decision.reason, RouteBlockReason.UNSUPPORTED_TASK.value)
+
     def test_decision_is_frozen(self) -> None:
         decision = decide_route(
             task_type="summary",
@@ -190,6 +273,57 @@ class GatewayRoutingPolicyTests(unittest.TestCase):
         self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint({key.lower() for key in data}))
         self.assertEqual(data["route"], "local")
         self.assertEqual(data["risk_level"], "low")
+
+    def test_decision_fingerprint_is_stable_without_id_or_timestamp(self) -> None:
+        first = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=10,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        second = type(first)(
+            decision_id="different-id",
+            timestamp_utc="2099-01-01T00:00:00Z",
+            route=first.route,
+            reason=first.reason,
+            risk_level=first.risk_level,
+            token_budget_class=first.token_budget_class,
+            remote_allowed=first.remote_allowed,
+            remote_candidate_provider=first.remote_candidate_provider,
+            requires_sanitization=first.requires_sanitization,
+            task_type=first.task_type,
+            estimated_prompt_tokens=first.estimated_prompt_tokens,
+            estimated_completion_tokens=first.estimated_completion_tokens,
+            estimated_remote_tokens=first.estimated_remote_tokens,
+            estimated_remote_tokens_avoided=first.estimated_remote_tokens_avoided,
+        )
+
+        self.assertEqual(first.decision_fingerprint(), second.decision_fingerprint())
+
+    def test_decision_fingerprint_changes_for_materially_different_policy(self) -> None:
+        first = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=10,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        second = decide_route(
+            task_type="portfolio_review",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=10,
+            contains_sensitive_context=False,
+            high_value_task=True,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        self.assertNotEqual(
+            first.decision_fingerprint(),
+            second.decision_fingerprint(),
+        )
 
     def test_token_economy_record_estimates_remote_tokens_avoided(self) -> None:
         decision = decide_route(

--- a/tests/unit/test_routing_decision_logger.py
+++ b/tests/unit/test_routing_decision_logger.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouterDecision,
+    RoutingDecisionLogger,
+    build_token_economy_record,
+    decide_route,
+)
+
+
+FORBIDDEN_SERIALIZED_KEYS = {
+    "query",
+    "question",
+    "prompt",
+    "answer",
+    "response",
+    "chunk",
+    "chunks",
+    "vector",
+    "vectors",
+    "embedding",
+    "payload",
+    "qdrant_payload",
+    "portfolio",
+    "carteira",
+    "api_key",
+    "authorization",
+    "secret",
+    "token_value",
+    "password",
+    "headers",
+}
+
+
+def _decision() -> RouterDecision:
+    return decide_route(
+        task_type="summary",
+        estimated_prompt_tokens=100,
+        estimated_completion_tokens=50,
+        contains_sensitive_context=False,
+        high_value_task=False,
+        policy=RemoteEscalationPolicy(),
+    )
+
+
+class RoutingDecisionLoggerTests(unittest.TestCase):
+    def test_disabled_logger_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = RoutingDecisionLogger(
+                Path(tmpdir) / "routing_decisions",
+                enabled=False,
+            )
+
+            result = logger.append(_decision())
+
+            self.assertIsNone(result)
+            self.assertEqual(list(Path(tmpdir).iterdir()), [])
+
+    def test_logger_writes_exactly_one_jsonl_line(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = RoutingDecisionLogger(
+                Path(tmpdir) / "routing_decisions",
+                rotate_daily=False,
+            )
+
+            path = logger.append(_decision())
+
+            self.assertIsNotNone(path)
+            assert path is not None
+            lines = path.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            data = json.loads(lines[0])
+            self.assertEqual(data["route"], "local")
+            self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint(set(data)))
+
+    def test_daily_rotation_filename_includes_utc_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = RoutingDecisionLogger(Path(tmpdir) / "routing_decisions")
+
+            path = logger.append(_decision())
+
+            self.assertIsNotNone(path)
+            assert path is not None
+            self.assertRegex(
+                path.name,
+                r"routing_decisions_\d{4}-\d{2}-\d{2}\.jsonl",
+            )
+
+    def test_logger_can_append_token_economy_record(self) -> None:
+        decision = _decision()
+        record = build_token_economy_record(decision)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = RoutingDecisionLogger(
+                Path(tmpdir) / "routing_decisions",
+                rotate_daily=False,
+            )
+
+            path = logger.append(record)
+
+            self.assertIsNotNone(path)
+            assert path is not None
+            data = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(data["cost_estimate_mode"], "estimated_not_billed")
+            self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint(set(data)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_token_budget_accumulator.py
+++ b/tests/unit/test_token_budget_accumulator.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import unittest
+
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    TokenBudgetAccumulator,
+    build_token_economy_record,
+    decide_route,
+)
+
+
+class TokenBudgetAccumulatorTests(unittest.TestCase):
+    def test_add_decision_and_total(self) -> None:
+        accumulator = TokenBudgetAccumulator()
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=100,
+            estimated_completion_tokens=50,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+
+        accumulator.add(decision)
+
+        self.assertEqual(
+            accumulator.total(),
+            {
+                "estimated_prompt_tokens": 100,
+                "estimated_completion_tokens": 50,
+                "estimated_remote_tokens": 150,
+                "estimated_remote_tokens_avoided": 150,
+            },
+        )
+
+    def test_add_token_economy_record_and_reset(self) -> None:
+        accumulator = TokenBudgetAccumulator()
+        decision = decide_route(
+            task_type="summary",
+            estimated_prompt_tokens=100,
+            estimated_completion_tokens=50,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        record = build_token_economy_record(decision)
+
+        accumulator.add(record)
+        self.assertEqual(accumulator.total()["estimated_remote_tokens"], 150)
+        self.assertEqual(accumulator.total()["estimated_remote_tokens_avoided"], 150)
+
+        accumulator.reset()
+
+        self.assertEqual(
+            accumulator.total(),
+            {
+                "estimated_prompt_tokens": 0,
+                "estimated_completion_tokens": 0,
+                "estimated_remote_tokens": 0,
+                "estimated_remote_tokens_avoided": 0,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds GW-14 config-driven routing policy loading, safe local JSONL routing audit records, heuristic prompt token estimation, session token budget accumulation, task type registry support, and routing decision fingerprints.

Closes #53.

## Scope

Included:

- `load_routing_policy()` for `config/rag_config.yaml` `gateway.routing`
- Safe defaults when routing config fields are absent
- Config fields for local decision audit and token estimation
- `estimate_prompt_tokens(...)` using a local heuristic only
- `TokenBudgetAccumulator` for in-memory session totals
- `RoutingDecisionLogger` for append-only local JSONL audit artifacts
- Config-driven `blocked_task_types` and `allowed_task_types`
- `RouterDecision.decision_fingerprint()` using safe policy fields only
- Unit and integration tests against the real `rag_config.yaml`
- Gateway-1 docs, token economy doc and handoff updates

Excluded:

- Remote provider enablement
- Remote calls
- Remote provider API keys
- LiteLLM remote aliases
- GatewayChatClient runtime behavior changes
- local_fallback_on_timeout
- Health-check-based runtime routing
- Qdrant mutation/reindexing/ingestion
- FastAPI, MCP, quant tools, dashboards, OpenTelemetry
- Sensitive logging

## Config Fields Added

```yaml
gateway:
  routing:
    decision_log_path: logs/routing_decisions
    decision_log_rotate_daily: true
    blocked_task_types:
      - trade_execution
      - brokerage_login
    allowed_task_types: []
    token_estimation:
      chars_per_token: 4
      min_tokens: 1
```

`remote_enabled` remains `false` and `allowed_remote_providers` remains empty.

## Security

- No remote providers enabled
- No remote calls
- No remote provider API keys read or added
- No prompt/query/answer/chunks/vectors/payloads/secrets serialized
- JSONL audit records are local artifacts ignored by git
- No runtime chat/RAG execution behavior changed
- No Qdrant mutation or `openclaw_knowledge` access

## Validation

```bash
git diff --check
uv run pytest tests/unit/test_gateway_routing_policy.py -v
uv run pytest tests/unit/test_routing_decision_logger.py -v
uv run pytest tests/unit/test_token_budget_accumulator.py -v
uv run pytest tests/integration/test_routing_policy_config_integration.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Results:

- routing policy unit: 22 passed
- routing decision logger unit: 4 passed
- token budget accumulator unit: 2 passed
- routing config integration: 2 passed
- full pytest: 261 passed, 7 skipped
- mypy strict: success, 65 source files
- pyright: 0 errors
- smoke: 5 passed, 7 skipped
