### PR TITLE
test(agent): harden Agent-0 runner contracts

### DIFF
--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -8,10 +8,22 @@ any future remote provider is enabled by ADR.
 
 from __future__ import annotations
 
+import hashlib
+import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
+from math import ceil
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
+
+import yaml
+
+
+DEFAULT_RAG_CONFIG_PATH = Path("config/rag_config.yaml")
+DEFAULT_BLOCKED_TASK_TYPES = ("trade_execution", "brokerage_login")
 
 
 class RouteDecisionKind(str, Enum):
@@ -62,6 +74,8 @@ class RemoteEscalationPolicy:
     monthly_budget_usd: float | None = None
     per_request_token_limit: int | None = None
     allowed_remote_providers: tuple[str, ...] = ()
+    blocked_task_types: tuple[str, ...] = DEFAULT_BLOCKED_TASK_TYPES
+    allowed_task_types: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.monthly_budget_usd is not None and self.monthly_budget_usd < 0:
@@ -73,6 +87,10 @@ class RemoteEscalationPolicy:
             raise ValueError("per_request_token_limit cannot be negative")
         for provider in self.allowed_remote_providers:
             _validate_non_empty(provider, "allowed_remote_providers")
+        for task_type in self.blocked_task_types:
+            _validate_non_empty(task_type, "blocked_task_types")
+        for task_type in self.allowed_task_types:
+            _validate_non_empty(task_type, "allowed_task_types")
 
 
 @dataclass(frozen=True)
@@ -88,6 +106,7 @@ class RouterDecision:
     remote_allowed: bool
     remote_candidate_provider: str | None
     requires_sanitization: bool
+    task_type: str | None = None
     estimated_prompt_tokens: int | None = None
     estimated_completion_tokens: int | None = None
     estimated_remote_tokens: int | None = None
@@ -102,6 +121,8 @@ class RouterDecision:
                 self.remote_candidate_provider,
                 "remote_candidate_provider",
             )
