### PR TITLE
feat(agent): add local fail-safe degradation

### DIFF
--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -45,6 +45,19 @@ class RouteBlockReason(str, Enum):
     UNKNOWN = "unknown"
 
 
+class FallbackReason(str, Enum):
+    """Safe local fallback reasons for Agent-0 degradation."""
+
+    QDRANT_UNAVAILABLE = "qdrant_unavailable"
+    RAG_UNAVAILABLE = "rag_unavailable"
+    THINK_TIMEOUT = "think_timeout"
+    ALIAS_UNAVAILABLE = "alias_unavailable"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    UNSUPPORTED_TASK = "unsupported_task"
+    FALLBACK_ALIAS_FAILED = "fallback_alias_failed"
+    UNKNOWN_LOCAL_FAILURE = "unknown_local_failure"
+
+
 class TaskRiskLevel(str, Enum):
     """Coarse task risk levels used by routing policy."""
 

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -205,8 +205,9 @@ task metadata + token estimates
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | 🚧 Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | 🚧 Current |
 
 GW-13 rules:
 
@@ -228,7 +229,12 @@ GW-15 rules:
   raw responses, secrets or Authorization headers.
 - GW-16 hardens contracts only: alias matrix, output schema, blocked/dry-run,
   degraded states, parse/render boundaries and no-fallback assertions.
-- Progressive fallback is deferred to GW-17.
+- GW-17 adds explicit local-only fail-safe degradation:
+  `local_rag`/RAG infrastructure failure can fallback once to `local_chat`;
+  policy blocks never fallback.
+- Fallback reason codes are enum-derived and metadata-only.
+- `local_think` timeout fallback is deferred until Agent-0 has a public think
+  path.
 - Golden questions harness is deferred to GW-18.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,23 +4,28 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-05-01
-**Updated by:** Codex — Agent-0 GW-16 runner contract hardening
+**Last updated:** 2026-05-02
+**Updated by:** Codex — Agent-0 GW-17 local fail-safe degradation
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** harden the Agent-0 local runner contracts for alias routing, output
-schema, dry-run, blocked and degraded states without adding fallback or new
-runtime features.
+**Goal:** add explicit local fail-safe degradation for Agent-0 so recoverable
+local RAG/Qdrant failures can fall back once to `local_chat`, while policy
+blocks remain hard refusals with no model call.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
-GW-16 branch: `feat/agent0-runner-contract-hardening`
+GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
+GW-17 branch: `feat/agent0-local-failsafe-degradation`
+
+Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
+hardening branch present, but the GW-16 commit was not on `origin/main`.
+GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
+should be retargeted/rebased after GW-16 is integrated.
 
 Current runtime path:
 
@@ -117,8 +122,9 @@ unavoidable, use `git push --force-with-lease`.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -132,6 +138,7 @@ GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
+GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -184,6 +191,27 @@ Rules:
   alias.
 - No remote providers, no remote calls, no Qdrant mutation, no live services
   required for tests.
+
+## GW-17 Current Work
+
+GW-17 adds the first explicit local fail-safe degradation layer.
+
+Rules:
+
+- Fallback reasons are enum-derived, not free-form strings.
+- RAG/Qdrant unavailable can fallback once from `local_rag` to `local_chat`.
+- Successful RAG fallback returns the chat answer, `alias=local_chat`, and
+  `used_rag=false`.
+- Policy blocks such as `budget_exceeded` and `unsupported_task` never
+  fallback, call no model, and return `error_category=blocked`.
+- If the fallback alias also fails, the runner returns a safe failure with no
+  second fallback.
+- Fallback emits a sanitized local `agent_fallback` loguru event only when
+  fallback occurs.
+- `local_think` timeout fallback is deferred because Agent-0 has no public
+  think path yet.
+- No remote providers, no remote calls, no Qdrant mutation, no real data, and
+  no live services required for unit tests.
 
 ## GW-13 Completed Work
 

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -65,6 +65,16 @@ collections, delete collections or mutate Qdrant.
 
 On failure it may also include `error_category`.
 
