### PR TITLE
test(agent): add golden question benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ Thumbs.db
 # Logs
 logs/
 *.log
+tests/golden/reports/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -207,7 +207,8 @@ task metadata + token estimates
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | 🚧 Current |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | 🚧 Current |
 
 GW-13 rules:
 
@@ -235,7 +236,11 @@ GW-15 rules:
 - Fallback reason codes are enum-derived and metadata-only.
 - `local_think` timeout fallback is deferred until Agent-0 has a public think
   path.
-- Golden questions harness is deferred to GW-18.
+- GW-18 adds the golden question harness:
+  `tests/golden/questions.yaml`, `scripts/run_golden_harness.py`, and
+  `scripts/compare_golden_runs.py`.
+- Golden harness reports are opt-in, local-only, synthetic-only, and omit answer
+  text by default.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,27 +5,29 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-02
-**Updated by:** Codex — Agent-0 GW-17 local fail-safe degradation
+**Updated by:** Codex — Agent-0 GW-18 golden question harness
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add explicit local fail-safe degradation for Agent-0 so recoverable
-local RAG/Qdrant failures can fall back once to `local_chat`, while policy
-blocks remain hard refusals with no model call.
+**Goal:** add the Agent-0 golden question benchmark harness: fixed synthetic
+financial-domain questions, offline dry-run reports, and summary comparison
+tools for future regression checks.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
-GW-17 branch: `feat/agent0-local-failsafe-degradation`
+GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
+GW-18 branch: `feat/agent0-golden-question-harness`
 
 Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
 hardening branch present, but the GW-16 commit was not on `origin/main`.
 GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
 should be retargeted/rebased after GW-16 is integrated.
+GW-18 was implemented as a stacked branch on GW-17 for the same reason and
+should be retargeted/rebased after GW-16/GW-17 are integrated.
 
 Current runtime path:
 
@@ -124,7 +126,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Current |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -139,6 +142,7 @@ GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
+GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -171,8 +175,8 @@ Rules:
 - `--dry-run` works without live services.
 - No remote providers, no remote calls, no API keys, no FastAPI, no MCP.
 - No Qdrant mutation, no reindexing, no ingestion, no real data.
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- Progressive fallback is handled by GW-17.
+- Golden questions harness is handled by GW-18.
 
 ## GW-16 Current Work
 
@@ -210,6 +214,31 @@ Rules:
   fallback occurs.
 - `local_think` timeout fallback is deferred because Agent-0 has no public
   think path yet.
+- No remote providers, no remote calls, no Qdrant mutation, no real data, and
+  no live services required for unit tests.
+
+## GW-18 Current Work
+
+GW-18 adds the reproducible Agent-0 golden question harness.
+
+Deliverables:
+
+- `tests/golden/questions.yaml` with 8 synthetic financial-domain questions.
+- `scripts/run_golden_harness.py` opt-in harness guarded by
+  `RUN_GOLDEN_HARNESS=1`.
+- Offline `--dry-run` mode that emits JSONL and summary JSON without live
+  services.
+- `scripts/compare_golden_runs.py` for summary-to-summary regression checks.
+- `docs/AGENT0_GOLDEN_HARNESS.md` and `tests/golden/README.md`.
+
+Rules:
+
+- No answer text is stored in JSONL by default; only `answer_length_chars`.
+- Reports exclude prompt/question/chunks/vectors/payloads/secrets and raw
+  exceptions.
+- Reports are written under `tests/golden/reports/`, which is ignored by Git.
+- Quality scoring is human-readable only; no LLM-as-judge and no external API.
+- Optional human scoring helper is deferred to a future issue.
 - No remote providers, no remote calls, no Qdrant mutation, no real data, and
   no live services required for unit tests.
 