+        if self.task_type is not None:
+            _validate_non_empty(self.task_type, "task_type")
         _validate_optional_non_negative(
             self.estimated_prompt_tokens,
             "estimated_prompt_tokens",
@@ -133,6 +154,7 @@ class RouterDecision:
         }
         optional_values: dict[str, object | None] = {
             "remote_candidate_provider": self.remote_candidate_provider,
+            "task_type": self.task_type,
             "estimated_prompt_tokens": self.estimated_prompt_tokens,
             "estimated_completion_tokens": self.estimated_completion_tokens,
             "estimated_remote_tokens": self.estimated_remote_tokens,
@@ -142,6 +164,25 @@ class RouterDecision:
             if value is not None:
                 data[key] = value
         return data
+
+    def decision_fingerprint(self) -> str:
+        """Return a stable hash from safe policy-relevant fields only."""
+        payload: dict[str, object | None] = {
+            "route": self.route.value,
+            "reason": self.reason,
+            "risk_level": self.risk_level.value,
+            "token_budget_class": self.token_budget_class.value,
+            "remote_allowed": self.remote_allowed,
+            "remote_candidate_provider": self.remote_candidate_provider,
+            "requires_sanitization": self.requires_sanitization,
+            "task_type": self.task_type,
+            "estimated_prompt_tokens": self.estimated_prompt_tokens,
+            "estimated_completion_tokens": self.estimated_completion_tokens,
+            "estimated_remote_tokens": self.estimated_remote_tokens,
+            "estimated_remote_tokens_avoided": self.estimated_remote_tokens_avoided,
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -194,6 +235,161 @@ class TokenEconomyRecord:
             if value is not None:
                 data[key] = value
         return data
+
+
+class TokenBudgetAccumulator:
+    """In-memory session token estimate accumulator."""
+
+    def __init__(self) -> None:
+        self._totals = {
+            "estimated_prompt_tokens": 0,
+            "estimated_completion_tokens": 0,
+            "estimated_remote_tokens": 0,
+            "estimated_remote_tokens_avoided": 0,
+        }
+
+    def add(self, decision: RouterDecision | TokenEconomyRecord) -> None:
+        """Add safe token estimate fields from one decision or record."""
+        if isinstance(decision, RouterDecision):
+            values = {
+                "estimated_prompt_tokens": decision.estimated_prompt_tokens,
+                "estimated_completion_tokens": decision.estimated_completion_tokens,
+                "estimated_remote_tokens": decision.estimated_remote_tokens,
+                "estimated_remote_tokens_avoided": (
+                    decision.estimated_remote_tokens_avoided
+                ),
+            }
+        else:
+            values = {
+                "estimated_prompt_tokens": None,
+                "estimated_completion_tokens": None,
+                "estimated_remote_tokens": decision.remote_tokens_estimated,
+                "estimated_remote_tokens_avoided": (
+                    decision.remote_tokens_avoided_estimated
+                ),
+            }
+        for key, value in values.items():
+            if value is None:
+                continue
+            _validate_non_negative(value, key)
+            self._totals[key] += value
+
+    def total(self) -> dict[str, int]:
+        """Return accumulated session totals."""
+        return dict(self._totals)
+
+    def reset(self) -> None:
+        """Reset accumulated session totals."""
+        for key in self._totals:
+            self._totals[key] = 0
+
+
+class RoutingDecisionLogger:
+    """Append safe routing decisions to a local JSONL audit file."""
+
+    def __init__(
+        self,
+        base_path: Path | str,
+        *,
+        rotate_daily: bool = True,
+        enabled: bool = True,
+    ) -> None:
+        self.base_path = Path(base_path)
+        self.rotate_daily = rotate_daily
+        self.enabled = enabled
+
+    def append(self, decision: RouterDecision | TokenEconomyRecord) -> Path | None:
+        """Append one safe JSON object and return the file path written."""
+        if not self.enabled:
+            return None
+        path = self._log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = decision.to_log_dict()
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, sort_keys=True) + "\n")
+        return path
+
+    def _log_path(self) -> Path:
+        stem_path = self.base_path.with_suffix("")
+        if self.rotate_daily:
+            date = datetime.now(UTC).date().isoformat()
+            return stem_path.with_name(f"{stem_path.name}_{date}").with_suffix(
+                ".jsonl"
+            )
+        return stem_path.with_suffix(".jsonl")
+
+
+def load_routing_policy(
+    config_path: Path | str = DEFAULT_RAG_CONFIG_PATH,
+) -> RemoteEscalationPolicy:
+    """Load a safe local-first routing policy from ``config/rag_config.yaml``."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if raw is None:
+        return RemoteEscalationPolicy()
+    if not isinstance(raw, Mapping):
+        raise ValueError("routing config root must be a mapping")
+    gateway = raw.get("gateway", {})
+    if gateway is None:
+        gateway = {}
+    if not isinstance(gateway, Mapping):
+        raise ValueError("gateway config must be a mapping")
+    routing = gateway.get("routing", {})
+    if routing is None:
+        routing = {}
+    if not isinstance(routing, Mapping):
+        raise ValueError("gateway.routing config must be a mapping")
+
+    remote_enabled = _read_bool(routing, "remote_enabled", default=False)
+    monthly_budget_usd = _read_optional_float(routing, "monthly_budget_usd")
+    per_request_token_limit = _read_optional_int(
+        routing,
+        "per_request_token_limit",
+    )
+    allowed_remote_providers = _read_string_tuple(
+        routing,
+        "allowed_remote_providers",
+        default=(),
+    )
+    blocked_task_types = _read_string_tuple(
+        routing,
+        "blocked_task_types",
+        default=DEFAULT_BLOCKED_TASK_TYPES,
+    )
+    allowed_task_types = _read_string_tuple(
+        routing,
+        "allowed_task_types",
+        default=(),
+    )
+
+    return RemoteEscalationPolicy(
+        remote_enabled=remote_enabled,
+        monthly_budget_usd=monthly_budget_usd,
+        per_request_token_limit=per_request_token_limit,
+        allowed_remote_providers=allowed_remote_providers,
+        blocked_task_types=blocked_task_types,
+        allowed_task_types=allowed_task_types,
+    )
+
+
+def estimate_prompt_tokens(
+    text: str,
+    *,
+    chars_per_token: int = 4,
+    min_tokens: int = 1,
+) -> int:
+    """Estimate prompt tokens using a conservative local heuristic.
+
+    This is an estimate for local policy decisions, not a billing record.
+    """
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    if chars_per_token <= 0:
+        raise ValueError("chars_per_token must be greater than zero")
+    if min_tokens < 0:
+        raise ValueError("min_tokens cannot be negative")
+    stripped = text.strip()
+    estimated = ceil(len(stripped) / chars_per_token) if stripped else 0
+    return max(estimated, min_tokens)
 
 
 def decide_route(
@@ -257,6 +453,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=contains_sensitive_context,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -272,13 +469,14 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=True,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
             estimated_remote_tokens_avoided=total_tokens,
         )
 
-    if _is_unsupported_task(clean_task_type):
+    if _is_unsupported_task(clean_task_type, policy):
         return _decision(
             route=RouteDecisionKind.BLOCKED,
             reason=RouteBlockReason.UNSUPPORTED_TASK.value,
@@ -287,6 +485,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=None,
             requires_sanitization=False,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -308,6 +507,7 @@ def decide_route(
                 remote_allowed=True,
                 remote_candidate_provider=provider,
                 requires_sanitization=True,
+                task_type=clean_task_type,
                 estimated_prompt_tokens=estimated_prompt_tokens,
                 estimated_completion_tokens=estimated_completion_tokens,
                 estimated_remote_tokens=total_tokens,
@@ -326,6 +526,7 @@ def decide_route(
             remote_allowed=False,
             remote_candidate_provider=provider,
             requires_sanitization=True,
+            task_type=clean_task_type,
             estimated_prompt_tokens=estimated_prompt_tokens,
             estimated_completion_tokens=estimated_completion_tokens,
             estimated_remote_tokens=total_tokens,
@@ -340,6 +541,7 @@ def decide_route(
         remote_allowed=False,
         remote_candidate_provider=None,
         requires_sanitization=False,
+        task_type=clean_task_type,
         estimated_prompt_tokens=estimated_prompt_tokens,
         estimated_completion_tokens=estimated_completion_tokens,
         estimated_remote_tokens=total_tokens,
@@ -386,6 +588,7 @@ def _decision(
     remote_allowed: bool,
     remote_candidate_provider: str | None,
     requires_sanitization: bool,
+    task_type: str,
     estimated_prompt_tokens: int,
     estimated_completion_tokens: int,
     estimated_remote_tokens: int | None,
@@ -401,6 +604,7 @@ def _decision(
         remote_allowed=remote_allowed,
         remote_candidate_provider=remote_candidate_provider,
         requires_sanitization=requires_sanitization,
+        task_type=task_type,
         estimated_prompt_tokens=estimated_prompt_tokens,
         estimated_completion_tokens=estimated_completion_tokens,
         estimated_remote_tokens=estimated_remote_tokens,
@@ -437,8 +641,13 @@ def _budget_exceeded(total_tokens: int, limit: int | None) -> bool:
     return limit is not None and limit > 0 and total_tokens > limit
 
 
-def _is_unsupported_task(task_type: str) -> bool:
-    return task_type.strip().lower() in {"trade_execution", "brokerage_login"}
+def _is_unsupported_task(task_type: str, policy: RemoteEscalationPolicy) -> bool:
+    clean_task_type = task_type.strip().lower()
+    blocked = {item.strip().lower() for item in policy.blocked_task_types}
+    allowed = {item.strip().lower() for item in policy.allowed_task_types}
+    if clean_task_type in blocked:
+        return True
+    return bool(allowed) and clean_task_type not in allowed
 
 
 def _sum_optional(left: int | None, right: int | None) -> int | None:
@@ -462,3 +671,50 @@ def _validate_non_negative(value: int, field_name: str) -> None:
 def _validate_optional_non_negative(value: int | None, field_name: str) -> None:
     if value is not None:
         _validate_non_negative(value, field_name)
+
+
+def _read_bool(
+    mapping: Mapping[str, Any],
+    key: str,
+    *,
+    default: bool,
+) -> bool:
+    value = mapping.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be a boolean")
+    return value
+
+
+def _read_optional_int(mapping: Mapping[str, Any], key: str) -> int | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be an integer")
+    return value
+
+
+def _read_optional_float(mapping: Mapping[str, Any], key: str) -> float | None:
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise ValueError(f"gateway.routing.{key} must be a number")
+    return float(value)
+
+
+def _read_string_tuple(
+    mapping: Mapping[str, Any],
+    key: str,
+    *,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = mapping.get(key, list(default))
+    if not isinstance(value, list):
+        raise ValueError(f"gateway.routing.{key} must be a list")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"gateway.routing.{key} must contain only strings")
+        result.append(_validate_non_empty(item, key))
+    return tuple(result)

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -187,6 +187,7 @@ OpenClaw / LocalGenerator
 | GW-09 | `feat/rag-collection-metadata-guard` | Collection metadata drift guard | ✅ Merged |
 | GW-10 | `feat/rag-run-trace-provenance` | `RagRunTrace` provenance | ✅ Merged |
 | GW-11 | `feat/rag-observability-events` | Local structured RAG lifecycle events | ✅ Merged |
+| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
 
 ### Sprint Gateway-1 — CURRENT
 
@@ -202,7 +203,9 @@ task metadata + token estimates
 
 | PR | Branch | Scope | Status |
 |---|---|---|---|
-| GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | 🚧 Current |
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | 🚧 Current |
 
 GW-13 rules:
 
@@ -211,7 +214,19 @@ GW-13 rules:
 - No secrets, no API keys, no remote calls.
 - No runtime model routing change.
 - No Qdrant mutation or `openclaw_knowledge` access.
-| GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
+
+GW-15 rules:
+
+- `scripts/run_local_agent.py` is a local CLI, not an API, daemon,
+  multi-agent system, FastAPI app or MCP server.
+- Default mode uses `local_chat`.
+- `--json` uses `local_json`.
+- `--rag` is explicit opt-in and uses the existing RAG path when available.
+- `--dry-run` must work without live services.
+- Output metadata must not include question, prompt, chunks, vectors, payloads,
+  raw responses, secrets or Authorization headers.
+- Progressive fallback is deferred to GW-16.
+- Golden questions harness is deferred to GW-17.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -205,7 +205,8 @@ task metadata + token estimates
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | 🚧 Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | 🚧 Current |
 
 GW-13 rules:
 
@@ -225,8 +226,10 @@ GW-15 rules:
 - `--dry-run` must work without live services.
 - Output metadata must not include question, prompt, chunks, vectors, payloads,
   raw responses, secrets or Authorization headers.
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- GW-16 hardens contracts only: alias matrix, output schema, blocked/dry-run,
+  degraded states, parse/render boundaries and no-fallback assertions.
+- Progressive fallback is deferred to GW-17.
+- Golden questions harness is deferred to GW-18.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,21 +5,22 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Agent-0 GW-15 local runner
+**Updated by:** Codex — Agent-0 GW-16 runner contract hardening
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add the first local MVP CLI entrypoint for one question, one routing
-decision, one local-only execution path and safe metadata output.
+**Goal:** harden the Agent-0 local runner contracts for alias routing, output
+schema, dry-run, blocked and degraded states without adding fallback or new
+runtime features.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
-GW-15 branch: `feat/agent0-local-runner`
+GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
+GW-16 branch: `feat/agent0-runner-contract-hardening`
 
 Current runtime path:
 
@@ -116,7 +117,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -129,6 +131,7 @@ GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
+GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -163,6 +166,24 @@ Rules:
 - No Qdrant mutation, no reindexing, no ingestion, no real data.
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
+
+## GW-16 Current Work
+
+GW-16 hardens the Agent-0 runner contract without adding new execution
+features.
+
+Rules:
+
+- Alias matrix is frozen: default `local_chat`, `--json` `local_json`,
+  `--rag` `local_rag`.
+- Output schema remains stable across success, dry-run, blocked and failure
+  states.
+- Blocked and dry-run paths return `latency_ms=0.0`.
+- Chat, JSON and RAG failures return safe error categories only.
+- No fallback is added. RAG/JSON/chat failures do not silently try another
+  alias.
+- No remote providers, no remote calls, no Qdrant mutation, no live services
+  required for tests.
 
 ## GW-13 Completed Work
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,19 +5,21 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Gateway GW-13 routing policy prelude
+**Updated by:** Codex — Agent-0 GW-15 local runner
 
 ---
 
-## Active Sprint: Gateway-1 / Local-First Routing Prelude
+## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add safe, offline local-first routing decision primitives and token
-economy records for future routing policy work. Remote providers remain
-disabled and no runtime model routing changes are made in GW-13.
+**Goal:** add the first local MVP CLI entrypoint for one question, one routing
+decision, one local-only execution path and safe metadata output.
 
-Gateway-0 is complete on `main`. Gateway-1 starts from issue
-[#51](https://github.com/franciscosalido/OPENCLAW/issues/51) and branch
-`feat/gateway1-routing-policy-prelude`.
+Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
+open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
+GW-14 token/config helpers are not present on `main`.
+
+GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
+GW-15 branch: `feat/agent0-local-runner`
 
 Current runtime path:
 
@@ -112,7 +114,9 @@ unavoidable, use `git push --force-with-lease`.
 | GW-10 | `feat/rag-run-trace-provenance` | Safe per-query RAG provenance trace | Done / merged |
 | GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
-| GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Current |
+| GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -124,12 +128,43 @@ GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
 GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
+GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
 
-## GW-13 Current Work
+## GW-15 Current Work
+
+GW-15 creates Agent-0, the first local MVP runner:
+
+```text
+question
+  -> decide_route(...)
+  -> local_chat | local_json | explicit local_rag
+  -> safe answer metadata
+```
+
+Deliverables:
+
+- `scripts/run_local_agent.py`.
+- `scripts/test_agent0_local_runner.sh` optional smoke guarded by
+  `RUN_AGENT0_LOCAL_SMOKE=1`.
+- `docs/AGENT0_LOCAL_RUNNER.md`.
+- `tests/unit/test_run_local_agent.py`.
+
+Rules:
+
+- Default execution uses `local_chat`.
+- `--json` uses `local_json`.
+- `--rag` explicitly opts into the existing local RAG path and `local_rag`.
+- `--dry-run` works without live services.
+- No remote providers, no remote calls, no API keys, no FastAPI, no MCP.
+- No Qdrant mutation, no reindexing, no ingestion, no real data.
+- Progressive fallback is deferred to GW-16.
+- Golden questions harness is deferred to GW-17.
+
+## GW-13 Completed Work
 
 GW-13 opens Gateway-1 with safe routing policy records only.
 

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -69,6 +69,42 @@ It never includes question text, prompts, chunks, vectors, embeddings, payloads,
 API keys, Authorization headers, secrets, passwords, raw model responses or
 tracebacks.
 
+## GW-16 Contract Hardening
+
+GW-16 freezes the Agent-0 runner contracts with offline tests only.
+
+Alias matrix:
+
+| Mode | Alias | `used_rag` |
+|---|---|---:|
+| default | `local_chat` | `false` |
+| `--json` | `local_json` | `false` |
+| `--rag` | `local_rag` | `true` |
+
+Output schema invariants:
+
+- `answer`, `route`, `alias`, `used_rag`, `latency_ms`, `decision_id`, and
+  `estimated_remote_tokens_avoided` are always present.
+- `error_category` appears only for blocked/failure results.
+- `latency_ms` is numeric and non-negative.
+- `estimated_remote_tokens_avoided` is numeric and non-negative.
+- `decision_id` is non-empty.
+
+Safe error categories:
+
+- `blocked`
+- `chat_unavailable`
+- `json_unavailable`
+- `rag_unavailable`
+- `invalid_arguments` is reserved for future CLI/reporting integration.
+
+Fallback remains intentionally disabled:
+
+- RAG failure does not fallback to `local_chat`.
+- JSON failure does not fallback to `local_chat`.
+- Chat failure does not try another alias.
+- Timeout/retry fallback is deferred to a future PR.
+
 ## Dry Run
 
 ```bash
@@ -88,7 +124,7 @@ The smoke script is opt-in and local-only. It requires
 
 ## Deferred
 
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- Progressive fallback is deferred to GW-17.
+- Golden questions harness is deferred to GW-18.
 - Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -1,0 +1,93 @@
+# Agent-0 Local Runner
+
+Agent-0 is the first local MVP entrypoint for OpenClaw/Quimera.
+
+It is a CLI only. It is not multi-agent orchestration, not a daemon, not an
+API, not FastAPI and not MCP.
+
+## Command
+
+```bash
+uv run python scripts/run_local_agent.py "Pergunta sintetica"
+```
+
+Flags:
+
+- `--rag`: use the existing local RAG pipeline and `local_rag` generation.
+- `--json`: use `local_json`.
+- `--output text|json`: choose output format.
+- `--show-metadata`: show safe metadata in text mode.
+- `--max-tokens INT`: pass a local generation token cap where supported.
+- `--temperature FLOAT`: pass local generation temperature where supported.
+- `--dry-run`: route and estimate tokens without model calls.
+- `--debug`: include exception class only in safe error category.
+
+`--rag` and `--json` cannot be combined.
+
+## Paths
+
+Default:
+
+```text
+question -> decide_route -> local_chat -> answer
+```
+
+JSON:
+
+```text
+question -> decide_route -> local_json -> answer
+```
+
+RAG:
+
+```text
+question -> decide_route -> existing LocalRagPipeline/local_rag -> answer
+```
+
+RAG is explicit opt-in. GW-15 does not ingest documents, reindex, create
+collections, delete collections or mutate Qdrant.
+
+## Safe JSON Output
+
+`--output json` returns only:
+
+```json
+{
+  "answer": "...",
+  "route": "local",
+  "alias": "local_chat",
+  "used_rag": false,
+  "latency_ms": 1234.5,
+  "decision_id": "...",
+  "estimated_remote_tokens_avoided": 850
+}
+```
+
+On failure it may also include `error_category`.
+
+It never includes question text, prompts, chunks, vectors, embeddings, payloads,
+API keys, Authorization headers, secrets, passwords, raw model responses or
+tracebacks.
+
+## Dry Run
+
+```bash
+uv run python scripts/run_local_agent.py "Pergunta sintetica" --dry-run --output json
+```
+
+Dry-run needs no live LiteLLM, Ollama or Qdrant services.
+
+## Optional Smoke
+
+```bash
+RUN_AGENT0_LOCAL_SMOKE=1 scripts/test_agent0_local_runner.sh
+```
+
+The smoke script is opt-in and local-only. It requires
+`QUIMERA_LLM_API_KEY` to match the local `LITELLM_MASTER_KEY`.
+
+## Deferred
+
+- Progressive fallback is deferred to GW-16.
+- Golden questions harness is deferred to GW-17.
+- Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -90,4 +90,5 @@ The smoke script is opt-in and local-only. It requires
 
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
+- Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,13 +1,13 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-01  
-**Current branch:** `feat/gateway1-routing-policy-prelude`  
-**Issue:** [#51](https://github.com/franciscosalido/OPENCLAW/issues/51)
+**Current branch:** `feat/agent0-local-runner`
+**Issue:** [#55](https://github.com/franciscosalido/OPENCLAW/issues/55)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
 
-## GW-13 Current Work
+## GW-13 Completed Work
 
 Scope:
 
@@ -40,6 +40,36 @@ Out of scope:
 
 | Item | Scope |
 |---|---|
-| GW-14 | Sanitization policy before any remote escalation |
-| GW-15 | Budget enforcement and approval flow |
-| GW-16 | Provider-specific ADR if remote routing is ever proposed |
+| GW-14 | Config-driven routing audit and token economy calibration |
+| GW-16 | Progressive local fallback on timeout/alias failure |
+| GW-17 | Golden questions harness |
+
+## GW-15 Current Work
+
+Scope:
+
+- Add `scripts/run_local_agent.py`.
+- Add one-question Agent-0 local CLI.
+- Route before execution using `decide_route(...)`.
+- Default to `local_chat`.
+- Use `local_json` only with `--json`.
+- Use existing local RAG path only with `--rag`.
+- Add safe JSON/text output.
+- Add optional smoke script guarded by `RUN_AGENT0_LOCAL_SMOKE=1`.
+- Add offline unit tests with mocks.
+
+Out of scope:
+
+- Remote providers and remote calls.
+- Multi-agent orchestration.
+- FastAPI, MCP, daemon/background workers.
+- Qdrant mutation, reindexing, ingestion or production collection changes.
+- Progressive fallback on timeout.
+- Golden questions harness.
+
+Safety:
+
+- No prompt/query/chunk/vector/payload/secret fields in output metadata.
+- Dry-run performs routing and token estimates without model calls.
+- RAG unavailable returns `error_category=rag_unavailable`; no silent fallback in
+  GW-15.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-01  
-**Current branch:** `feat/agent0-local-runner`
-**Issue:** [#55](https://github.com/franciscosalido/OPENCLAW/issues/55)
+**Current branch:** `feat/agent0-runner-contract-hardening`
+**Issue:** [#57](https://github.com/franciscosalido/OPENCLAW/issues/57)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -41,8 +41,8 @@ Out of scope:
 | Item | Scope |
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
-| GW-16 | Progressive local fallback on timeout/alias failure |
-| GW-17 | Golden questions harness |
+| GW-17 | Progressive local fallback on timeout/alias failure |
+| GW-18 | Golden questions harness |
 
 ## GW-15 Current Work
 
@@ -73,3 +73,28 @@ Safety:
 - Dry-run performs routing and token estimates without model calls.
 - RAG unavailable returns `error_category=rag_unavailable`; no silent fallback in
   GW-15.
+
+## GW-16 Current Work
+
+Scope:
+
+- Harden `scripts/run_local_agent.py` contracts with offline tests.
+- Freeze alias matrix for `local_chat`, `local_json`, and `local_rag`.
+- Freeze output schema invariants across success, dry-run, blocked and failure
+  states.
+- Validate degraded-state behavior for chat, JSON and RAG.
+- Assert no silent fallback between aliases.
+- Validate parse/render/token-estimate boundaries.
+
+Out of scope:
+
+- Progressive fallback.
+- Retry/fallback on timeout.
+- Golden questions harness.
+- Remote providers or calls.
+- Qdrant mutation, reindexing or ingestion.
+
+Safety:
+
+- Runner output still excludes prompt/query/chunks/vectors/payloads/secrets.
+- Live services are not required for GW-16 tests.

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -14,9 +14,7 @@ import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
-from math import ceil
 from typing import Any, Protocol
-from typing import cast
 
 from backend.gateway.client import (
     DEFAULT_LLM_JSON_MODEL,
@@ -24,12 +22,13 @@ from backend.gateway.client import (
     DEFAULT_LLM_RAG_MODEL,
     GatewayChatClient,
 )
-from backend.gateway import routing_policy as routing_policy_module
 from backend.gateway.routing_policy import (
     RemoteEscalationPolicy,
     RouteDecisionKind,
     RouterDecision,
     decide_route,
+    estimate_prompt_tokens,
+    load_routing_policy,
 )
 from scripts.rag_ask_local import ask_local
 
@@ -170,7 +169,6 @@ async def run_agent(
     """Run one local Agent-0 request and return a safe result."""
     if use_rag and use_json:
         raise ValueError("--rag and --json cannot be used together")
-    start = time.perf_counter()
     alias = _select_alias(use_rag=use_rag, use_json=use_json)
     estimated_prompt_tokens = _estimate_prompt_token_count(question)
     estimated_completion_tokens = max_tokens or 512
@@ -192,7 +190,7 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=_elapsed_ms(start),
+            latency_ms=0.0,
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
             error_category="blocked",
@@ -204,11 +202,12 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=_elapsed_ms(start),
+            latency_ms=0.0,
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
         )
 
+    start = time.perf_counter()
     try:
         if use_rag:
             active_rag_call = _call_rag if rag_call is None else rag_call
@@ -321,23 +320,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def _safe_policy() -> RemoteEscalationPolicy:
-    loader = getattr(routing_policy_module, "load_routing_policy", None)
-    if callable(loader):
-        try:
-            loaded = cast(Callable[[], object], loader)()
-        except Exception:
-            return RemoteEscalationPolicy(remote_enabled=False)
-        if isinstance(loaded, RemoteEscalationPolicy):
-            return loaded
-    return RemoteEscalationPolicy(remote_enabled=False)
+    """Load routing policy from config with safe fallback."""
+    try:
+        return load_routing_policy()
+    except Exception:
+        return RemoteEscalationPolicy(remote_enabled=False)
 
 
 def _estimate_prompt_token_count(question: str) -> int:
-    estimator = getattr(routing_policy_module, "estimate_prompt_tokens", None)
-    if callable(estimator):
-        return cast(Callable[[str], int], estimator)(question)
-    stripped = question.strip()
-    return max(ceil(len(stripped) / 4) if stripped else 0, 1)
+    """Estimate prompt token count using the local heuristic."""
+    return estimate_prompt_tokens(question)
 
 
 def _select_alias(*, use_rag: bool, use_json: bool) -> str:

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -39,6 +39,7 @@ LOCAL_JSON_ALIAS = DEFAULT_LLM_JSON_MODEL
 SAFE_ERROR_CATEGORIES = {
     "blocked",
     "chat_unavailable",
+    "json_unavailable",
     "rag_unavailable",
     "invalid_arguments",
 }
@@ -226,7 +227,12 @@ async def run_agent(
                 response_format={"type": "json_object"} if use_json else None,
             )
     except Exception as exc:
-        error_category = "rag_unavailable" if use_rag else "chat_unavailable"
+        if use_rag:
+            error_category = "rag_unavailable"
+        elif use_json:
+            error_category = "json_unavailable"
+        else:
+            error_category = "chat_unavailable"
         if debug:
             error_category = f"{error_category}:{exc.__class__.__name__}"
         return AgentRunResult(

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+"""Agent-0 local runner MVP.
+
+This CLI is local-only. It never calls remote providers and never includes the
+raw question, prompt, chunks, vectors, payloads or secrets in metadata output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from math import ceil
+from typing import Any, Protocol
+from typing import cast
+
+from backend.gateway.client import (
+    DEFAULT_LLM_JSON_MODEL,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_RAG_MODEL,
+    GatewayChatClient,
+)
+from backend.gateway import routing_policy as routing_policy_module
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouteDecisionKind,
+    RouterDecision,
+    decide_route,
+)
+from scripts.rag_ask_local import ask_local
+
+
+LOCAL_CHAT_ALIAS = DEFAULT_LLM_MODEL
+LOCAL_RAG_ALIAS = DEFAULT_LLM_RAG_MODEL
+LOCAL_JSON_ALIAS = DEFAULT_LLM_JSON_MODEL
+SAFE_ERROR_CATEGORIES = {
+    "blocked",
+    "chat_unavailable",
+    "rag_unavailable",
+    "invalid_arguments",
+}
+
+__all__ = [
+    "AgentRunResult",
+    "main",
+    "main_async",
+    "parse_args",
+    "render_result",
+    "run_agent",
+]
+
+
+class ChatCallable(Protocol):
+    """Callable used by tests to replace the live chat path."""
+
+    def __call__(
+        self,
+        question: str,
+        *,
+        alias: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        response_format: Mapping[str, object] | None,
+    ) -> Awaitable[str]:
+        """Return an answer from a local alias."""
+        ...
+
+
+class RagCallable(Protocol):
+    """Callable used by tests to replace the live RAG path."""
+
+    def __call__(
+        self,
+        question: str,
+        *,
+        max_tokens: int | None,
+        temperature: float | None,
+    ) -> Awaitable[str]:
+        """Return an answer from the local RAG pipeline."""
+        ...
+
+
+@dataclass(frozen=True)
+class AgentRunResult:
+    """Safe Agent-0 runner result."""
+
+    answer: str
+    route: str
+    alias: str
+    used_rag: bool
+    latency_ms: float
+    decision_id: str
+    estimated_remote_tokens_avoided: int
+    error_category: str | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return the safe public output schema."""
+        data: dict[str, object] = {
+            "answer": self.answer,
+            "route": self.route,
+            "alias": self.alias,
+            "used_rag": self.used_rag,
+            "latency_ms": self.latency_ms,
+            "decision_id": self.decision_id,
+            "estimated_remote_tokens_avoided": self.estimated_remote_tokens_avoided,
+        }
+        if self.error_category is not None:
+            data["error_category"] = self.error_category
+        return data
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse Agent-0 CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run one local-only Agent-0 question.",
+    )
+    parser.add_argument("question", help="Question to answer locally.")
+    parser.add_argument("--rag", action="store_true", help="Use local RAG path.")
+    parser.add_argument("--json", action="store_true", help="Use local_json alias.")
+    parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--show-metadata",
+        action="store_true",
+        help="Include safe metadata in text mode.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Return routing decision and token estimates without model calls.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Include exception class only on safe failures.",
+    )
+    args = parser.parse_args(argv)
+    if args.rag and args.json:
+        parser.error("--rag and --json cannot be used together")
+    if args.max_tokens is not None and args.max_tokens <= 0:
+        parser.error("--max-tokens must be greater than zero")
+    if args.temperature is not None and not 0.0 <= args.temperature <= 2.0:
+        parser.error("--temperature must be between 0.0 and 2.0")
+    return args
+
+
+async def run_agent(
+    *,
+    question: str,
+    use_rag: bool = False,
+    use_json: bool = False,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    dry_run: bool = False,
+    debug: bool = False,
+    chat_call: ChatCallable | None = None,
+    rag_call: RagCallable | None = None,
+    policy_loader: Callable[[], RemoteEscalationPolicy] | None = None,
+) -> AgentRunResult:
+    """Run one local Agent-0 request and return a safe result."""
+    if use_rag and use_json:
+        raise ValueError("--rag and --json cannot be used together")
+    start = time.perf_counter()
+    alias = _select_alias(use_rag=use_rag, use_json=use_json)
+    estimated_prompt_tokens = _estimate_prompt_token_count(question)
+    estimated_completion_tokens = max_tokens or 512
+    policy = policy_loader() if policy_loader is not None else _safe_policy()
+    decision = decide_route(
+        task_type=_task_type(use_rag=use_rag, use_json=use_json),
+        estimated_prompt_tokens=estimated_prompt_tokens,
+        estimated_completion_tokens=estimated_completion_tokens,
+        contains_sensitive_context=False,
+        high_value_task=False,
+        policy=policy,
+    )
+    avoided = decision.estimated_remote_tokens_avoided
+    safe_avoided = int(avoided or 0)
+
+    if decision.route is RouteDecisionKind.BLOCKED:
+        return AgentRunResult(
+            answer="Request blocked by local routing policy.",
+            route=decision.route.value,
+            alias=alias,
+            used_rag=use_rag,
+            latency_ms=_elapsed_ms(start),
+            decision_id=decision.decision_id,
+            estimated_remote_tokens_avoided=safe_avoided,
+            error_category="blocked",
+        )
+
+    if dry_run:
+        return AgentRunResult(
+            answer="Dry run: no model call executed.",
+            route=decision.route.value,
+            alias=alias,
+            used_rag=use_rag,
+            latency_ms=_elapsed_ms(start),
+            decision_id=decision.decision_id,
+            estimated_remote_tokens_avoided=safe_avoided,
+        )
+
+    try:
+        if use_rag:
+            active_rag_call = _call_rag if rag_call is None else rag_call
+            answer = await active_rag_call(
+                question,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        else:
+            active_chat_call = _call_chat_alias if chat_call is None else chat_call
+            answer = await active_chat_call(
+                question,
+                alias=alias,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                response_format={"type": "json_object"} if use_json else None,
+            )
+    except Exception as exc:
+        error_category = "rag_unavailable" if use_rag else "chat_unavailable"
+        if debug:
+            error_category = f"{error_category}:{exc.__class__.__name__}"
+        return AgentRunResult(
+            answer="Local Agent-0 execution failed.",
+            route=decision.route.value,
+            alias=alias,
+            used_rag=use_rag,
+            latency_ms=_elapsed_ms(start),
+            decision_id=decision.decision_id,
+            estimated_remote_tokens_avoided=safe_avoided,
+            error_category=error_category,
+        )
+
+    return AgentRunResult(
+        answer=answer,
+        route=decision.route.value,
+        alias=alias,
+        used_rag=use_rag,
+        latency_ms=_elapsed_ms(start),
+        decision_id=decision.decision_id,
+        estimated_remote_tokens_avoided=safe_avoided,
+    )
+
+
+async def _call_chat_alias(
+    question: str,
+    *,
+    alias: str,
+    max_tokens: int | None,
+    temperature: float | None,
+    response_format: Mapping[str, object] | None,
+) -> str:
+    async with GatewayChatClient() as client:
+        return await client.chat_completion(
+            [{"role": "user", "content": question}],
+            model=alias,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format=response_format,
+        )
+
+
+async def _call_rag(
+    question: str,
+    *,
+    max_tokens: int | None,
+    temperature: float | None,
+) -> str:
+    del max_tokens, temperature
+    result = await ask_local(question=question, model=LOCAL_RAG_ALIAS)
+    return result.answer
+
+
+def render_result(result: AgentRunResult, *, output: str, show_metadata: bool) -> str:
+    """Render a safe CLI result."""
+    if output == "json":
+        return json.dumps(result.to_json_dict(), ensure_ascii=False, sort_keys=True)
+    if not show_metadata:
+        return result.answer
+    metadata = result.to_json_dict()
+    metadata.pop("answer", None)
+    return result.answer + "\n\nmetadata=" + json.dumps(
+        metadata,
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async CLI entrypoint."""
+    args = parse_args(argv)
+    result = await run_agent(
+        question=args.question,
+        use_rag=args.rag,
+        use_json=args.json,
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        dry_run=args.dry_run,
+        debug=args.debug,
+    )
+    sys.stdout.write(
+        render_result(result, output=args.output, show_metadata=args.show_metadata)
+        + "\n"
+    )
+    return 1 if result.error_category else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def _safe_policy() -> RemoteEscalationPolicy:
+    loader = getattr(routing_policy_module, "load_routing_policy", None)
+    if callable(loader):
+        try:
+            loaded = cast(Callable[[], object], loader)()
+        except Exception:
+            return RemoteEscalationPolicy(remote_enabled=False)
+        if isinstance(loaded, RemoteEscalationPolicy):
+            return loaded
+    return RemoteEscalationPolicy(remote_enabled=False)
+
+
+def _estimate_prompt_token_count(question: str) -> int:
+    estimator = getattr(routing_policy_module, "estimate_prompt_tokens", None)
+    if callable(estimator):
+        return cast(Callable[[str], int], estimator)(question)
+    stripped = question.strip()
+    return max(ceil(len(stripped) / 4) if stripped else 0, 1)
+
+
+def _select_alias(*, use_rag: bool, use_json: bool) -> str:
+    if use_rag:
+        return LOCAL_RAG_ALIAS
+    if use_json:
+        return LOCAL_JSON_ALIAS
+    return LOCAL_CHAT_ALIAS
+
+
+def _task_type(*, use_rag: bool, use_json: bool) -> str:
+    if use_rag:
+        return "agent0_rag"
+    if use_json:
+        return "agent0_json"
+    return "agent0_chat"
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_agent0_local_runner.sh
+++ b/scripts/test_agent0_local_runner.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${RUN_AGENT0_LOCAL_SMOKE:-}" != "1" ]]; then
+  echo "SKIP: set RUN_AGENT0_LOCAL_SMOKE=1 to run Agent-0 local smoke."
+  exit 0
+fi
+
+if [[ -z "${QUIMERA_LLM_API_KEY:-}" ]]; then
+  echo "ERROR: QUIMERA_LLM_API_KEY is required for live Agent-0 local smoke."
+  exit 1
+fi
+
+QUIMERA_LLM_BASE_URL="${QUIMERA_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+case "$QUIMERA_LLM_BASE_URL" in
+  http://127.0.0.1:*|http://localhost:*) ;;
+  *)
+    echo "ERROR: QUIMERA_LLM_BASE_URL must be local. Refusing to run."
+    exit 1
+    ;;
+esac
+
+echo "OK: Agent-0 dry-run"
+uv run python scripts/run_local_agent.py \
+  "Explique em uma frase o que e uma decisao local." \
+  --dry-run \
+  --output json >/dev/null
+
+echo "OK: Agent-0 local_chat"
+uv run python scripts/run_local_agent.py \
+  "Explique em uma frase o que e uma decisao local." \
+  --output json >/dev/null
+
+echo "OK: Agent-0 local_json"
+uv run python scripts/run_local_agent.py \
+  "Responda somente JSON valido: {\"classe\":\"sintetica\"}" \
+  --json \
+  --output json >/dev/null
+
+echo "OK: Agent-0 local runner smoke completed."

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import inspect
+import unittest
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import patch
+
+from backend.gateway.routing_policy import (
+    RemoteEscalationPolicy,
+    RouterDecision,
+    decide_route,
+)
+from scripts import run_local_agent
+
+
+FORBIDDEN_OUTPUT_KEYS = {
+    "query",
+    "question",
+    "prompt",
+    "chunks",
+    "chunk_text",
+    "vectors",
+    "embeddings",
+    "payload",
+    "qdrant_payload",
+    "api_key",
+    "authorization",
+    "secret",
+    "password",
+    "headers",
+    "raw_response",
+    "traceback",
+}
+
+
+class RunLocalAgentCliTests(unittest.TestCase):
+    def test_missing_question_exits_nonzero(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            run_local_agent.parse_args([])
+
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_rag_and_json_together_exits_nonzero(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            run_local_agent.parse_args(["pergunta", "--rag", "--json"])
+
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_help_exits_zero(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            run_local_agent.parse_args(["--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+
+
+class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_default_mode_selects_local_chat(self) -> None:
+        seen: dict[str, object] = {}
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            self.assertEqual(question, "pergunta")
+            seen.update(
+                {
+                    "alias": alias,
+                    "max_tokens": max_tokens,
+                    "temperature": temperature,
+                    "response_format": response_format,
+                }
+            )
+            return "answer"
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            max_tokens=123,
+            temperature=0.1,
+            chat_call=chat_call,
+        )
+
+        self.assertEqual(result.answer, "answer")
+        self.assertEqual(result.alias, "local_chat")
+        self.assertFalse(result.used_rag)
+        self.assertEqual(seen["alias"], "local_chat")
+        self.assertEqual(seen["max_tokens"], 123)
+        self.assertEqual(seen["temperature"], 0.1)
+        self.assertIsNone(seen["response_format"])
+
+    async def test_json_mode_selects_local_json(self) -> None:
+        seen: dict[str, object] = {}
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del max_tokens, temperature
+            self.assertEqual(question, "pergunta")
+            seen["alias"] = alias
+            seen["response_format"] = response_format
+            return '{"ok": true}'
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_json=True,
+            chat_call=chat_call,
+        )
+
+        self.assertEqual(result.alias, "local_json")
+        self.assertFalse(result.used_rag)
+        self.assertEqual(seen["alias"], "local_json")
+        self.assertEqual(seen["response_format"], {"type": "json_object"})
+
+    async def test_rag_mode_selects_rag_path(self) -> None:
+        called = {"rag": False}
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            self.assertIsNone(max_tokens)
+            self.assertIsNone(temperature)
+            self.assertEqual(question, "pergunta")
+            called["rag"] = True
+            return "rag answer"
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            rag_call=rag_call,
+        )
+
+        self.assertTrue(called["rag"])
+        self.assertEqual(result.alias, "local_rag")
+        self.assertTrue(result.used_rag)
+        self.assertEqual(result.answer, "rag answer")
+
+    async def test_dry_run_does_not_call_model(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            dry_run=True,
+            chat_call=chat_call,
+        )
+
+        self.assertEqual(result.answer, "Dry run: no model call executed.")
+        self.assertEqual(result.alias, "local_chat")
+
+    async def test_output_json_returns_safe_schema(self) -> None:
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            dry_run=True,
+        )
+
+        rendered = run_local_agent.render_result(
+            result,
+            output="json",
+            show_metadata=False,
+        )
+        data = json.loads(rendered)
+
+        self.assertEqual(
+            set(data),
+            {
+                "answer",
+                "route",
+                "alias",
+                "used_rag",
+                "latency_ms",
+                "decision_id",
+                "estimated_remote_tokens_avoided",
+            },
+        )
+        self.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
+
+    async def test_routing_decision_happens_before_execution(self) -> None:
+        events: list[str] = []
+        original_decide = decide_route
+
+        def wrapped_decide(**kwargs: Any) -> RouterDecision:
+            events.append("decision")
+            return original_decide(**kwargs)
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            events.append("chat")
+            return "answer"
+
+        with patch("scripts.run_local_agent.decide_route", wrapped_decide):
+            await run_local_agent.run_agent(question="pergunta", chat_call=chat_call)
+
+        self.assertEqual(events, ["decision", "chat"])
+
+    async def test_policy_blocked_decision_prevents_model_call(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            chat_call=chat_call,
+            policy_loader=lambda: RemoteEscalationPolicy(per_request_token_limit=1),
+        )
+
+        self.assertEqual(result.error_category, "blocked")
+        self.assertEqual(result.route, "blocked")
+
+    async def test_rag_unavailable_produces_safe_error_category(self) -> None:
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("service down with private details")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            rag_call=rag_call,
+        )
+
+        data = result.to_json_dict()
+        self.assertEqual(data["error_category"], "rag_unavailable")
+        self.assertNotIn("service down", json.dumps(data))
+
+    async def test_remote_provider_is_never_called(self) -> None:
+        source = inspect.getsource(run_local_agent)
+
+        for forbidden in ("openai", "anthropic", "gemini", "openrouter"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, source.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -5,34 +5,88 @@ import inspect
 import unittest
 from collections.abc import Mapping
 from typing import Any
+from typing import cast
 from unittest.mock import patch
 
 from backend.gateway.routing_policy import (
     RemoteEscalationPolicy,
+    RouteDecisionKind,
+    TaskRiskLevel,
+    TokenBudgetClass,
     RouterDecision,
     decide_route,
+    load_routing_policy,
 )
 from scripts import run_local_agent
 
 
+REQUIRED_KEYS = {
+    "answer",
+    "route",
+    "alias",
+    "used_rag",
+    "latency_ms",
+    "decision_id",
+    "estimated_remote_tokens_avoided",
+}
+OPTIONAL_KEYS = {"error_category"}
 FORBIDDEN_OUTPUT_KEYS = {
     "query",
     "question",
     "prompt",
+    "system_prompt",
+    "user_prompt",
+    "answer_raw",
+    "raw_response",
     "chunks",
+    "chunk",
     "chunk_text",
+    "retrieved_context",
+    "context_text",
     "vectors",
+    "vector",
     "embeddings",
+    "embedding",
     "payload",
     "qdrant_payload",
+    "documents",
+    "portfolio",
+    "carteira",
     "api_key",
     "authorization",
     "secret",
     "password",
     "headers",
-    "raw_response",
     "traceback",
 }
+BLOCKED_ANSWER = "Request blocked by local routing policy."
+DRY_RUN_ANSWER = "Dry run: no model call executed."
+FAILURE_ANSWER = "Local Agent-0 execution failed."
+
+
+def _assert_safe_schema(
+    test_case: unittest.TestCase,
+    data: Mapping[str, object],
+    *,
+    expect_error: str | None = None,
+) -> None:
+    test_case.assertTrue(REQUIRED_KEYS.issubset(data))
+    extra_keys = set(data) - REQUIRED_KEYS - OPTIONAL_KEYS
+    test_case.assertEqual(extra_keys, set())
+    if expect_error is None:
+        test_case.assertNotIn("error_category", data)
+    else:
+        test_case.assertEqual(data["error_category"], expect_error)
+    test_case.assertIsInstance(data["latency_ms"], int | float)
+    test_case.assertGreaterEqual(cast(float, data["latency_ms"]), 0.0)
+    test_case.assertIsInstance(data["estimated_remote_tokens_avoided"], int | float)
+    test_case.assertGreaterEqual(
+        cast(int, data["estimated_remote_tokens_avoided"]),
+        0,
+    )
+    test_case.assertIsInstance(data["decision_id"], str)
+    test_case.assertTrue(data["decision_id"])
+    test_case.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
 
 
 class RunLocalAgentCliTests(unittest.TestCase):
@@ -54,8 +108,79 @@ class RunLocalAgentCliTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 0)
 