+When GW-17 local fail-safe degradation applies, it may also include these safe
+optional fields:
+
+- `fallback_applied`
+- `fallback_from_alias`
+- `fallback_to_alias`
+- `fallback_reason`
+- `fallback_chain`
+- `block_reason`
+
 It never includes question text, prompts, chunks, vectors, embeddings, payloads,
 API keys, Authorization headers, secrets, passwords, raw model responses or
 tracebacks.
@@ -98,12 +108,50 @@ Safe error categories:
 - `rag_unavailable`
 - `invalid_arguments` is reserved for future CLI/reporting integration.
 
-Fallback remains intentionally disabled:
+GW-16 fallback remained intentionally disabled:
 
 - RAG failure does not fallback to `local_chat`.
 - JSON failure does not fallback to `local_chat`.
 - Chat failure does not try another alias.
 - Timeout/retry fallback is deferred to a future PR.
+
+## GW-17 Local Fail-Safe Degradation
+
+GW-17 adds one explicit local-only fallback path for recoverable local
+infrastructure failure.
+
+Fallback matrix:
+
+| Condition | Behavior | Exit |
+|---|---|---:|
+| RAG/Qdrant unavailable | fallback once from `local_rag` to `local_chat` | `0` if fallback succeeds |
+| fallback `local_chat` fails | safe failure, no second fallback | non-zero |
+| `budget_exceeded` policy block | structured refusal, no model call, no fallback | non-zero |
+| `unsupported_task` policy block | structured refusal, no model call, no fallback | non-zero |
+| `local_think` timeout | deferred because Agent-0 has no public think path yet | n/a |
+| JSON failure | safe failure, no fallback to chat | non-zero |
+| Chat failure | safe failure, no fallback | non-zero |
+
+Fallback reason codes are enum-derived and never free-form strings:
+
+- `qdrant_unavailable`
+- `rag_unavailable`
+- `think_timeout`
+- `alias_unavailable`
+- `budget_exceeded`
+- `unsupported_task`
+- `fallback_alias_failed`
+- `unknown_local_failure`
+
+Successful fallback returns the fallback answer and preserves the stable output
+schema. It sets `alias` to the alias that produced the answer, currently
+`local_chat`, and sets `used_rag` to `false`.
+
+Fallback emits a local loguru event named `agent_fallback` with only safe
+metadata: decision id, enum reason, source alias, target alias, success flag,
+latency and status. It does not log question text, prompts, answers, chunks,
+vectors, payloads, exception messages, tracebacks, API keys or Authorization
+headers.
 
 ## Dry Run
 
@@ -124,7 +172,7 @@ The smoke script is opt-in and local-only. It requires
 
 ## Deferred
 
-- Progressive fallback is deferred to GW-17.
+- Progressive remote escalation remains out of scope.
 - Golden questions harness is deferred to GW-18.
 - Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