--- a/docs/AGENT0_GOLDEN_HARNESS.md
+++ b/docs/AGENT0_GOLDEN_HARNESS.md
@@ -1,0 +1,150 @@
+# Agent-0 Golden Harness
+
+GW-18 adds an opt-in golden question benchmark harness for Agent-0.
+
+The harness is a reproducible quality and latency baseline. It does not improve
+model behavior, does not judge answers with another model, and does not change
+runtime routing.
+
+## Synthetic-Only Policy
+
+Questions must be synthetic and educational. They must not include real
+tickers, companies, funds, portfolios, private documents or user data.
+
+The registry lives at:
+
+```text
+tests/golden/questions.yaml
+```
+
+Each question has:
+
+- `id`
+- `domain`
+- `mode`
+- `question`
+- `rationale`
+
+Supported modes:
+
+- `chat`
+- `rag`
+- `json`
+
+## Dry Run
+
+Dry-run is fully offline and does not call LiteLLM, Ollama or Qdrant:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py --dry-run
+```
+
+Custom output directory:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py \
+  --dry-run \
+  --output-dir /tmp/openclaw_golden_reports
+```
+
+If `RUN_GOLDEN_HARNESS` is not `1`, the harness exits safely without running.
+
+## Optional Live Run
+
+Live mode may call the local Agent-0 runner. It remains local-only:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py \
+  --output-dir tests/golden/reports
+```
+
+Live mode requires the same local services as the selected runner modes. Reports
+remain local artifacts and are ignored by Git.
+
+## JSONL Result Schema
+
+The JSONL report contains one safe object per question. It stores answer length
+only, not answer text.
+
+Fields include:
+
+- `question_id`
+- `domain`
+- `mode`
+- `route`
+- `alias`
+- `used_rag`
+- `latency_ms`
+- `decision_id`
+- `estimated_remote_tokens_avoided`
+- `answer_length_chars`
+- `error_category`
+- `fallback_applied`
+- `fallback_reason`
+- `quality_score`
+- `skipped`
+- `skipped_reason`
+
+It never stores question text, answer text, prompts, chunks, vectors, payloads,
+raw model responses, exception messages, API keys, Authorization headers or
+secrets.
+
+## Summary Schema
+
+The summary JSON includes:
+
+- `run_id`
+- `timestamp_utc`
+- `total_questions`
+- `passed`
+- `failed`
+- `skipped`
+- `fallback_count`
+- `mean_latency_ms_by_alias`
+- `p95_latency_ms_by_alias`
+- `total_estimated_remote_tokens_avoided`
+- `quality_score_present`
+- `model_under_test_aliases`
+
+Alias names are semantic aliases only. Concrete model names are not recorded.
+
+## Human Scoring Rubric
+
+GW-18 does not implement LLM-as-judge.
+
+Future human review may use this rubric:
+
+- `0`: no answer or hard error
+- `1`: answer present but off-topic or incomplete
+- `2`: plausible and topically relevant
+- `3`: accurate, well-reasoned, cites if RAG
+
+The optional scoring helper is deferred to GW-19 to keep GW-18 focused on the
+registry, report contract and comparison tool.
+
+## Comparison
+
+Compare two summary files:
+
+```bash
+uv run python scripts/compare_golden_runs.py \
+  --baseline path/to/baseline_summary.json \
+  --candidate path/to/candidate_summary.json \
+  --latency-threshold-pct 20
+```
+
+The comparison exits non-zero only for hard regressions:
+
+- pass rate decreases
+- any per-alias mean latency regresses beyond the threshold
+
+## Out Of Scope
+
+- Remote providers
+- Remote API calls
+- LLM-as-judge
+- Dashboards
+- OpenTelemetry
+- Prometheus or Grafana
+- Qdrant mutation or reindexing
+- Real data

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -173,6 +173,7 @@ The smoke script is opt-in and local-only. It requires
 ## Deferred
 
 - Progressive remote escalation remains out of scope.
-- Golden questions harness is deferred to GW-18.
-- Observability E2E validation is deferred to GW-18.
+- Golden questions harness is provided by GW-18 in
+  `scripts/run_golden_harness.py`.
+- Observability E2E validation remains deferred to a future explicit issue.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-02
-**Current branch:** `feat/agent0-local-failsafe-degradation`
-**Issue:** [#59](https://github.com/franciscosalido/OPENCLAW/issues/59)
+**Current branch:** `feat/agent0-golden-question-harness`
+**Issue:** [#61](https://github.com/franciscosalido/OPENCLAW/issues/61)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -42,7 +42,7 @@ Out of scope:
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
 | GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
-| GW-18 | Golden questions harness |
+| GW-18 | Golden question benchmark harness |
 
 ## GW-15 Current Work
 
@@ -127,3 +127,32 @@ Safety:
 - Fallback metadata excludes prompt/query/chunks/vectors/payloads/secrets.
 - Successful fallback exits `0`; policy block and unrecoverable local failure
   exit non-zero.
+
+## GW-18 Current Work
+
+Scope:
+
+- Add `tests/golden/questions.yaml` with fixed synthetic financial-domain
+  questions.
+- Add `scripts/run_golden_harness.py` with opt-in dry-run and optional live
+  execution.
+- Emit safe JSONL and summary JSON reports without answer text.
+- Add `scripts/compare_golden_runs.py` for summary-to-summary regression checks.
+- Add offline unit tests for registry, report schema, guard behavior and
+  comparison logic.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- LLM-as-judge.
+- Dashboards, OpenTelemetry, Prometheus or Grafana.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- Live baseline publication. First committed live baseline requires a future
+  explicit baseline-update decision.
+
+Safety:
+
+- Golden questions are synthetic-only.
+- Reports exclude prompt/question/chunks/vectors/payloads/secrets and do not
+  include answer text by default.
+- `tests/golden/reports/` is ignored by Git.

--- a/scripts/compare_golden_runs.py
+++ b/scripts/compare_golden_runs.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Compare two Agent-0 golden harness summary files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse comparison CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare two Agent-0 golden harness summary JSON files.",
+    )
+    parser.add_argument("--baseline", required=True, help="Baseline summary JSON.")
+    parser.add_argument("--candidate", required=True, help="Candidate summary JSON.")
+    parser.add_argument(
+        "--latency-threshold-pct",
+        type=float,
+        default=20.0,
+        help="Mean latency regression threshold by alias.",
+    )
+    return parser.parse_args(argv)
+
+
+def compare_summaries(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    latency_threshold_pct: float,
+) -> tuple[str, int]:
+    """Return a human-readable comparison table and exit code."""
+    if latency_threshold_pct < 0:
+        raise ValueError("latency_threshold_pct cannot be negative")
+    baseline_rate = _pass_rate(baseline)
+    candidate_rate = _pass_rate(candidate)
+    pass_rate_delta = candidate_rate - baseline_rate
+    baseline_latency = _read_float_mapping(baseline, "mean_latency_ms_by_alias")
+    candidate_latency = _read_float_mapping(candidate, "mean_latency_ms_by_alias")
+    aliases = sorted(set(baseline_latency) | set(candidate_latency))
+    latency_rows: list[tuple[str, float, float, float]] = []
+    latency_regression = False
+    for alias in aliases:
+        base = baseline_latency.get(alias, 0.0)
+        cand = candidate_latency.get(alias, 0.0)
+        delta_pct = _percent_delta(base, cand)
+        latency_rows.append((alias, base, cand, delta_pct))
+        if base > 0 and delta_pct > latency_threshold_pct:
+            latency_regression = True
+
+    fallback_delta = _read_int(candidate, "fallback_count") - _read_int(
+        baseline,
+        "fallback_count",
+    )
+    token_delta = _read_float(
+        candidate,
+        "total_estimated_remote_tokens_avoided",
+    ) - _read_float(baseline, "total_estimated_remote_tokens_avoided")
+
+    lines = [
+        "golden_run_comparison",
+        f"pass_rate_delta={pass_rate_delta:.4f}",
+        f"fallback_count_delta={fallback_delta}",
+        f"total_estimated_remote_tokens_avoided_delta={token_delta:.1f}",
+        "alias | baseline_mean_ms | candidate_mean_ms | delta_pct",
+    ]
+    for alias, base, cand, delta_pct in latency_rows:
+        lines.append(f"{alias} | {base:.1f} | {cand:.1f} | {delta_pct:.1f}")
+
+    exit_code = 1 if pass_rate_delta < 0 or latency_regression else 0
+    return "\n".join(lines) + "\n", exit_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    baseline = _load_summary(args.baseline)
+    candidate = _load_summary(args.candidate)
+    output, exit_code = compare_summaries(
+        baseline,
+        candidate,
+        latency_threshold_pct=args.latency_threshold_pct,
+    )
+    sys.stdout.write(output)
+    return exit_code
+
+
+def _load_summary(path: Path | str) -> Mapping[str, Any]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("summary JSON must be an object")
+    return raw
+
+
+def _pass_rate(summary: Mapping[str, Any]) -> float:
+    total = _read_int(summary, "total_questions")
+    if total <= 0:
+        return 0.0
+    return _read_int(summary, "passed") / total
+
+
+def _read_int(summary: Mapping[str, Any], key: str) -> int:
+    value = summary.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"summary {key} must be an integer")
+    return value
+
+
+def _read_float(summary: Mapping[str, Any], key: str) -> float:
+    value = summary.get(key)
+    if not isinstance(value, int | float):
+        raise ValueError(f"summary {key} must be numeric")
+    return float(value)
+
+
+def _read_float_mapping(summary: Mapping[str, Any], key: str) -> dict[str, float]:
+    value = summary.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"summary {key} must be an object")
+    output: dict[str, float] = {}
+    for alias, latency in value.items():
+        if not isinstance(alias, str):
+            raise ValueError(f"summary {key} keys must be strings")
+        if not isinstance(latency, int | float):
+            raise ValueError(f"summary {key}.{alias} must be numeric")
+        output[alias] = float(latency)
+    return output
+
+
+def _percent_delta(baseline: float, candidate: float) -> float:
+    if baseline <= 0:
+        return 0.0 if candidate <= 0 else 100.0
+    return ((candidate - baseline) / baseline) * 100.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_golden_harness.py
+++ b/scripts/run_golden_harness.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+"""Run the Agent-0 golden question harness.
+
+The harness is opt-in and local-only. Dry-run mode is fully offline and never
+calls LiteLLM, Ollama or Qdrant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import mean
+from uuid import uuid4
+
+import yaml
+
+from scripts import run_local_agent
+
+
+DEFAULT_QUESTIONS_PATH = Path("tests/golden/questions.yaml")
+DEFAULT_OUTPUT_DIR = Path("tests/golden/reports")
+HARNESS_GUARD_ENV = "RUN_GOLDEN_HARNESS"
+
+
+@dataclass(frozen=True)
+class GoldenQuestion:
+    """Synthetic golden benchmark question."""
+
+    question_id: str
+    domain: str
+    mode: str
+    question: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class GoldenResult:
+    """Safe per-question benchmark result without answer text."""
+
+    question_id: str
+    domain: str
+    mode: str
+    route: str
+    alias: str | None
+    used_rag: bool
+    latency_ms: float
+    decision_id: str
+    estimated_remote_tokens_avoided: int | float
+    answer_length_chars: int
+    error_category: str | None
+    fallback_applied: bool | None
+    fallback_reason: str | None
+    quality_score: None
+    skipped: bool = False
+    skipped_reason: str | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return allowlisted JSONL-safe result metadata."""
+        data: dict[str, object] = {
+            "question_id": self.question_id,
+            "domain": self.domain,
+            "mode": self.mode,
+            "route": self.route,
+            "used_rag": self.used_rag,
+            "latency_ms": self.latency_ms,
+            "decision_id": self.decision_id,
+            "estimated_remote_tokens_avoided": (
+                self.estimated_remote_tokens_avoided
+            ),
+            "answer_length_chars": self.answer_length_chars,
+            "quality_score": self.quality_score,
+            "skipped": self.skipped,
+        }
+        optional_values: dict[str, object | None] = {
+            "alias": self.alias,
+            "error_category": self.error_category,
+            "fallback_applied": self.fallback_applied,
+            "fallback_reason": self.fallback_reason,
+            "skipped_reason": self.skipped_reason,
+        }
+        for key, value in optional_values.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse harness CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the opt-in Agent-0 golden question harness.",
+    )
+    parser.add_argument(
+        "--questions",
+        default=str(DEFAULT_QUESTIONS_PATH),
+        help="Path to the golden question registry.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for JSONL and summary reports.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run offline with deterministic fake runner results.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_questions(path: Path | str = DEFAULT_QUESTIONS_PATH) -> list[GoldenQuestion]:
+    """Load synthetic golden questions from YAML."""
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("golden questions root must be a mapping")
+    items = raw.get("questions")
+    if not isinstance(items, list):
+        raise ValueError("golden questions file must contain a questions list")
+    questions: list[GoldenQuestion] = []
+    seen_ids: set[str] = set()
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ValueError("each golden question must be a mapping")
+        question = GoldenQuestion(
+            question_id=_read_str(item, "id"),
+            domain=_read_str(item, "domain"),
+            mode=_read_mode(item),
+            question=_read_str(item, "question"),
+            rationale=_read_str(item, "rationale"),
+        )
+        if question.question_id in seen_ids:
+            raise ValueError(f"duplicate golden question id: {question.question_id}")
+        seen_ids.add(question.question_id)
+        questions.append(question)
+    return questions
+
+
+async def run_harness(
+    *,
+    questions_path: Path | str = DEFAULT_QUESTIONS_PATH,
+    output_dir: Path | str = DEFAULT_OUTPUT_DIR,
+    dry_run: bool,
+) -> tuple[Path, Path]:
+    """Run all golden questions and write JSONL plus summary reports."""
+    questions = load_questions(questions_path)
+    run_id = uuid4().hex[:12]
+    timestamp = _utc_now()
+    results: list[GoldenResult] = []
+    for question in questions:
+        if dry_run:
+            result = _dry_run_result(question)
+        else:
+            result = await _live_result(question)
+        results.append(result)
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = out_dir / f"golden_results_{run_id}.jsonl"
+    summary_path = out_dir / f"golden_summary_{run_id}.json"
+    _write_jsonl(jsonl_path, results)
+    _write_summary(
+        summary_path,
+        run_id=run_id,
+        timestamp_utc=timestamp,
+        results=results,
+    )
+    return jsonl_path, summary_path
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async harness entrypoint."""
+    args = parse_args(argv)
+    if os.environ.get(HARNESS_GUARD_ENV) != "1":
+        sys.stdout.write(
+            "Golden harness is opt-in. Set RUN_GOLDEN_HARNESS=1 to run.\n",
+        )
+        return 2
+    jsonl_path, summary_path = await run_harness(
+        questions_path=args.questions,
+        output_dir=args.output_dir,
+        dry_run=args.dry_run,
+    )
+    sys.stdout.write(f"OK golden_jsonl={jsonl_path} summary_json={summary_path}\n")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def _dry_run_result(question: GoldenQuestion) -> GoldenResult:
+    alias = _alias_for_mode(question.mode)
+    answer = "Dry run: no model call executed."
+    estimated = run_local_agent._estimate_prompt_token_count(question.question)
+    return GoldenResult(
+        question_id=question.question_id,
+        domain=question.domain,
+        mode=question.mode,
+        route="local",
+        alias=alias,
+        used_rag=question.mode == "rag",
+        latency_ms=0.0,
+        decision_id=f"dryrun-{question.question_id}",
+        estimated_remote_tokens_avoided=estimated,
+        answer_length_chars=len(answer),
+        error_category=None,
+        fallback_applied=None,
+        fallback_reason=None,
+        quality_score=None,
+    )
+
+
+async def _live_result(question: GoldenQuestion) -> GoldenResult:
+    result = await run_local_agent.run_agent(
+        question=question.question,
+        use_rag=question.mode == "rag",
+        use_json=question.mode == "json",
+    )
+    return GoldenResult(
+        question_id=question.question_id,
+        domain=question.domain,
+        mode=question.mode,
+        route=result.route,
+        alias=result.alias,
+        used_rag=result.used_rag,
+        latency_ms=result.latency_ms,
+        decision_id=result.decision_id,
+        estimated_remote_tokens_avoided=result.estimated_remote_tokens_avoided,
+        answer_length_chars=len(result.answer),
+        error_category=result.error_category,
+        fallback_applied=result.fallback_applied,
+        fallback_reason=(
+            result.fallback_reason.value
+            if result.fallback_reason is not None
+            else None
+        ),
+        quality_score=None,
+    )
+
+
+def _write_jsonl(path: Path, results: Sequence[GoldenResult]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(result.to_json_dict(), sort_keys=True) + "\n")
+
+
+def _write_summary(
+    path: Path,
+    *,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[GoldenResult],
+) -> None:
+    summary = build_summary(
+        run_id=run_id,
+        timestamp_utc=timestamp_utc,
+        results=results,
+    )
+    path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_summary(
+    *,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[GoldenResult],
+) -> dict[str, object]:
+    """Build a safe aggregate benchmark summary."""
+    failed = sum(1 for result in results if result.error_category is not None)
+    skipped = sum(1 for result in results if result.skipped)
+    passed = len(results) - failed - skipped
+    aliases = sorted(
+        {result.alias for result in results if result.alias is not None}
+    )
+    return {
+        "run_id": run_id,
+        "timestamp_utc": timestamp_utc,
+        "total_questions": len(results),
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "fallback_count": sum(1 for result in results if result.fallback_applied),
+        "mean_latency_ms_by_alias": _latency_by_alias(results, percentile=False),
+        "p95_latency_ms_by_alias": _latency_by_alias(results, percentile=True),
+        "total_estimated_remote_tokens_avoided": sum(
+            result.estimated_remote_tokens_avoided for result in results
+        ),
+        "quality_score_present": False,
+        "model_under_test_aliases": aliases,
+    }
+
+
+def _latency_by_alias(
+    results: Sequence[GoldenResult],
+    *,
+    percentile: bool,
+) -> dict[str, float]:
+    values: dict[str, list[float]] = {}
+    for result in results:
+        if result.alias is None:
+            continue
+        values.setdefault(result.alias, []).append(result.latency_ms)
+    output: dict[str, float] = {}
+    for alias, latencies in values.items():
+        output[alias] = _p95(latencies) if percentile else mean(latencies)
+    return output
+
+
+def _p95(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    index = max(0, min(len(sorted_values) - 1, int(len(sorted_values) * 0.95) - 1))
+    return sorted_values[index]
+
+
+def _alias_for_mode(mode: str) -> str:
+    if mode == "rag":
+        return run_local_agent.LOCAL_RAG_ALIAS
+    if mode == "json":
+        return run_local_agent.LOCAL_JSON_ALIAS
+    return run_local_agent.LOCAL_CHAT_ALIAS
+
+
+def _read_str(item: Mapping[object, object], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"golden question {key} must be a non-empty string")
+    return value.strip()
+
+
+def _read_mode(item: Mapping[object, object]) -> str:
+    mode = _read_str(item, "mode")
+    if mode not in {"chat", "rag", "json"}:
+        raise ValueError(f"unsupported golden question mode: {mode}")
+    return mode
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -450,9 +450,9 @@ def _elapsed_ms(started_at: float) -> float:
 def _block_reason(decision: RouterDecision) -> str:
     """Return a safe block reason from routing policy metadata."""
     if decision.reason == RouteBlockReason.BUDGET_EXCEEDED.value:
-        return FallbackReason.BUDGET_EXCEEDED.value
+        return RouteBlockReason.BUDGET_EXCEEDED.value
     if decision.reason == RouteBlockReason.UNSUPPORTED_TASK.value:
-        return FallbackReason.UNSUPPORTED_TASK.value
+        return RouteBlockReason.UNSUPPORTED_TASK.value
     return decision.reason
 
 

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,16 @@
+# Agent-0 Golden Questions
+
+This directory contains the stable synthetic question registry for the Agent-0
+golden benchmark harness.
+
+Reports are written to `tests/golden/reports/` and are intentionally ignored by
+Git. Do not commit generated reports unless a future baseline-update issue
+explicitly authorizes it.
+
+Baseline policy:
+
+- The registry is synthetic-only.
+- No real tickers, companies, funds, portfolios or private data are allowed.
+- Dry-run reports are useful for schema validation only.
+- The first live baseline should preferably use the median of 3 local runs.
+- Live baseline publication is deferred until an explicit future decision.

--- a/tests/golden/questions.yaml
+++ b/tests/golden/questions.yaml
@@ -1,0 +1,41 @@
+questions:
+  - id: gq_chat_macro_001
+    domain: macro
+    mode: chat
+    question: "Explique, em termos gerais, como um cenario macro sintetico de juros altos poderia afetar uma alocacao educacional ficticia."
+    rationale: "Covers local_chat baseline behavior for macro reasoning without real assets."
+  - id: gq_chat_allocation_001
+    domain: allocation
+    mode: chat
+    question: "Compare uma carteira ficticia conservadora com outra moderada usando apenas percentuais simulados e sem recomendar ativos reais."
+    rationale: "Covers allocation explanation and safety around non-advisory synthetic examples."
+  - id: gq_chat_risk_001
+    domain: risk
+    mode: chat
+    question: "Liste tres riscos de concentracao em um fundo sintetico chamado Fundo Didatico Alpha, sem citar empresas reais."
+    rationale: "Covers risk language and fictional fund handling."
+  - id: gq_json_allocation_001
+    domain: allocation
+    mode: json
+    question: "Retorne JSON valido com os campos classe, risco e observacao para uma alocacao sintetica de estudo com 40 por cento em renda fixa simulada."
+    rationale: "Covers local_json schema-like behavior without requiring real financial instruments."
+  - id: gq_json_risk_001
+    domain: risk
+    mode: json
+    question: "Retorne JSON valido classificando uma pergunta ficticia sobre concentracao, com campos tipo_risco, severidade e acao_educacional."
+    rationale: "Covers JSON path for risk classification."
+  - id: gq_rag_fixed_income_001
+    domain: fixed_income
+    mode: rag
+    question: "Segundo o material sintetico local, qual e a diferenca entre renda fixa simulada pos-fixada e prefixada?"
+    rationale: "Covers RAG path for fixed-income explanation with synthetic local context."
+  - id: gq_rag_funds_001
+    domain: funds
+    mode: rag
+    question: "Use apenas contexto sintetico para explicar o objetivo do Fundo Ficticio Horizonte e cite a fonte se houver contexto."
+    rationale: "Covers RAG citation behavior for fictional funds."
+  - id: gq_chat_funds_001
+    domain: funds
+    mode: chat
+    question: "Descreva, de forma educacional, como avaliar um fundo imobiliario sintetico sem usar ticker, empresa ou fundo real."
+    rationale: "Covers equity-like or funds analysis while avoiding real tickers and fund names."

--- a/tests/unit/test_compare_golden_runs.py
+++ b/tests/unit/test_compare_golden_runs.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import compare_golden_runs
+
+
+def _summary(
+    *,
+    passed: int = 8,
+    total_questions: int = 8,
+    local_chat_latency: float = 100.0,
+    local_rag_latency: float = 200.0,
+    tokens_avoided: float = 1000.0,
+    fallback_count: int = 0,
+) -> dict[str, object]:
+    return {
+        "run_id": "run",
+        "timestamp_utc": "2026-05-02T00:00:00Z",
+        "total_questions": total_questions,
+        "passed": passed,
+        "failed": total_questions - passed,
+        "skipped": 0,
+        "fallback_count": fallback_count,
+        "mean_latency_ms_by_alias": {
+            "local_chat": local_chat_latency,
+            "local_rag": local_rag_latency,
+        },
+        "p95_latency_ms_by_alias": {
+            "local_chat": local_chat_latency,
+            "local_rag": local_rag_latency,
+        },
+        "total_estimated_remote_tokens_avoided": tokens_avoided,
+        "quality_score_present": False,
+        "model_under_test_aliases": ["local_chat", "local_rag"],
+    }
+
+
+class CompareGoldenRunsTests(unittest.TestCase):
+    def test_compare_passes_when_candidate_is_within_threshold(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(),
+            _summary(local_chat_latency=110.0, local_rag_latency=210.0),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("golden_run_comparison", output)
+        self.assertIn("pass_rate_delta=0.0000", output)
+
+    def test_compare_detects_pass_rate_regression(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(passed=8),
+            _summary(passed=7),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("pass_rate_delta=-0.1250", output)
+
+    def test_compare_detects_latency_regression_over_threshold(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(local_chat_latency=100.0),
+            _summary(local_chat_latency=130.0),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("local_chat | 100.0 | 130.0 | 30.0", output)
+
+    def test_main_reads_summary_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            baseline = Path(temp_dir) / "baseline.json"
+            candidate = Path(temp_dir) / "candidate.json"
+            baseline.write_text(json.dumps(_summary()), encoding="utf-8")
+            candidate.write_text(json.dumps(_summary()), encoding="utf-8")
+
+            exit_code = compare_golden_runs.main(
+                [
+                    "--baseline",
+                    str(baseline),
+                    "--candidate",
+                    str(candidate),
+                    "--latency-threshold-pct",
+                    "20",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_golden_harness.py
+++ b/tests/unit/test_golden_harness.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import run_golden_harness
+
+
+FORBIDDEN_REPORT_KEYS = {
+    "answer",
+    "question",
+    "prompt",
+    "chunks",
+    "chunk",
+    "vectors",
+    "vector",
+    "payload",
+    "qdrant_payload",
+    "api_key",
+    "authorization",
+    "secret",
+    "password",
+    "headers",
+    "raw_response",
+    "raw_exception",
+    "exception_message",
+}
+FORBIDDEN_REAL_TERMS = {
+    "petr4",
+    "vale3",
+    "itub4",
+    "bova11",
+    "tesouro selic",
+    "magalu",
+    "petrobras",
+    "vale",
+    "itau",
+    "bradesco",
+}
+REQUIRED_DOMAINS = {"macro", "allocation", "risk", "fixed_income", "funds"}
+
+
+class GoldenHarnessTests(unittest.IsolatedAsyncioTestCase):
+    def test_questions_yaml_loads_and_has_unique_ids(self) -> None:
+        questions = run_golden_harness.load_questions()
+
+        self.assertGreaterEqual(len(questions), 5)
+        self.assertLessEqual(len(questions), 10)
+        ids = [question.question_id for question in questions]
+        self.assertEqual(len(ids), len(set(ids)))
+        for question in questions:
+            self.assertTrue(question.rationale)
+
+    def test_questions_are_synthetic_and_cover_domains_and_modes(self) -> None:
+        questions = run_golden_harness.load_questions()
+        combined_text = " ".join(
+            f"{question.question} {question.rationale}".lower()
+            for question in questions
+        )
+        domains = {question.domain for question in questions}
+        modes = {question.mode for question in questions}
+
+        self.assertTrue(REQUIRED_DOMAINS.issubset(domains))
+        self.assertTrue({"chat", "rag", "json"}.issubset(modes))
+        for forbidden in FORBIDDEN_REAL_TERMS:
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, combined_text)
+
+    def test_golden_result_serialization_excludes_sensitive_content(self) -> None:
+        result = run_golden_harness.GoldenResult(
+            question_id="gq_test",
+            domain="risk",
+            mode="chat",
+            route="local",
+            alias="local_chat",
+            used_rag=False,
+            latency_ms=0.0,
+            decision_id="decision",
+            estimated_remote_tokens_avoided=10,
+            answer_length_chars=30,
+            error_category=None,
+            fallback_applied=None,
+            fallback_reason=None,
+            quality_score=None,
+        )
+        data = result.to_json_dict()
+
+        self.assertTrue(FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in data}))
+        self.assertEqual(data["answer_length_chars"], 30)
+
+    async def test_dry_run_harness_produces_jsonl_and_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jsonl_path, summary_path = await run_golden_harness.run_harness(
+                output_dir=temp_dir,
+                dry_run=True,
+            )
+
+            self.assertTrue(jsonl_path.exists())
+            self.assertTrue(summary_path.exists())
+            lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            questions = run_golden_harness.load_questions()
+
+            self.assertEqual(len(lines), len(questions))
+            for line in lines:
+                row = json.loads(line)
+                self.assertTrue(
+                    FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in row})
+                )
+                self.assertEqual(row["latency_ms"], 0.0)
+                self.assertIn(row["alias"], {"local_chat", "local_rag", "local_json"})
+                self.assertIsNone(row["quality_score"])
+
+            self.assertEqual(summary["total_questions"], len(questions))
+            self.assertEqual(summary["failed"], 0)
+            self.assertEqual(summary["skipped"], 0)
+            self.assertIn("mean_latency_ms_by_alias", summary)
+            self.assertIn("p95_latency_ms_by_alias", summary)
+            self.assertFalse(summary["quality_score_present"])
+
+    async def test_guard_env_prevents_accidental_runs(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await run_golden_harness.main_async(["--dry-run"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("opt-in", write_mock.call_args.args[0])
+
+    async def test_guard_env_allows_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(os.environ, {"RUN_GOLDEN_HARNESS": "1"}, clear=True),
+                patch("sys.stdout.write"),
+            ):
+                exit_code = await run_golden_harness.main_async(
+                    ["--dry-run", "--output-dir", temp_dir]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(list(Path(temp_dir).glob("golden_results_*.jsonl")))
+            self.assertTrue(list(Path(temp_dir).glob("golden_summary_*.json")))
+
+    def test_reports_directory_is_gitignored(self) -> None:
+        gitignore = Path(".gitignore").read_text(encoding="utf-8")
+
+        self.assertIn("tests/golden/reports/", gitignore)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -48,6 +48,8 @@ FORBIDDEN_OUTPUT_KEYS = {
     "user_prompt",
     "answer_raw",
     "raw_response",
+    "raw_exception",
+    "exception_message",
     "chunks",
     "chunk",
     "chunk_text",


### PR DESCRIPTION
## Summary

Adds the GW-18 Agent-0 golden question benchmark harness: a fixed synthetic financial-domain question registry, an opt-in offline/live harness, safe JSONL and summary reports, and a summary comparison tool for future regression checks.

This PR is stacked on GW-17 (`feat/agent0-local-failsafe-degradation`) because GitHub/local state showed GW-16/GW-17 were not yet on `origin/main` when GW-18 started. Retarget or rebase after GW-16/GW-17 are integrated.

Closes #61.

## Scope

Included:

- `tests/golden/questions.yaml` with 8 synthetic financial-domain questions
- `scripts/run_golden_harness.py` guarded by `RUN_GOLDEN_HARNESS=1`
- Offline `--dry-run` mode that does not call live services
- Safe `GoldenResult` JSONL contract with answer length only, not answer text
- Summary JSON with per-alias mean/p95 latency, fallback count and token economy totals
- `scripts/compare_golden_runs.py` for baseline/candidate summary comparison
- `tests/golden/reports/` ignored by Git
- Unit tests for registry, safety, dry-run reports, guard behavior and comparison regressions
- GW-17 cleanup: `_block_reason()` now returns `RouteBlockReason` values directly and runner forbidden-key tests include `raw_exception` / `exception_message`

Deferred:

- Human scoring helper / `scores.jsonl` writer
- Live baseline publication
- LLM-as-judge, explicitly out of scope

## Synthetic Question Coverage

The registry includes 8 questions across:

- macro
- allocation
- risk
- fixed_income
- funds

Modes covered:

- chat
- rag
- json

All questions are synthetic-only and avoid real tickers, companies, funds, portfolios and private data.

## Report Safety

JSONL results include safe metadata only:

- question id/domain/mode
- route/alias/used_rag
- latency
- decision id
- estimated remote tokens avoided
- answer length chars
- fallback/error metadata
- quality score placeholder

They do not include answer text, question text, prompts, chunks, vectors, payloads, raw model responses, exception messages, API keys, Authorization headers or secrets.

## Validation

```bash
git diff --check
uv run python scripts/run_golden_harness.py --help
RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py --dry-run --output-dir /tmp/openclaw_golden_reports
uv run python scripts/compare_golden_runs.py --help
uv run pytest tests/unit/test_golden_harness.py -v
uv run pytest tests/unit/test_compare_golden_runs.py -v
uv run pytest tests/unit/test_run_local_agent.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Reported local results:

- Golden harness unit tests: 7 passed, 10 subtests passed
- Compare golden runs unit tests: 4 passed
- Agent runner unit tests: 32 passed, 19 subtests passed
- Full pytest: 287 passed, 7 skipped, 130 subtests passed
- mypy strict: success
- pyright: 0 errors
- smoke tests: 5 passed, 7 skipped

## Security

- No remote providers enabled
- No remote calls added
- No secrets committed
- No real data used
- No Qdrant mutation or reindex
- No generated reports committed