+    def test_parse_args_rejects_invalid_boundaries(self) -> None:
+        invalid_cases = [
+            ["pergunta", "--max-tokens", "0"],
+            ["pergunta", "--max-tokens", "-1"],
+            ["pergunta", "--temperature", "-0.1"],
+            ["pergunta", "--temperature", "2.1"],
+            ["pergunta", "--output", "yaml"],
+        ]
+
+        for args in invalid_cases:
+            with self.subTest(args=args):
+                with self.assertRaises(SystemExit):
+                    run_local_agent.parse_args(args)
+
+    def test_parse_args_accepts_temperature_bounds(self) -> None:
+        self.assertEqual(
+            run_local_agent.parse_args(["pergunta", "--temperature", "0.0"]).temperature,
+            0.0,
+        )
+        self.assertEqual(
+            run_local_agent.parse_args(["pergunta", "--temperature", "2.0"]).temperature,
+            2.0,
+        )
+
 
 class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_alias_contract_matrix(self) -> None:
+        cases = [
+            {"kwargs": {}, "alias": "local_chat", "used_rag": False},
+            {"kwargs": {"use_json": True}, "alias": "local_json", "used_rag": False},
+            {"kwargs": {"use_rag": True}, "alias": "local_rag", "used_rag": True},
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                seen: dict[str, object] = {}
+
+                async def chat_call(
+                    question: str,
+                    *,
+                    alias: str,
+                    max_tokens: int | None,
+                    temperature: float | None,
+                    response_format: Mapping[str, object] | None,
+                ) -> str:
+                    del question, max_tokens, temperature, response_format
+                    seen["alias"] = alias
+                    return "answer"
+
+                async def rag_call(
+                    question: str,
+                    *,
+                    max_tokens: int | None,
+                    temperature: float | None,
+                ) -> str:
+                    del question, max_tokens, temperature
+                    seen["alias"] = "local_rag"
+                    return "rag answer"
+
+                kwargs = case["kwargs"]
+                assert isinstance(kwargs, dict)
+                result = await run_local_agent.run_agent(
+                    question="pergunta",
+                    chat_call=chat_call,
+                    rag_call=rag_call,
+                    **kwargs,
+                )
+
+                self.assertEqual(result.alias, case["alias"])
+                self.assertEqual(result.used_rag, case["used_rag"])
+                self.assertEqual(seen["alias"], case["alias"])
+                _assert_safe_schema(self, result.to_json_dict())
+
     async def test_default_mode_selects_local_chat(self) -> None:
         seen: dict[str, object] = {}
 
@@ -165,8 +290,10 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             chat_call=chat_call,
         )
 