-**Last updated:** 2026-05-01  
-**Current branch:** `feat/agent0-runner-contract-hardening`
-**Issue:** [#57](https://github.com/franciscosalido/OPENCLAW/issues/57)
+**Last updated:** 2026-05-02
+**Current branch:** `feat/agent0-local-failsafe-degradation`
+**Issue:** [#59](https://github.com/franciscosalido/OPENCLAW/issues/59)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -41,7 +41,7 @@ Out of scope:
 | Item | Scope |
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
-| GW-17 | Progressive local fallback on timeout/alias failure |
+| GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
 | GW-18 | Golden questions harness |
 
 ## GW-15 Current Work
@@ -98,3 +98,32 @@ Safety:
 
 - Runner output still excludes prompt/query/chunks/vectors/payloads/secrets.
 - Live services are not required for GW-16 tests.
+
+## GW-17 Current Work
+
+Scope:
+
+- Add typed fallback reason vocabulary.
+- Add safe optional fallback metadata to Agent-0 runner output.
+- Fallback once from `local_rag` to `local_chat` when local RAG/Qdrant
+  infrastructure is unavailable.
+- Keep policy blocks as hard stops with no model call and no fallback.
+- Add a no-double-fallback guard when the fallback alias also fails.
+- Emit a sanitized local `agent_fallback` loguru event.
+- Add offline tests for fallback, policy blocks, schema stability and exit
+  codes.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- FastAPI, MCP or multi-agent orchestration.
+- Qdrant mutation, reindexing, ingestion or `openclaw_knowledge` access.
+- Public `local_think` runner path. `local_think` timeout fallback remains
+  deferred until a think path exists.
+
+Safety:
+
+- Fallback reason codes are enum-derived.
+- Fallback metadata excludes prompt/query/chunks/vectors/payloads/secrets.
+- Successful fallback exits `0`; policy block and unrecoverable local failure
+  exit non-zero.

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -16,6 +16,8 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from loguru import logger
+
 from backend.gateway.client import (
     DEFAULT_LLM_JSON_MODEL,
     DEFAULT_LLM_MODEL,
@@ -23,7 +25,9 @@ from backend.gateway.client import (
     GatewayChatClient,
 )
 from backend.gateway.routing_policy import (
+    FallbackReason,
     RemoteEscalationPolicy,
+    RouteBlockReason,
     RouteDecisionKind,
     RouterDecision,
     decide_route,
@@ -41,6 +45,7 @@ SAFE_ERROR_CATEGORIES = {
     "chat_unavailable",
     "json_unavailable",
     "rag_unavailable",
+    "fallback_alias_failed",
     "invalid_arguments",
 }
 
@@ -96,6 +101,12 @@ class AgentRunResult:
     decision_id: str
     estimated_remote_tokens_avoided: int
     error_category: str | None = None
+    fallback_applied: bool | None = None
+    fallback_from_alias: str | None = None
+    fallback_to_alias: str | None = None
+    fallback_reason: FallbackReason | None = None
+    fallback_chain: tuple[FallbackReason, ...] | None = None
+    block_reason: str | None = None
 
     def to_json_dict(self) -> dict[str, object]:
         """Return the safe public output schema."""
@@ -110,6 +121,18 @@ class AgentRunResult:
         }
         if self.error_category is not None:
             data["error_category"] = self.error_category
+        if self.fallback_applied is not None:
+            data["fallback_applied"] = self.fallback_applied
+        if self.fallback_from_alias is not None:
+            data["fallback_from_alias"] = self.fallback_from_alias
+        if self.fallback_to_alias is not None:
+            data["fallback_to_alias"] = self.fallback_to_alias
+        if self.fallback_reason is not None:
+            data["fallback_reason"] = self.fallback_reason.value
+        if self.fallback_chain:
+            data["fallback_chain"] = [reason.value for reason in self.fallback_chain]
+        if self.block_reason is not None:
+            data["block_reason"] = self.block_reason
         return data
 
 
@@ -195,6 +218,8 @@ async def run_agent(
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
             error_category="blocked",
+            fallback_applied=False,
+            block_reason=_block_reason(decision),
         )
 
     if dry_run:
@@ -212,11 +237,75 @@ async def run_agent(
     try:
         if use_rag:
             active_rag_call = _call_rag if rag_call is None else rag_call
-            answer = await active_rag_call(
-                question,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            try:
+                answer = await active_rag_call(
+                    question,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+            except Exception as rag_exc:
+                active_chat_call = _call_chat_alias if chat_call is None else chat_call
+                fallback_reason = _rag_fallback_reason(rag_exc)
+                try:
+                    answer = await active_chat_call(
+                        question,
+                        alias=LOCAL_CHAT_ALIAS,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        response_format=None,
+                    )
+                except Exception as chat_exc:
+                    latency_ms = _elapsed_ms(start)
+                    _emit_fallback_event(
+                        decision_id=decision.decision_id,
+                        fallback_reason=fallback_reason,
+                        original_alias=LOCAL_RAG_ALIAS,
+                        fallback_alias=LOCAL_CHAT_ALIAS,
+                        fallback_succeeded=False,
+                        latency_ms=latency_ms,
+                    )
+                    error_category = "fallback_alias_failed"
+                    if debug:
+                        error_category = f"{error_category}:{chat_exc.__class__.__name__}"
+                    return AgentRunResult(
+                        answer="Local Agent-0 execution failed.",
+                        route=decision.route.value,
+                        alias=LOCAL_CHAT_ALIAS,
+                        used_rag=False,
+                        latency_ms=latency_ms,
+                        decision_id=decision.decision_id,
+                        estimated_remote_tokens_avoided=safe_avoided,
+                        error_category=error_category,
+                        fallback_applied=True,
+                        fallback_from_alias=LOCAL_RAG_ALIAS,
+                        fallback_to_alias=LOCAL_CHAT_ALIAS,
+                        fallback_reason=fallback_reason,
+                        fallback_chain=(fallback_reason,),
+                    )
+
+                latency_ms = _elapsed_ms(start)
+                _emit_fallback_event(
+                    decision_id=decision.decision_id,
+                    fallback_reason=fallback_reason,
+                    original_alias=LOCAL_RAG_ALIAS,
+                    fallback_alias=LOCAL_CHAT_ALIAS,
+                    fallback_succeeded=True,
+                    latency_ms=latency_ms,
+                )
+                return AgentRunResult(
+                    answer=answer,
+                    route=decision.route.value,
+                    alias=LOCAL_CHAT_ALIAS,
+                    used_rag=False,
+                    latency_ms=latency_ms,
+                    decision_id=decision.decision_id,
+                    estimated_remote_tokens_avoided=safe_avoided,
+                    fallback_applied=True,
+                    fallback_from_alias=LOCAL_RAG_ALIAS,
+                    fallback_to_alias=LOCAL_CHAT_ALIAS,
+                    fallback_reason=fallback_reason,
+                    fallback_chain=(fallback_reason,),
+                )
         else:
             active_chat_call = _call_chat_alias if chat_call is None else chat_call
             answer = await active_chat_call(
@@ -356,6 +445,47 @@ def _task_type(*, use_rag: bool, use_json: bool) -> str:
 
 def _elapsed_ms(started_at: float) -> float:
     return (time.perf_counter() - started_at) * 1000
+
+
+def _block_reason(decision: RouterDecision) -> str:
+    """Return a safe block reason from routing policy metadata."""
+    if decision.reason == RouteBlockReason.BUDGET_EXCEEDED.value:
+        return FallbackReason.BUDGET_EXCEEDED.value
+    if decision.reason == RouteBlockReason.UNSUPPORTED_TASK.value:
+        return FallbackReason.UNSUPPORTED_TASK.value
+    return decision.reason
+
+
+def _rag_fallback_reason(exc: Exception) -> FallbackReason:
+    """Classify a RAG failure without exposing exception details."""
+    class_name = exc.__class__.__name__.lower()
+    module_name = exc.__class__.__module__.lower()
+    if "qdrant" in class_name or "qdrant" in module_name:
+        return FallbackReason.QDRANT_UNAVAILABLE
+    return FallbackReason.RAG_UNAVAILABLE
+
+
+def _emit_fallback_event(
+    *,
+    decision_id: str,
+    fallback_reason: FallbackReason,
+    original_alias: str,
+    fallback_alias: str,
+    fallback_succeeded: bool,
+    latency_ms: float,
+) -> None:
+    """Emit a safe local fallback event with allowlisted metadata only."""
+    event: dict[str, object] = {
+        "event": "agent_fallback",
+        "decision_id": decision_id,
+        "fallback_reason": fallback_reason.value,
+        "original_alias": original_alias,
+        "fallback_alias": fallback_alias,
+        "fallback_succeeded": fallback_succeeded,
+        "latency_ms": latency_ms,
+        "status": "success" if fallback_succeeded else "failure",
+    }
+    logger.bind(event=event).info("agent_fallback")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -9,8 +9,10 @@ from typing import cast
 from unittest.mock import patch
 
 from backend.gateway.routing_policy import (
+    FallbackReason,
     RemoteEscalationPolicy,
     RouteDecisionKind,
+    RouteBlockReason,
     TaskRiskLevel,
     TokenBudgetClass,
     RouterDecision,
@@ -29,7 +31,15 @@ REQUIRED_KEYS = {
     "decision_id",
     "estimated_remote_tokens_avoided",
 }
-OPTIONAL_KEYS = {"error_category"}
+OPTIONAL_KEYS = {
+    "error_category",
+    "fallback_applied",
+    "fallback_from_alias",
+    "fallback_to_alias",
+    "fallback_reason",
+    "fallback_chain",
+    "block_reason",
+}
 FORBIDDEN_OUTPUT_KEYS = {
     "query",
     "question",
@@ -87,6 +97,19 @@ def _assert_safe_schema(
     test_case.assertIsInstance(data["decision_id"], str)
     test_case.assertTrue(data["decision_id"])
     test_case.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
+
+
+def _assert_fallback_metadata(
+    test_case: unittest.TestCase,
+    data: Mapping[str, object],
+    *,
+    reason: FallbackReason,
+) -> None:
+    test_case.assertEqual(data["fallback_applied"], True)
+    test_case.assertEqual(data["fallback_from_alias"], "local_rag")
+    test_case.assertEqual(data["fallback_to_alias"], "local_chat")
+    test_case.assertEqual(data["fallback_reason"], reason.value)
+    test_case.assertEqual(data["fallback_chain"], [reason.value])
 
 
 class RunLocalAgentCliTests(unittest.TestCase):
@@ -357,6 +380,8 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.route, "blocked")
         self.assertEqual(result.answer, BLOCKED_ANSWER)
         self.assertEqual(result.latency_ms, 0.0)
+        self.assertFalse(result.fallback_applied)
+        self.assertEqual(result.block_reason, FallbackReason.BUDGET_EXCEEDED.value)
         _assert_safe_schema(self, result.to_json_dict(), expect_error="blocked")
 
     async def test_chat_unavailable_produces_safe_error_category(self) -> None:
@@ -444,8 +469,8 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["alias"], "local_json")
         _assert_safe_schema(self, data)
 
-    async def test_rag_unavailable_produces_safe_error_category_without_chat_fallback(self) -> None:
-        chat_called = False
+    async def test_rag_unavailable_falls_back_once_to_local_chat(self) -> None:
+        calls: list[str] = []
 
         async def chat_call(
             question: str,
@@ -455,10 +480,9 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             temperature: float | None,
             response_format: Mapping[str, object] | None,
         ) -> str:
-            del question, alias, max_tokens, temperature, response_format
-            nonlocal chat_called
-            chat_called = True
-            return "should not be used"
+            del question, max_tokens, temperature, response_format
+            calls.append(alias)
+            return "fallback chat answer"
 
         async def rag_call(
             question: str,
@@ -477,12 +501,100 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         )
 
         data = result.to_json_dict()
-        self.assertEqual(data["error_category"], "rag_unavailable")
-        self.assertEqual(data["alias"], "local_rag")
-        self.assertTrue(data["used_rag"])
-        self.assertFalse(chat_called)
+        self.assertNotIn("error_category", data)
+        self.assertEqual(data["answer"], "fallback chat answer")
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertFalse(data["used_rag"])
+        self.assertEqual(calls, ["local_chat"])
         self.assertNotIn("service down", json.dumps(data))
-        _assert_safe_schema(self, data, expect_error="rag_unavailable")
+        _assert_safe_schema(self, data)
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.RAG_UNAVAILABLE,
+        )
+
+    async def test_qdrant_unavailable_fallback_reason_is_typed(self) -> None:
+        class QdrantUnavailableError(RuntimeError):
+            pass
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback chat answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise QdrantUnavailableError("private details")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.QDRANT_UNAVAILABLE,
+        )
+
+    async def test_rag_unavailable_and_fallback_chat_failure_has_no_double_fallback(self) -> None:
+        calls: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, max_tokens, temperature, response_format
+            calls.append(alias)
+            raise RuntimeError("fallback private failure")
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("rag private failure")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(calls, ["local_chat"])
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertFalse(data["used_rag"])
+        self.assertNotIn("rag private failure", json.dumps(data))
+        self.assertNotIn("fallback private failure", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="fallback_alias_failed")
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.RAG_UNAVAILABLE,
+        )
 
     async def test_debug_failure_includes_exception_class_only(self) -> None:
         async def chat_call(
@@ -505,6 +617,40 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(data["error_category"], "chat_unavailable:RuntimeError")
         self.assertNotIn("sensitive message", json.dumps(data))
+
+    async def test_fallback_debug_failure_includes_exception_class_only(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError("fallback sensitive message")
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("rag sensitive message")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            debug=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "fallback_alias_failed:RuntimeError")
+        self.assertNotIn("fallback sensitive message", json.dumps(data))
+        self.assertNotIn("rag sensitive message", json.dumps(data))
 
     async def test_remote_provider_is_never_called(self) -> None:
         source = inspect.getsource(run_local_agent)
@@ -574,7 +720,7 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             decision_id="blocked-decision",
             timestamp_utc="2026-05-02T00:00:00Z",
             route=RouteDecisionKind.BLOCKED,
-            reason="policy_denied",
+            reason=RouteBlockReason.BUDGET_EXCEEDED.value,
             risk_level=TaskRiskLevel.LOW,
             token_budget_class=TokenBudgetClass.TINY,
             remote_allowed=False,
@@ -610,7 +756,149 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["decision_id"], "blocked-decision")
         self.assertEqual(data["answer"], BLOCKED_ANSWER)
         self.assertEqual(data["latency_ms"], 0.0)
+        self.assertEqual(data["fallback_applied"], False)
+        self.assertEqual(data["block_reason"], FallbackReason.BUDGET_EXCEEDED.value)
         _assert_safe_schema(self, data, expect_error="blocked")
+
+    async def test_policy_block_unsupported_task_never_fallbacks(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            chat_call=chat_call,
+            policy_loader=lambda: RemoteEscalationPolicy(
+                blocked_task_types=("agent0_chat",),
+            ),
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "blocked")
+        self.assertEqual(data["fallback_applied"], False)
+        self.assertEqual(data["block_reason"], FallbackReason.UNSUPPORTED_TASK.value)
+        _assert_safe_schema(self, data, expect_error="blocked")
+
+    async def test_successful_fallback_exits_zero(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("private")
+
+        with (
+            patch("scripts.run_local_agent._call_chat_alias", chat_call),
+            patch("scripts.run_local_agent._call_rag", rag_call),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await run_local_agent.main_async(["pergunta", "--rag"])
+
+        self.assertEqual(exit_code, 0)
+        rendered = write_mock.call_args.args[0]
+        self.assertIn("fallback answer", rendered)
+
+    async def test_policy_block_exits_nonzero(self) -> None:
+        with (
+            patch(
+                "scripts.run_local_agent._safe_policy",
+                lambda: RemoteEscalationPolicy(per_request_token_limit=1),
+            ),
+            patch("sys.stdout.write"),
+        ):
+            exit_code = await run_local_agent.main_async(["pergunta"])
+
+        self.assertNotEqual(exit_code, 0)
+
+    async def test_fallback_event_is_safe_and_emitted_only_on_fallback(self) -> None:
+        events: list[dict[str, object]] = []
+
+        class BoundLogger:
+            def __init__(self, event: dict[str, object]) -> None:
+                self.event = event
+
+            def info(self, message: str) -> None:
+                self.event["message"] = message
+                events.append(self.event)
+
+        def fake_bind(**kwargs: object) -> BoundLogger:
+            event = kwargs["event"]
+            assert isinstance(event, dict)
+            return BoundLogger(event)
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("private prompt should not leak")
+
+        with patch("scripts.run_local_agent.logger.bind", fake_bind):
+            await run_local_agent.run_agent(
+                question="pergunta",
+                use_rag=True,
+                chat_call=chat_call,
+                rag_call=rag_call,
+            )
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["event"], "agent_fallback")
+        self.assertEqual(event["fallback_reason"], FallbackReason.RAG_UNAVAILABLE.value)
+        self.assertEqual(event["original_alias"], "local_rag")
+        self.assertEqual(event["fallback_alias"], "local_chat")
+        self.assertTrue(event["fallback_succeeded"])
+        self.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in event}))
+
+    async def test_no_fallback_event_without_fallback(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        with patch("scripts.run_local_agent.logger.bind") as bind_mock:
+            await run_local_agent.run_agent(question="pergunta", chat_call=chat_call)
+
+        bind_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds explicit local-only fail-safe degradation for the Agent-0 runner. Recoverable local RAG/Qdrant failures can fallback once from `local_rag` to `local_chat`; policy blocks remain hard refusals with no model call and no fallback.

This PR is stacked on GW-16 (`feat/agent0-runner-contract-hardening`) because GitHub/local state showed the GW-16 commit was not on `origin/main` when GW-17 started. Retarget/rebase after GW-16 is integrated.

Closes #59.

## Scope

Included:

- `FallbackReason` enum with safe degradation reason codes
- Optional safe fallback metadata in `AgentRunResult` output
- RAG/Qdrant unavailable fallback: `local_rag` -> `local_chat`
- Policy block hard stops for `budget_exceeded` and `unsupported_task`
- No-double-fallback guard when fallback alias also fails
- Sanitized local `agent_fallback` loguru event
- Offline unit tests for fallback, blocking, schema and exit-code behavior
- Runner docs and memory handoff updates

Deferred:

- `local_think` timeout fallback, because Agent-0 has no public think path yet
- Progressive remote escalation
- Golden questions harness
- Live observability E2E validation

## Fallback Matrix

| Condition | Behavior | Exit |
|---|---|---:|
| RAG/Qdrant unavailable | fallback once from `local_rag` to `local_chat` | `0` if fallback succeeds |
| fallback `local_chat` fails | safe failure, no second fallback | non-zero |
| `budget_exceeded` policy block | refusal, no model call, no fallback | non-zero |
| `unsupported_task` policy block | refusal, no model call, no fallback | non-zero |
| JSON failure | safe failure, no fallback | non-zero |
| Chat failure | safe failure, no fallback | non-zero |

## Validation

```bash
git diff --check
uv run python scripts/run_local_agent.py --help
uv run pytest tests/unit/test_run_local_agent.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Reported local results:

- `tests/unit/test_run_local_agent.py`: 32 passed, 19 subtests passed
- full pytest: 276 passed, 7 skipped, 120 subtests passed
- mypy strict: success
- pyright: 0 errors
- smoke tests: 5 passed, 7 skipped

## Security

- No remote providers enabled
- No remote calls added
- No secrets committed
- No Qdrant mutation or reindex
- No real data ingested
- No prompt/query/chunks/vectors/payloads/exception messages/tracebacks/API keys/Authorization headers in fallback output or fallback events
