### PR TITLE
test(agent): verify observability signal contract

### DIFF
--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -1,0 +1,271 @@
+"""Canonical safe observability signal contracts for Agent-0.
+
+This module is intentionally side-effect free. It defines allowlists used by
+tests and documentation to verify that observability records never serialize
+prompt text, chunks, vectors, payloads or secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+ROUTER_DECISION_KEYS = frozenset(
+    {
+        "decision_id",
+        "route",
+        "reason",
+        "policy_outcome",
+        "task_type",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens",
+        "estimated_remote_tokens_avoided",
+        "timestamp_utc",
+        # Existing routing metadata kept for backward-compatible serializers.
+        "risk_level",
+        "token_budget_class",
+        "remote_allowed",
+        "remote_candidate_provider",
+        "requires_sanitization",
+    }
+)
+
+TOKEN_ECONOMY_RECORD_KEYS = frozenset(
+    {
+        "decision_id",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens_avoided",
+        "local_budget_consumed",
+        "remote_budget_consumed",
+        "timestamp_utc",
+        # Existing token economy metadata kept for backward-compatible
+        # serializers and local audit records.
+        "provider_used",
+        "route",
+        "local_tokens_estimated",
+        "remote_tokens_estimated",
+        "remote_tokens_avoided_estimated",
+        "cost_estimate_mode",
+    }
+)
+
+RAG_RUN_TRACE_KEYS = frozenset(
+    {
+        "decision_id",
+        "query_id",
+        "timestamp_utc",
+        "collection_name",
+        "embedding_backend",
+        "embedding_model",
+        "embedding_alias",
+        "embedding_dimensions",
+        "gateway_alias",
+        "used_rag",
+        "fallback_occurred",
+        "chunk_count",
+        "retrieval_latency_ms",
+        "generation_latency_ms",
+        "total_latency_ms",
+        # Existing safe trace fields.
+        "guard_result",
+        "strict_mode",
+        "prompt_latency_ms",
+        "context_chunk_count",
+    }
+)
+
+FALLBACK_EVENT_KEYS = frozenset(
+    {
+        "event",
+        "event_kind",
+        "decision_id",
+        "fallback_reason",
+        "original_alias",
+        "fallback_alias",
+        "fallback_succeeded",
+        "latency_ms",
+        "status",
+        "timestamp_utc",
+    }
+)
+
+DECISION_LOG_KEYS = frozenset(
+    {
+        "decision_id",
+        "route",
+        "reason",
+        "policy_outcome",
+        "estimated_remote_tokens_avoided",
+        "timestamp_utc",
+        # Existing RoutingDecisionLogger compatibility fields.
+        "risk_level",
+        "token_budget_class",
+        "remote_allowed",
+        "remote_candidate_provider",
+        "requires_sanitization",
+        "task_type",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens",
+    }
+)
+
+AGENT_RUN_RESULT_KEYS = frozenset(
+    {
+        "answer",
+        "route",
+        "alias",
+        "used_rag",
+        "latency_ms",
+        "decision_id",
+        "estimated_remote_tokens_avoided",
+        "error_category",
+        "fallback_applied",
+        "fallback_from_alias",
+        "fallback_to_alias",
+        "fallback_reason",
+        "fallback_chain",
+        "block_reason",
+    }
+)
+
+GOLDEN_RESULT_KEYS = frozenset(
+    {
+        "question_id",
+        "domain",
+        "mode",
+        "route",
+        "alias",
+        "used_rag",
+        "latency_ms",
+        "decision_id",
+        "estimated_remote_tokens_avoided",
+        "answer_length_chars",
+        "error_category",
+        "fallback_applied",
+        "fallback_reason",
+        "quality_score",
+        "skipped",
+        "skipped_reason",
+    }
+)
+
+GOLDEN_SUMMARY_KEYS = frozenset(
+    {
+        "run_id",
+        "timestamp_utc",
+        "total_questions",
+        "passed",
+        "failed",
+        "skipped",
+        "fallback_count",
+        "mean_latency_ms_by_alias",
+        "p95_latency_ms_by_alias",
+        "total_estimated_remote_tokens_avoided",
+        "quality_score_present",
+        "model_under_test_aliases",
+    }
+)
+
+PROHIBITED_SIGNAL_KEYS = frozenset(
+    {
+        "prompt",
+        "system_prompt",
+        "user_prompt",
+        "query",
+        "question",
+        "raw_user_input",
+        "input_text",
+        "chunks",
+        "chunk",
+        "chunk_text",
+        "retrieved_context",
+        "context_text",
+        "vectors",
+        "vector",
+        "embeddings",
+        "embedding",
+        "payload",
+        "qdrant_payload",
+        "api_key",
+        "authorization",
+        "headers",
+        "secret",
+        "password",
+        "raw_response",
+        "raw_exception",
+        "exception_message",
+        "traceback",
+        "model_weights_path",
+        "weights_path",
+    }
+)
+
+SAFE_ROUTER_REASON_VALUES = frozenset(
+    {
+        "budget_exceeded",
+        "remote_disabled",
+        "sensitive_context",
+        "unsupported_task",
+        "policy_denied",
+        "unknown",
+        # Existing deterministic local policy outcomes.
+        "local_first_default",
+        "remote_candidate_policy_match",
+    }
+)
+
+SAFE_FALLBACK_REASON_VALUES = frozenset(
+    {
+        "qdrant_unavailable",
+        "rag_unavailable",
+        "think_timeout",
+        "alias_unavailable",
+        "budget_exceeded",
+        "unsupported_task",
+        "fallback_alias_failed",
+        "unknown_local_failure",
+    }
+)
+
+
+def assert_signal_allowlisted(
+    signal: Mapping[str, object],
+    *,
+    allowlist: frozenset[str],
+    signal_name: str,
+) -> None:
+    """Raise ``AssertionError`` if a signal violates its allowlist."""
+    keys = frozenset(signal)
+    extra_keys = keys - allowlist
+    if extra_keys:
+        raise AssertionError(
+            f"{signal_name} contains non-allowlisted keys: {sorted(extra_keys)}"
+        )
+    prohibited = {key for key in keys if key.lower() in PROHIBITED_SIGNAL_KEYS}
+    if prohibited:
+        raise AssertionError(
+            f"{signal_name} contains prohibited keys: {sorted(prohibited)}"
+        )
+
+
+def token_economy_canonical_signal(
+    record: Mapping[str, object],
+) -> dict[str, object]:
+    """Project existing token economy metadata into canonical GW-19 fields."""
+    signal: dict[str, object] = {}
+    if "decision_id" in record:
+        signal["decision_id"] = record["decision_id"]
+    if "timestamp_utc" in record:
+        signal["timestamp_utc"] = record["timestamp_utc"]
+    if "remote_tokens_avoided_estimated" in record:
+        signal["estimated_remote_tokens_avoided"] = record[
+            "remote_tokens_avoided_estimated"
+        ]
+    if "local_tokens_estimated" in record:
+        signal["local_budget_consumed"] = record["local_tokens_estimated"]
+    if "remote_tokens_estimated" in record:
+        signal["remote_budget_consumed"] = record["remote_tokens_estimated"]
+    return signal

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -208,7 +208,8 @@ task metadata + token estimates
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
 | GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | 🚧 Current |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | 🚧 Current |
 
 GW-13 rules:
 
@@ -241,6 +242,11 @@ GW-15 rules:
   `scripts/compare_golden_runs.py`.
 - Golden harness reports are opt-in, local-only, synthetic-only, and omit answer
   text by default.
+- GW-19 adds offline observability signal contract tests for `RouterDecision`,
+  `TokenEconomyRecord`, `RagRunTrace`, fallback events and decision logs.
+- GW-19 uses allowlists to enforce no prompt, raw input, chunks, vectors,
+  payloads, headers, API keys, raw exceptions or model weight paths in signal
+  keys.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,22 +5,22 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-02
-**Updated by:** Codex — Agent-0 GW-18 golden question harness
+**Updated by:** Codex — Agent-0 GW-19 observability signal contract
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add the Agent-0 golden question benchmark harness: fixed synthetic
-financial-domain questions, offline dry-run reports, and summary comparison
-tools for future regression checks.
+**Goal:** verify Agent-0 observability signal completeness and sanitization
+with deterministic offline tests for routing, token economy, RAG trace,
+fallback and decision-log records.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
-GW-18 branch: `feat/agent0-golden-question-harness`
+GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
+GW-19 branch: `feat/agent0-observability-signal-contract`
 
 Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
 hardening branch present, but the GW-16 commit was not on `origin/main`.
@@ -28,6 +28,8 @@ GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
 should be retargeted/rebased after GW-16 is integrated.
 GW-18 was implemented as a stacked branch on GW-17 for the same reason and
 should be retargeted/rebased after GW-16/GW-17 are integrated.
+GW-19 was implemented as a stacked branch on the GW-18 integration branch and
+should be retargeted/rebased after GW-16/GW-17/GW-18 are integrated.
 
 Current runtime path:
 
@@ -127,7 +129,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
 | GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Current |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -143,6 +146,7 @@ GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
 GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
+GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -241,6 +245,35 @@ Rules:
 - Optional human scoring helper is deferred to a future issue.
 - No remote providers, no remote calls, no Qdrant mutation, no real data, and
   no live services required for unit tests.
+
+## GW-19 Current Work
+
+GW-19 adds the Agent-0 observability signal contract.
+
+Deliverables:
+
+- `backend/gateway/observability_contract.py` with canonical allowlists and
+  prohibited signal keys.
+- `tests/unit/test_observability_signal_contract.py` for RouterDecision,
+  TokenEconomyRecord, RagRunTrace, fallback events, decision logs, Agent-0
+  output and golden harness dry-run reports.
+- `docs/AGENT0_OBSERVABILITY.md`.
+- GW-18 NB fixes:
+  - golden harness uses `estimate_prompt_tokens` directly from
+    `backend.gateway.routing_policy`;
+  - `GoldenResult` rejects `skipped=True` with `error_category`.
+
+Rules:
+
+- Sanitization is enforced with allowlists, not blocklist-only checks.
+- Fallback event `decision_id` must correlate with Agent-0 output.
+- `estimated_remote_tokens_avoided` is checked across success, dry-run,
+  blocked, fallback success and fallback failure paths.
+- No prompt, raw user input, chunks, vectors, payloads, headers, API keys, raw
+  exceptions or model weight paths may appear in observability keys.
+- No runtime routing behavior, fallback behavior or remote provider behavior is
+  changed.
+- No live LiteLLM/Ollama/Qdrant services are required for tests.
 
 ## GW-13 Completed Work
 

--- a/docs/AGENT0_GOLDEN_HARNESS.md
+++ b/docs/AGENT0_GOLDEN_HARNESS.md
@@ -89,6 +89,9 @@ It never stores question text, answer text, prompts, chunks, vectors, payloads,
 raw model responses, exception messages, API keys, Authorization headers or
 secrets.
 
+Skipped semantics are explicit: a result cannot be both skipped and failed. If
+`skipped` is `true`, `error_category` must be absent.
+
 ## Summary Schema
 
 The summary JSON includes:

--- a/docs/AGENT0_OBSERVABILITY.md
+++ b/docs/AGENT0_OBSERVABILITY.md
@@ -1,0 +1,108 @@
+# Agent-0 Observability Contract
+
+GW-19 verifies Agent-0 observability signal completeness and sanitization.
+
+This is not OpenTelemetry, not a dashboard, not remote telemetry and not a
+runtime behavior change. It is an offline contract that tests existing local
+signals.
+
+## Signals
+
+Agent-0 observability uses these safe metadata signals:
+
+- `RouterDecision`: route selected, reason code, policy outcome and token
+  estimates.
+- `TokenEconomyRecord`: local estimate of remote tokens avoided and budget-like
+  token totals.
+- `RagRunTrace`: safe RAG provenance and segment latency metadata when RAG
+  tracing is applicable.
+- Decision logs: local JSONL audit records written by `RoutingDecisionLogger`.
+- Fallback events: local `agent_fallback` loguru events when GW-17 fallback is
+  applied.
+
+## Allowlist Rule
+
+Serializers are tested against explicit allowlists in
+`backend/gateway/observability_contract.py`.
+
+Tests assert that signal keys are a subset of the relevant allowlist. This is
+intentional: new fields must be deliberately added to the allowlist before they
+can appear in structured output.
+
+## Prohibited Fields
+
+The following categories must never appear as keys in Agent-0 observability
+signals:
+
+- prompt or system/user prompt
+- query, question or raw user input
+- chunks, retrieved context or context text
+- vectors or embeddings
+- payloads or Qdrant payloads
+- API keys, Authorization headers, headers, tokens, passwords or secrets
+- raw model responses
+- raw exceptions, exception messages or tracebacks
+- model weights paths
+
+Tests use deterministic synthetic sentinels to verify that raw input and raw
+exception text do not leak into outputs or fallback events.
+
+## Reason Codes
+
+Routing and fallback reasons must be deterministic safe codes.
+
+Examples:
+
+- `local_first_default`
+- `budget_exceeded`
+- `unsupported_task`
+- `remote_disabled`
+- `qdrant_unavailable`
+- `rag_unavailable`
+- `fallback_alias_failed`
+
+Free-form exception messages are not valid reason codes.
+
+## Correlation
+
+Fallback events must include the same `decision_id` that appears in the
+Agent-0 runner output. Decision logs and token-economy records are also keyed by
+`decision_id`.
+
+## Offline Coverage
+
+GW-19 tests cover:
+
+- RouterDecision serialization
+- TokenEconomyRecord serialization and canonical projection
+- RagRunTrace serialization
+- fallback event sanitization and `decision_id` correlation
+- local decision JSONL safety
+- Agent-0 dry-run output safety
+- estimated remote tokens avoided across success, dry-run, blocked, fallback
+  success and fallback failure paths
+- golden harness dry-run JSONL and summary safety
+
+All tests are offline and deterministic. They do not require LiteLLM, Ollama,
+Qdrant or network services.
+
+## Deferred
+
+`RagRunTrace` currently predates Agent-0 and does not carry Agent-0
+`decision_id`, `used_rag` or `fallback_occurred` fields directly. The GW-19
+allowlist reserves those fields for future integration, but does not force a
+runtime schema change in this PR.
+
+Future work may add a unified in-process signal collector, but that requires a
+separate issue.
+
+## Out Of Scope
+
+- OpenTelemetry
+- dashboards
+- Prometheus/Grafana
+- remote telemetry
+- remote providers
+- live baseline freeze
+- LLM-as-judge
+- Qdrant mutation or reindexing

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-02
-**Current branch:** `feat/agent0-golden-question-harness`
-**Issue:** [#61](https://github.com/franciscosalido/OPENCLAW/issues/61)
+**Current branch:** `feat/agent0-observability-signal-contract`
+**Issue:** [#63](https://github.com/franciscosalido/OPENCLAW/issues/63)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -43,6 +43,7 @@ Out of scope:
 | GW-14 | Config-driven routing audit and token economy calibration |
 | GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
 | GW-18 | Golden question benchmark harness |
+| GW-19 | Agent-0 observability signal contract |
 
 ## GW-15 Current Work
 
@@ -156,3 +157,30 @@ Safety:
 - Reports exclude prompt/question/chunks/vectors/payloads/secrets and do not
   include answer text by default.
 - `tests/golden/reports/` is ignored by Git.
+
+## GW-19 Current Work
+
+Scope:
+
+- Add canonical signal allowlists in
+  `backend/gateway/observability_contract.py`.
+- Verify `RouterDecision`, `TokenEconomyRecord`, `RagRunTrace`, fallback events
+  and decision logs are serialized with safe metadata only.
+- Verify fallback event `decision_id` correlates with runner output.
+- Verify `estimated_remote_tokens_avoided` is present and non-negative across
+  success, dry-run, blocked, fallback success and fallback failure paths.
+- Verify GW-18 golden harness dry-run JSONL and summary outputs stay sanitized.
+
+Out of scope:
+
+- Runtime behavior changes.
+- Remote providers or remote calls.
+- OpenTelemetry, dashboards, Prometheus or Grafana.
+- Live LiteLLM/Ollama/Qdrant services in unit tests.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+
+Safety:
+
+- Sanitization tests use allowlists and deterministic sentinels.
+- Prohibited fields include prompts, raw user input, chunks, vectors, payloads,
+  headers, API keys, raw exceptions and model weight paths.

--- a/scripts/run_golden_harness.py
+++ b/scripts/run_golden_harness.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 import yaml
 
+from backend.gateway.routing_policy import estimate_prompt_tokens
 from scripts import run_local_agent
 
 
@@ -60,6 +61,10 @@ class GoldenResult:
     quality_score: None
     skipped: bool = False
     skipped_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.skipped and self.error_category is not None:
+            raise ValueError("GoldenResult cannot be both skipped and failed")
 
     def to_json_dict(self) -> dict[str, object]:
         """Return allowlisted JSONL-safe result metadata."""
@@ -198,7 +203,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _dry_run_result(question: GoldenQuestion) -> GoldenResult:
     alias = _alias_for_mode(question.mode)
     answer = "Dry run: no model call executed."
-    estimated = run_local_agent._estimate_prompt_token_count(question.question)
+    estimated = estimate_prompt_tokens(question.question)
     return GoldenResult(
         question_id=question.question_id,
         domain=question.domain,

--- a/tests/unit/test_golden_harness.py
+++ b/tests/unit/test_golden_harness.py
@@ -92,6 +92,27 @@ class GoldenHarnessTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in data}))
         self.assertEqual(data["answer_length_chars"], 30)
 
+    def test_golden_result_cannot_be_skipped_and_failed(self) -> None:
+        with self.assertRaises(ValueError):
+            run_golden_harness.GoldenResult(
+                question_id="gq_test",
+                domain="risk",
+                mode="chat",
+                route="local",
+                alias=None,
+                used_rag=False,
+                latency_ms=0.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=0,
+                answer_length_chars=0,
+                error_category="chat_unavailable",
+                fallback_applied=None,
+                fallback_reason=None,
+                quality_score=None,
+                skipped=True,
+                skipped_reason="offline",
+            )
+
     async def test_dry_run_harness_produces_jsonl_and_summary(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             jsonl_path, summary_path = await run_golden_harness.run_harness(

--- a/tests/unit/test_observability_signal_contract.py
+++ b/tests/unit/test_observability_signal_contract.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+from backend.gateway.observability_contract import (
+    AGENT_RUN_RESULT_KEYS,
+    DECISION_LOG_KEYS,
+    FALLBACK_EVENT_KEYS,
+    GOLDEN_RESULT_KEYS,
+    GOLDEN_SUMMARY_KEYS,
+    PROHIBITED_SIGNAL_KEYS,
+    RAG_RUN_TRACE_KEYS,
+    ROUTER_DECISION_KEYS,
+    SAFE_FALLBACK_REASON_VALUES,
+    SAFE_ROUTER_REASON_VALUES,
+    TOKEN_ECONOMY_RECORD_KEYS,
+    assert_signal_allowlisted,
+    token_economy_canonical_signal,
+)
+from backend.gateway.routing_policy import (
+    FallbackReason,
+    RemoteEscalationPolicy,
+    RouteBlockReason,
+    RoutingDecisionLogger,
+    build_token_economy_record,
+    decide_route,
+)
+from backend.rag.run_trace import build_rag_run_trace
+from scripts import run_golden_harness, run_local_agent
+
+
+SENSITIVE_SENTINEL = "PRIVATE_PROMPT_api_key_headers_model_weights_path"
+
+
+class ObservabilitySignalContractTests(unittest.IsolatedAsyncioTestCase):
+    def test_router_decision_signals_are_allowlisted_for_core_routes(self) -> None:
+        cases = [
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(),
+            ),
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(per_request_token_limit=1),
+            ),
+            decide_route(
+                task_type="trade_execution",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(),
+            ),
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=True,
+                policy=RemoteEscalationPolicy(
+                    remote_enabled=True,
+                    allowed_remote_providers=("review_stub",),
+                ),
+            ),
+        ]
+
+        for decision in cases:
+            with self.subTest(route=decision.route.value, reason=decision.reason):
+                data = decision.to_log_dict()
+                assert_signal_allowlisted(
+                    data,
+                    allowlist=ROUTER_DECISION_KEYS,
+                    signal_name="RouterDecision",
+                )
+                self.assertTrue(data["decision_id"])
+                self.assertIn(data["reason"], SAFE_ROUTER_REASON_VALUES)
+                self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    def test_token_economy_record_signal_is_allowlisted_and_canonicalized(self) -> None:
+        decision = decide_route(
+            task_type="agent0_chat",
+            estimated_prompt_tokens=12,
+            estimated_completion_tokens=34,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        record = build_token_economy_record(decision)
+        raw = record.to_log_dict()
+        canonical = token_economy_canonical_signal(raw)
+
+        assert_signal_allowlisted(
+            raw,
+            allowlist=TOKEN_ECONOMY_RECORD_KEYS,
+            signal_name="TokenEconomyRecord",
+        )
+        assert_signal_allowlisted(
+            canonical,
+            allowlist=TOKEN_ECONOMY_RECORD_KEYS,
+            signal_name="TokenEconomyRecordCanonical",
+        )
+        self.assertEqual(canonical["decision_id"], decision.decision_id)
+        self.assertIsInstance(canonical["estimated_remote_tokens_avoided"], int)
+        self.assertGreaterEqual(
+            cast(int, canonical["estimated_remote_tokens_avoided"]),
+            0,
+        )
+
+    def test_rag_run_trace_signal_is_allowlisted(self) -> None:
+        trace = build_rag_run_trace(
+            collection_name="gw19_synthetic_collection",
+            embedding_backend="gateway_litellm_current",
+            embedding_model="nomic-embed-text",
+            embedding_alias="quimera_embed",
+            embedding_dimensions=768,
+            expected_dimensions=768,
+            retrieval_latency_ms=1.5,
+            generation_latency_ms=12.5,
+            chunk_count=3,
+            gateway_alias="local_rag",
+            guard_result={
+                "sampled_count": 2,
+                "metadata_absent_count": 0,
+                "backend_matches": True,
+                "payload": "must be ignored",
+            },
+            total_latency_ms=14.0,
+        )
+        data = trace.to_log_dict()
+
+        assert_signal_allowlisted(
+            data,
+            allowlist=RAG_RUN_TRACE_KEYS,
+            signal_name="RagRunTrace",
+        )
+        self.assertEqual(data["gateway_alias"], "local_rag")
+        self.assertEqual(data["chunk_count"], 3)
+        self.assertNotIn("payload", json.dumps(data))
+
+    async def test_fallback_event_is_allowlisted_and_correlated_with_result(self) -> None:
+        events: list[dict[str, object]] = []
+
+        class BoundLogger:
+            def __init__(self, event: dict[str, object]) -> None:
+                self.event = event
+
+            def info(self, message: str) -> None:
+                self.event["message"] = message
+                events.append(self.event)
+
+        def fake_bind(**kwargs: object) -> BoundLogger:
+            event = kwargs["event"]
+            assert isinstance(event, dict)
+            return BoundLogger(event)
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        with patch("scripts.run_local_agent.logger.bind", fake_bind):
+            result = await run_local_agent.run_agent(
+                question=SENSITIVE_SENTINEL,
+                use_rag=True,
+                rag_call=rag_call,
+                chat_call=chat_call,
+            )
+        output = result.to_json_dict()
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        assert_signal_allowlisted(
+            event,
+            allowlist=FALLBACK_EVENT_KEYS | {"message"},
+            signal_name="FallbackEvent",
+        )
+        self.assertEqual(event["event"], "agent_fallback")
+        self.assertEqual(event["fallback_reason"], FallbackReason.RAG_UNAVAILABLE.value)
+        self.assertIn(event["fallback_reason"], SAFE_FALLBACK_REASON_VALUES)
+        self.assertEqual(event["decision_id"], output["decision_id"])
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(event))
+        assert_signal_allowlisted(
+            output,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+
+    async def test_non_fallback_run_emits_no_fallback_event(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        with patch("scripts.run_local_agent.logger.bind") as bind_mock:
+            result = await run_local_agent.run_agent(
+                question=SENSITIVE_SENTINEL,
+                chat_call=chat_call,
+            )
+
+        bind_mock.assert_not_called()
+        data = result.to_json_dict()
+        assert_signal_allowlisted(
+            data,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    def test_decision_log_jsonl_is_allowlisted(self) -> None:
+        decision = decide_route(
+            task_type="agent0_chat",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=20,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            logger = RoutingDecisionLogger(Path(temp_dir) / "decisions", rotate_daily=False)
+            path = logger.append(decision)
+            assert path is not None
+            rows = path.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(len(rows), 1)
+        row = json.loads(rows[0])
+        assert_signal_allowlisted(
+            row,
+            allowlist=DECISION_LOG_KEYS,
+            signal_name="DecisionLog",
+        )
+        self.assertIn(row["reason"], SAFE_ROUTER_REASON_VALUES)
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(row))
+
+    async def test_dry_run_output_signal_has_required_token_economy(self) -> None:
+        result = await run_local_agent.run_agent(
+            question=SENSITIVE_SENTINEL,
+            dry_run=True,
+        )
+        data = result.to_json_dict()
+
+        assert_signal_allowlisted(
+            data,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+        self.assertIsInstance(data["estimated_remote_tokens_avoided"], int | float)
+        self.assertGreaterEqual(cast(int, data["estimated_remote_tokens_avoided"]), 0)
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    async def test_estimated_remote_tokens_avoided_exists_across_runner_paths(self) -> None:
+        async def chat_ok(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        async def chat_fail(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        async def rag_fail(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        cases = [
+            await run_local_agent.run_agent(question="ok", chat_call=chat_ok),
+            await run_local_agent.run_agent(question="dry", dry_run=True),
+            await run_local_agent.run_agent(
+                question="blocked",
+                policy_loader=lambda: RemoteEscalationPolicy(per_request_token_limit=1),
+                chat_call=chat_fail,
+            ),
+            await run_local_agent.run_agent(
+                question="fallback",
+                use_rag=True,
+                rag_call=rag_fail,
+                chat_call=chat_ok,
+            ),
+            await run_local_agent.run_agent(
+                question="fallback failure",
+                use_rag=True,
+                rag_call=rag_fail,
+                chat_call=chat_fail,
+            ),
+        ]
+
+        for result in cases:
+            with self.subTest(result=result):
+                data = result.to_json_dict()
+                self.assertIn("estimated_remote_tokens_avoided", data)
+                self.assertIsInstance(
+                    data["estimated_remote_tokens_avoided"],
+                    int | float,
+                )
+                self.assertGreaterEqual(
+                    cast(int, data["estimated_remote_tokens_avoided"]),
+                    0,
+                )
+                self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    async def test_golden_harness_dry_run_reports_are_allowlisted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jsonl_path, summary_path = await run_golden_harness.run_harness(
+                output_dir=temp_dir,
+                dry_run=True,
+            )
+            rows = [
+                json.loads(line)
+                for line in jsonl_path.read_text(encoding="utf-8").splitlines()
+            ]
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            assert_signal_allowlisted(
+                row,
+                allowlist=GOLDEN_RESULT_KEYS,
+                signal_name="GoldenResult",
+            )
+            self.assertIsNone(row["quality_score"])
+            self.assertNotIn("answer", row)
+        assert_signal_allowlisted(
+            summary,
+            allowlist=GOLDEN_SUMMARY_KEYS,
+            signal_name="GoldenSummary",
+        )
+        self.assertFalse(summary["quality_score_present"])
+
+    def test_prohibited_key_contract_is_canonical(self) -> None:
+        expected = {
+            "prompt",
+            "chunks",
+            "vectors",
+            "api_key",
+            "headers",
+            "raw_user_input",
+            "model_weights_path",
+        }
+
+        self.assertTrue(expected.issubset(PROHIBITED_SIGNAL_KEYS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds GW-19 offline observability signal contract checks for Agent-0. This PR verifies that existing routing, token economy, RAG trace, fallback-event, decision-log and golden-harness signals are allowlisted, correlated and sanitized.

This PR is stacked on `feat/agent0-local-failsafe-degradation`, which currently contains the merged GW-18 stack. Retarget/rebase after GW-16/GW-17/GW-18 are integrated into `main`.

Closes #63.

## Scope

Included:

- `backend/gateway/observability_contract.py` with canonical allowlists and prohibited signal keys
- RouterDecision signal contract tests for local, blocked and remote-candidate metadata-only decisions
- TokenEconomyRecord signal tests plus canonical projection for `estimated_remote_tokens_avoided`
- RagRunTrace serialization allowlist tests
- Fallback event sanitization and `decision_id` correlation tests
- Decision log JSONL safety tests
- Agent-0 dry-run output safety tests
- `estimated_remote_tokens_avoided` coverage across success, dry-run, blocked, fallback success and fallback failure paths
- Golden harness dry-run JSONL and summary allowlist checks
- Docs for the Agent-0 observability contract

GW-18 cleanup included:

- `scripts/run_golden_harness.py` now imports `estimate_prompt_tokens` directly from `backend.gateway.routing_policy` instead of using the runner private helper.
- `GoldenResult` now rejects `skipped=True` together with `error_category`.

## Deferred

- `RagRunTrace` does not yet carry Agent-0 `decision_id`, `used_rag` or `fallback_occurred` directly. The GW-19 allowlist reserves those fields for future integration without forcing a runtime schema change here.
- No unified runtime signal collector is added in this PR.

## Validation

```bash
git diff --check
uv run pytest tests/unit/test_observability_signal_contract.py -v
uv run pytest tests/unit/test_run_local_agent.py -v
uv run pytest tests/unit/test_golden_harness.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py --dry-run --output-dir /tmp/openclaw_golden_reports_gw19
```

Reported local results:

- observability signal contract: 10 passed, 9 subtests passed
- run local agent: 32 passed, 19 subtests passed
- golden harness: 8 passed, 10 subtests passed
- full pytest: 298 passed, 7 skipped, 139 subtests passed
- mypy strict: success
- pyright: 0 errors
- smoke tests: 5 passed, 7 skipped
- golden harness dry-run: OK

## Security

- No remote providers enabled
- No remote calls added
- No live LiteLLM/Ollama/Qdrant required by tests
- No Qdrant mutation or reindex
- No secrets committed
- No raw prompt/input/chunks/vectors/payloads/headers/API keys/raw exceptions/model weight paths in signal keys