-        self.assertEqual(result.answer, "Dry run: no model call executed.")
+        self.assertEqual(result.answer, DRY_RUN_ANSWER)
         self.assertEqual(result.alias, "local_chat")
+        self.assertEqual(result.latency_ms, 0.0)
+        _assert_safe_schema(self, result.to_json_dict())
 
     async def test_output_json_returns_safe_schema(self) -> None:
         result = await run_local_agent.run_agent(
@@ -181,19 +308,7 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         )
         data = json.loads(rendered)
 
-        self.assertEqual(
-            set(data),
-            {
-                "answer",
-                "route",
-                "alias",
-                "used_rag",
-                "latency_ms",
-                "decision_id",
-                "estimated_remote_tokens_avoided",
-            },
-        )
-        self.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
+        _assert_safe_schema(self, data)
 
     async def test_routing_decision_happens_before_execution(self) -> None:
         events: list[str] = []
@@ -240,8 +355,111 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.error_category, "blocked")
         self.assertEqual(result.route, "blocked")
+        self.assertEqual(result.answer, BLOCKED_ANSWER)
+        self.assertEqual(result.latency_ms, 0.0)
+        _assert_safe_schema(self, result.to_json_dict(), expect_error="blocked")
 
-    async def test_rag_unavailable_produces_safe_error_category(self) -> None:
+    async def test_chat_unavailable_produces_safe_error_category(self) -> None:
+        attempts: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            attempts.append(alias)
+            del question, max_tokens, temperature, response_format
+            raise RuntimeError("sensitive private message")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            chat_call=chat_call,
+        )
+
+        data = result.to_json_dict()
+        self.assertEqual(result.answer, FAILURE_ANSWER)
+        self.assertEqual(data["error_category"], "chat_unavailable")
+        self.assertEqual(attempts, ["local_chat"])
+        self.assertNotIn("sensitive private message", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="chat_unavailable")
+
+    async def test_json_unavailable_does_not_fallback_to_chat(self) -> None:
+        attempts: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, max_tokens, temperature, response_format
+            attempts.append(alias)
+            raise RuntimeError("json private failure")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_json=True,
+            chat_call=chat_call,
+        )
+
+        self.assertEqual(attempts, ["local_json"])
+        self.assertEqual(result.alias, "local_json")
+        _assert_safe_schema(
+            self,
+            result.to_json_dict(),
+            expect_error="json_unavailable",
+        )
+
+    async def test_json_mode_keeps_model_answer_as_string_inside_runner_schema(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return '{"foo": "bar"}'
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_json=True,
+            chat_call=chat_call,
+        )
+        data = json.loads(
+            run_local_agent.render_result(
+                result,
+                output="json",
+                show_metadata=False,
+            )
+        )
+
+        self.assertEqual(data["answer"], '{"foo": "bar"}')
+        self.assertEqual(data["alias"], "local_json")
+        _assert_safe_schema(self, data)
+
+    async def test_rag_unavailable_produces_safe_error_category_without_chat_fallback(self) -> None:
+        chat_called = False
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            nonlocal chat_called
+            chat_called = True
+            return "should not be used"
+
         async def rag_call(
             question: str,
             *,
@@ -254,12 +472,39 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         result = await run_local_agent.run_agent(
             question="pergunta",
             use_rag=True,
+            chat_call=chat_call,
             rag_call=rag_call,
         )
 
         data = result.to_json_dict()
         self.assertEqual(data["error_category"], "rag_unavailable")
+        self.assertEqual(data["alias"], "local_rag")
+        self.assertTrue(data["used_rag"])
+        self.assertFalse(chat_called)
         self.assertNotIn("service down", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="rag_unavailable")
+
+    async def test_debug_failure_includes_exception_class_only(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError("sensitive message must not appear")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            debug=True,
+            chat_call=chat_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "chat_unavailable:RuntimeError")
+        self.assertNotIn("sensitive message", json.dumps(data))
 
     async def test_remote_provider_is_never_called(self) -> None:
         source = inspect.getsource(run_local_agent)
@@ -267,6 +512,105 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         for forbidden in ("openai", "anthropic", "gemini", "openrouter"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, source.lower())
+
+    async def test_token_estimate_consistency(self) -> None:
+        for question in ("", " ", "a", "abcd", "abcde", "Olá, decisão local.", "x" * 100):
+            with self.subTest(question=question):
+                result = await run_local_agent.run_agent(question=question, dry_run=True)
+                self.assertIsInstance(result.estimated_remote_tokens_avoided, int)
+                self.assertGreaterEqual(result.estimated_remote_tokens_avoided, 0)
+
+    def test_prompt_token_estimate_boundaries(self) -> None:
+        self.assertEqual(run_local_agent._estimate_prompt_token_count(""), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("   "), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("a"), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("abcd"), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("abcde"), 2)
+        self.assertGreaterEqual(
+            run_local_agent._estimate_prompt_token_count("Olá, ação local."),
+            1,
+        )
+
+    def test_render_result_contracts(self) -> None:
+        result = run_local_agent.AgentRunResult(
+            answer="answer",
+            route="local",
+            alias="local_chat",
+            used_rag=False,
+            latency_ms=1.0,
+            decision_id="decision-id",
+            estimated_remote_tokens_avoided=10,
+        )
+
+        self.assertEqual(
+            run_local_agent.render_result(result, output="text", show_metadata=False),
+            "answer",
+        )
+        with_metadata = run_local_agent.render_result(
+            result,
+            output="text",
+            show_metadata=True,
+        )
+        self.assertIn("metadata=", with_metadata)
+        self.assertNotIn('"answer"', with_metadata)
+        data = json.loads(
+            run_local_agent.render_result(
+                result,
+                output="json",
+                show_metadata=False,
+            )
+        )
+        _assert_safe_schema(self, data)
+
+    def test_real_routing_policy_config_remains_local_only_when_available(self) -> None:
+        policy = load_routing_policy()
+
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+        self.assertIn(policy.per_request_token_limit, (0, None))
+
+    async def test_fake_blocked_decision_preserves_schema(self) -> None:
+        blocked = RouterDecision(
+            decision_id="blocked-decision",
+            timestamp_utc="2026-05-02T00:00:00Z",
+            route=RouteDecisionKind.BLOCKED,
+            reason="policy_denied",
+            risk_level=TaskRiskLevel.LOW,
+            token_budget_class=TokenBudgetClass.TINY,
+            remote_allowed=False,
+            remote_candidate_provider=None,
+            requires_sanitization=False,
+            estimated_prompt_tokens=1,
+            estimated_completion_tokens=1,
+            estimated_remote_tokens=2,
+            estimated_remote_tokens_avoided=2,
+        )
+
+        def fake_decide(**_kwargs: object) -> RouterDecision:
+            return blocked
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        with patch("scripts.run_local_agent.decide_route", fake_decide):
+            result = await run_local_agent.run_agent(
+                question="pergunta",
+                chat_call=chat_call,
+            )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["decision_id"], "blocked-decision")
+        self.assertEqual(data["answer"], BLOCKED_ANSWER)
+        self.assertEqual(data["latency_ms"], 0.0)
+        _assert_safe_schema(self, data, expect_error="blocked")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Hardens the Agent-0 local runner contract introduced in GW-15 with offline tests and one narrow safe correction.

This PR is stacked on GW-15 / PR #56 because that PR is still open. After GW-15 lands, this branch can be retargeted or rebased onto main.

## Scope

Included:

- Alias contract matrix for `local_chat`, `local_json`, and `local_rag`
- Stable JSON output schema guard for success, dry-run, blocked and failure paths
- Blocked route contract: no model call, safe sentinel answer, `latency_ms=0.0`
- Dry-run contract: no model call, safe metadata, `latency_ms=0.0`
- Degraded chat/json/rag failure contracts with safe error categories
- Explicit no-fallback assertions for chat, JSON and RAG paths
- JSON mode shape test preserving model JSON as answer string
- Token estimate boundary tests
- CLI argument validation boundary tests
- Documentation updates for GW-16 contract hardening

Small code correction:

- JSON execution failures now return `json_unavailable` instead of the generic chat failure category.

Excluded:

- Progressive fallback
- Timeout fallback/retry changes
- Golden questions harness
- Observability E2E validation
- Multi-agent orchestration
- FastAPI
- MCP
- Remote providers
- Qdrant mutation or reindexing

## Validation

```bash
git diff --check
uv run python scripts/run_local_agent.py --help
uv run pytest tests/unit/test_run_local_agent.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Reported local results:

- `tests/unit/test_run_local_agent.py`: 24 passed, 19 subtests passed
- full pytest: 268 passed, 7 skipped, 120 subtests passed
- mypy strict: success
- pyright: 0 errors
- smoke tests: 5 passed, 7 skipped

## Security

- No remote providers enabled
- No remote calls added
- No secrets committed
- No Qdrant mutation
- No real data ingested
- Runner schema excludes prompts, chunks, vectors, payloads, raw responses, tracebacks and secrets

Closes #57
