### PR TITLE
test(gateway): add Gateway-1 proof-of-life smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Thumbs.db
 logs/
 *.log
 tests/golden/reports/
+reports/gateway1_smoke/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -663,3 +663,66 @@ Append or paste this at the end of substantial sessions:
 ### Risks
 - Live readiness (`--live`) not run in this shell — requires `LITELLM_MASTER_KEY` export and local services running.
 - None known for static validation.
+
+---
+
+## Handoff — 2026-05-02
+
+**Agent:** Codex
+**Branch:** `feat/gateway1-proof-of-life-smoke`
+**Issue/PR:** #65 / pending PR
+**Task:** GW-20 — Gateway-1 operational proof-of-life smoke.
+
+### Changed
+- `docs/sprints/GATEWAY1_DONE_CRITERIA.md`: fixed G1-01 through G1-11
+  done criteria for Gateway-1.
+- `scripts/test_gateway1_proof_of_life.py`: opt-in proof-of-life smoke with
+  local URL guards, Ollama/Qdrant/LiteLLM probes, Agent-0 dry-run/live checks,
+  forced Qdrant degradation, policy block validation and sanitized summary JSON.
+- `tests/unit/test_gateway1_proof_of_life.py`: 17 offline deterministic tests
+  for URL guards, serialization allowlists, sanitizer, criteria logic, forced
+  degradation, policy block and summary writing.
+- `docs/AGENT0_SMOKE.md`, `docs/AGENT0_LOCAL_RUNNER.md`,
+  `docs/AGENT0_OBSERVABILITY.md`, `docs/sprints/GATEWAY1_SPRINT_HANDOFF.md`:
+  operator docs and handoff updates.
+- `.gitignore`: ignores `reports/gateway1_smoke/`.
+
+### Validation
+- `git diff --check` — passed.
+- `uv run python scripts/test_gateway1_proof_of_life.py --help` — passed.
+- `uv run pytest tests/unit/test_gateway1_proof_of_life.py -v` — 17 passed.
+- `uv run pytest -v` — 315 passed, 7 skipped, 139 subtests passed.
+- `uv run mypy --strict .` — 0 errors.
+- `uv run pyright` — 0 errors.
+- `uv run pytest tests/smoke/ -v` — 5 passed, 7 skipped.
+- Live proof with local key:
+  `QUIMERA_LLM_API_KEY=dev-local-key-change-me RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke`
+  — **passed**, 11 criteria passed, 0 failed, 0 skipped.
+
+### Live Summary
+- Summary file:
+  `/tmp/openclaw_gateway1_smoke/gateway1_proof_of_life_9f23ce3df3f2.json`.
+- Ollama/Qdrant/LiteLLM probes: OK.
+- Agent-0 `local_chat`: OK.
+- Agent-0 `local_rag`: OK.
+- Forced degradation: `qdrant_unavailable` fallback to `local_chat`.
+- Policy block: no model call.
+
+### Not Changed
+- No remote providers, remote API keys or remote aliases.
+- No Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- No real portfolio data, real tickers, real companies or real funds.
+- No runtime behavior change in Agent-0 beyond calling existing public APIs.
+- No OpenTelemetry, dashboards, Prometheus, Grafana, FastAPI, MCP or new
+  runtime architecture.
+
+### Next Action
+- Open PR for GW-20 with title
+  `test(gateway): add Gateway-1 proof-of-life smoke`.
+- After merge, Gateway-1 can be considered operationally ready for Gateway-2
+  planning.
+
+### Risks
+- Proof-of-life requires local services plus `QUIMERA_LLM_API_KEY` for full
+  pass. Without the key, the summary is still written but G1-05 fails as
+  `authentication`.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -648,3 +648,60 @@ Out of scope:
 - OpenTelemetry, Prometheus, Grafana, dashboards, distributed tracing,
   profiling, soak tests, and memory/resource baselines.
 - Memory/resource baseline: not implemented in GW-12. Deferred to a future sprint. See ADR-0019 Future Work section.
+
+## GW-20 Completed Work
+
+GW-20 adds the Gateway-1 operational proof-of-life smoke and closes the
+Gateway-1 readiness loop before Gateway-2:
+
+```text
+dry-run Agent-0
+  -> local URL guard
+  -> Ollama/Qdrant/LiteLLM probes
+  -> live local_chat
+  -> live local_rag or explicit fallback
+  -> forced Qdrant degradation
+  -> policy block no-model-call check
+  -> sanitized summary JSON
+```
+
+Key files:
+
+- `docs/sprints/GATEWAY1_DONE_CRITERIA.md`
+- `scripts/test_gateway1_proof_of_life.py`
+- `docs/AGENT0_SMOKE.md`
+- `tests/unit/test_gateway1_proof_of_life.py`
+
+Rules:
+
+- The smoke is opt-in with `RUN_GATEWAY1_PROOF_OF_LIFE=1`.
+- Live probes refuse non-local service URLs.
+- Summary reports do not store answer text, prompts, questions, chunks,
+  vectors, payloads, secrets, Authorization headers, raw exceptions or
+  tracebacks.
+- Forced degradation is injected through Agent-0 hooks; it does not stop Docker,
+  mutate Qdrant, reindex, or touch `openclaw_knowledge`.
+- Gateway-2 should not begin until GW-20 passes locally.
+
+Live proof result on 2026-05-02:
+
+- Command:
+  `QUIMERA_LLM_API_KEY=dev-local-key-change-me RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke`
+- Result: **PASSED** — G1-01 through G1-11 all true.
+- Summary: `/tmp/openclaw_gateway1_smoke/gateway1_proof_of_life_9f23ce3df3f2.json`.
+- Probes: Ollama OK, Qdrant OK, LiteLLM OK.
+- Live runner: `local_chat` OK, `local_rag` OK.
+- Forced Qdrant degradation: fallback to `local_chat` with
+  `qdrant_unavailable`.
+- Policy block: blocked before model call.
+
+Observed live latencies:
+
+| Check | Latency |
+|---|---:|
+| Ollama probe | 28.6 ms |
+| Qdrant probe | 9.4 ms |
+| LiteLLM probe | 26.1 ms |
+| Agent-0 `local_chat` | 8790.5 ms |
+| Agent-0 `local_rag` | 32162.8 ms |
+| forced degradation | 0.03 ms |

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -170,10 +170,24 @@ RUN_AGENT0_LOCAL_SMOKE=1 scripts/test_agent0_local_runner.sh
 The smoke script is opt-in and local-only. It requires
 `QUIMERA_LLM_API_KEY` to match the local `LITELLM_MASTER_KEY`.
 
+## Gateway-1 Proof-of-Life
+
+GW-20 adds the final Gateway-1 proof-of-life smoke:
+
+```bash
+RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
+```
+
+The command validates dry-run, local service probes, live `local_chat`, live
+`--rag` success or explicit fallback, forced Qdrant degradation and policy block
+behavior. It writes only sanitized metadata and answer lengths, never answer
+text, prompt text, chunks, vectors, payloads or secrets.
+
 ## Deferred
 
 - Progressive remote escalation remains out of scope.
 - Golden questions harness is provided by GW-18 in
   `scripts/run_golden_harness.py`.
-- Observability E2E validation remains deferred to a future explicit issue.
+- Observability signal validation is covered by GW-19; Gateway-1 proof-of-life
+  is covered by GW-20.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_OBSERVABILITY.md
+++ b/docs/AGENT0_OBSERVABILITY.md
@@ -86,6 +86,17 @@ GW-19 tests cover:
 All tests are offline and deterministic. They do not require LiteLLM, Ollama,
 Qdrant or network services.
 
+## Gateway-1 Proof-of-Life
+
+GW-20 adds an opt-in operator smoke that scans structured proof-of-life outputs
+using the same prohibited-field discipline. It validates dry-run, local service
+probes, live runner paths, forced degradation and policy block behavior, then
+writes a sanitized summary JSON.
+
+The proof-of-life smoke is not OpenTelemetry, not a dashboard, not remote
+telemetry and not a profiling baseline. It is a local readiness gate for
+Gateway-2.
+
 ## Deferred
 
 `RagRunTrace` currently predates Agent-0 and does not carry Agent-0

--- a/docs/AGENT0_SMOKE.md
+++ b/docs/AGENT0_SMOKE.md
@@ -1,0 +1,109 @@
+# Agent-0 Gateway-1 Proof-of-Life Smoke
+
+GW-20 adds the final operational proof-of-life smoke for Sprint Gateway-1. It
+is a single opt-in command that validates the local stack as a unit before
+Gateway-2 starts.
+
+## Command
+
+```bash
+RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
+```
+
+The command exits `0` only when every mandatory Gateway-1 done criterion passes.
+It writes a sanitized JSON summary named:
+
+```text
+gateway1_proof_of_life_<run_id>.json
+```
+
+Generated reports under `reports/gateway1_smoke/` are ignored by Git.
+
+## Prerequisites
+
+The live portions require local services only:
+
+- Ollama: `http://127.0.0.1:11434`
+- Qdrant: `http://127.0.0.1:6333`
+- LiteLLM: `http://127.0.0.1:4000/v1`
+
+Required environment:
+
+```bash
+export QUIMERA_LLM_API_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+export QDRANT_URL="http://127.0.0.1:6333"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+```
+
+The script refuses non-local service URLs before any live probe.
+
+## Done Criteria
+
+The fixed criteria live in
+`docs/sprints/GATEWAY1_DONE_CRITERIA.md`:
+
+- G1-01 dry-run runner ok
+- G1-02 local URLs only
+- G1-03 Ollama probe ok
+- G1-04 Qdrant probe ok
+- G1-05 LiteLLM probe ok
+- G1-06 local chat runner ok
+- G1-07 RAG path or explicit fallback ok
+- G1-08 forced Qdrant degradation ok
+- G1-09 policy block no model call ok
+- G1-10 sanitized output ok
+- G1-11 summary report written ok
+
+## Summary Shape
+
+The summary contains only safe metadata:
+
+- `run_id`
+- `timestamp_utc`
+- `gateway_sprint`
+- `criteria_manifest_ref`
+- `service_probes`
+- `runner_tests`
+- `passed`
+- `failed`
+- `skipped`
+- `criteria_met`
+- `overall_passed`
+
+Runner results store answer length, alias, route, `used_rag`, fallback metadata
+and token estimates. They do not store answer text.
+
+## RAG Success vs Fallback
+
+`G1-07` accepts either:
+
+- RAG success through `local_rag` with `used_rag=true`; or
+- explicit GW-17 fallback to `local_chat` with `used_rag=false` and an
+  enum-derived fallback reason.
+
+Both outcomes are valid because Gateway-1 requires honest local degradation, not
+silent fallback or remote escalation.
+
+## Forced Qdrant Degradation
+
+`G1-08` injects a Qdrant-like unavailable error through the Agent-0 runner test
+hook. It does not stop Docker, mutate Qdrant, delete collections, reindex, or
+touch `openclaw_knowledge`.
+
+## Safety
+
+The proof-of-life summary and runtime checks never include:
+
+- prompt, question or raw user input
+- answer text
+- chunks or retrieved context
+- vectors or embeddings
+- Qdrant payloads
+- API keys, Authorization headers, tokens, passwords or secrets
+- raw model responses
+- raw exceptions, exception messages or tracebacks
+- model weights paths
+
+Remote providers remain disabled. Gateway-2 must not begin until GW-20 passes
+locally.

--- a/docs/sprints/GATEWAY1_DONE_CRITERIA.md
+++ b/docs/sprints/GATEWAY1_DONE_CRITERIA.md
@@ -1,0 +1,19 @@
+# Gateway-1 Done Criteria
+
+Gateway-1 is complete only when the opt-in proof-of-life smoke validates the local stack as a unit without remote providers, Qdrant mutation, real data, or sensitive logging.
+
+| ID | Description | Component | Mandatory | Failure Meaning |
+| --- | --- | --- | --- | --- |
+| G1-01 dry_run_runner_ok | Agent-0 dry-run executes offline and returns the stable safe schema. | Agent-0 runner | true | The runner contract is not available without live services. |
+| G1-02 local_urls_only | Ollama, Qdrant and LiteLLM URLs are localhost or 127.0.0.1 only. | Safety guard | true | The smoke could call a remote service and must stop. |
+| G1-03 ollama_probe_ok | Ollama responds to read-only `GET /api/tags`. | Ollama | true | Local model runtime is not reachable. |
+| G1-04 qdrant_probe_ok | Qdrant responds to read-only `GET /healthz`. | Qdrant | true | Local vector store is not reachable. |
+| G1-05 litellm_probe_ok | LiteLLM responds to `GET /v1/models` and exposes required local aliases. | LiteLLM gateway | true | Local gateway or alias contract is not ready. |
+| G1-06 local_chat_runner_ok | Agent-0 live default path returns safe schema through `local_chat`. | Agent-0 local chat | true | Default local execution is not operational. |
+| G1-07 rag_path_or_explicit_fallback_ok | Agent-0 `--rag` succeeds via `local_rag` or explicitly falls back to `local_chat`. | Agent-0 RAG | true | RAG path neither works nor degrades honestly. |
+| G1-08 forced_qdrant_degradation_ok | Injected Qdrant-like failure triggers the GW-17 fallback contract without stopping Qdrant. | Agent-0 fallback | true | Degraded-state safety is not reproducible. |
+| G1-09 policy_block_no_model_call_ok | Policy block refuses before any model call. | Routing policy | true | Blocked requests may still execute models. |
+| G1-10 sanitized_output_ok | Structured outputs contain no prompt, question, chunks, vectors, payloads or secrets. | Safety audit | true | Smoke artifacts may leak sensitive content. |
+| G1-11 summary_report_written_ok | A structured JSON summary is written even when failures occur where possible. | Operator report | true | Operators cannot inspect proof-of-life outcome. |
+
+Generated proof-of-life summaries are local artifacts and must not be committed.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -184,3 +184,32 @@ Safety:
 - Sanitization tests use allowlists and deterministic sentinels.
 - Prohibited fields include prompts, raw user input, chunks, vectors, payloads,
   headers, API keys, raw exceptions and model weight paths.
+
+## GW-20 Current Work
+
+Scope:
+
+- Add `docs/sprints/GATEWAY1_DONE_CRITERIA.md` with fixed Gateway-1 done
+  criteria G1-01 through G1-11.
+- Add `scripts/test_gateway1_proof_of_life.py`, a single opt-in local
+  proof-of-life smoke command.
+- Probe Ollama, Qdrant and LiteLLM through local-only read-only endpoints.
+- Verify Agent-0 dry-run, live `local_chat`, live `--rag` success or honest
+  fallback, forced Qdrant degradation and policy-block behavior.
+- Write a sanitized structured JSON summary without answer text, prompt text,
+  chunks, vectors, payloads or secrets.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- New runtime architecture.
+- OpenTelemetry, dashboards, Prometheus or Grafana.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- Real portfolio data, real tickers, real companies or real fund names.
+
+Safety:
+
+- The smoke is guarded by `RUN_GATEWAY1_PROOF_OF_LIFE=1`.
+- Live probes refuse non-local URLs.
+- Forced degradation is injected through runner hooks; it does not stop Qdrant.
+- A summary exits `0` only when all mandatory criteria pass.

--- a/scripts/test_gateway1_proof_of_life.py
+++ b/scripts/test_gateway1_proof_of_life.py
@@ -221,16 +221,23 @@ async def run_proof_of_life(
     criteria_met["G1-02"] = local_guard_ok
 
     if local_guard_ok:
-        probes["ollama"] = probe_ollama(urls.ollama_api_base)
-        probes["qdrant"] = probe_qdrant(urls.qdrant_url)
-        probes["litellm"] = probe_litellm(
-            urls.litellm_base_url,
-            api_key=os.environ.get("QUIMERA_LLM_API_KEY"),
+        (
+            probes["ollama"],
+            probes["qdrant"],
+            probes["litellm"],
+        ) = await asyncio.gather(
+            probe_ollama(urls.ollama_api_base),
+            probe_qdrant(urls.qdrant_url),
+            probe_litellm(
+                urls.litellm_base_url,
+                api_key=os.environ.get("QUIMERA_LLM_API_KEY"),
+            ),
         )
         criteria_met["G1-03"] = probes["ollama"].ok
         criteria_met["G1-04"] = probes["qdrant"].ok
         criteria_met["G1-05"] = probes["litellm"].ok
     else:
+        probes.update(_local_url_rejected_probes())
         skipped.update({"G1-03", "G1-04", "G1-05", "G1-06", "G1-07"})
 
     live_ready = all(
@@ -337,25 +344,49 @@ def is_local_url(url: str) -> bool:
     return url.startswith("http://127.0.0.1:") or url.startswith("http://localhost:")
 
 
-def probe_ollama(base_url: str) -> ProbeResult:
+def _local_url_rejected_probes() -> dict[str, ProbeResult]:
+    """Return safe placeholder probe results when URL guard blocks execution."""
+    return {
+        "ollama": ProbeResult(
+            service="ollama",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+        "qdrant": ProbeResult(
+            service="qdrant",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+        "litellm": ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+    }
+
+
+async def probe_ollama(base_url: str) -> ProbeResult:
     """Probe Ollama tags endpoint without mutating state."""
-    return _http_probe(
+    return await _http_probe(
         service="ollama",
         url=f"{base_url.rstrip('/')}/api/tags",
         expected_json_mapping=True,
     )
 
 
-def probe_qdrant(base_url: str) -> ProbeResult:
+async def probe_qdrant(base_url: str) -> ProbeResult:
     """Probe Qdrant health endpoint without mutating state."""
-    return _http_probe(
+    return await _http_probe(
         service="qdrant",
         url=f"{base_url.rstrip('/')}/healthz",
         expected_json_mapping=False,
     )
 
 
-def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
+async def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
     """Probe LiteLLM models endpoint and required aliases."""
     if not api_key:
         return ProbeResult(
@@ -366,11 +397,11 @@ def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
         )
     start = time.perf_counter()
     try:
-        response = httpx.get(
-            f"{base_url.rstrip('/')}/models",
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=PROBE_TIMEOUT_SECONDS,
-        )
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{base_url.rstrip('/')}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
         response.raise_for_status()
         payload = response.json()
         aliases = _extract_model_aliases(payload)
@@ -391,7 +422,7 @@ def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
         )
 
 
-def _http_probe(
+async def _http_probe(
     *,
     service: str,
     url: str,
@@ -399,7 +430,8 @@ def _http_probe(
 ) -> ProbeResult:
     start = time.perf_counter()
     try:
-        response = httpx.get(url, timeout=PROBE_TIMEOUT_SECONDS)
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(url)
         response.raise_for_status()
         if expected_json_mapping and not isinstance(response.json(), Mapping):
             return ProbeResult(

--- a/scripts/test_gateway1_proof_of_life.py
+++ b/scripts/test_gateway1_proof_of_life.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python
+"""Gateway-1 operational proof-of-life smoke.
+
+The smoke is opt-in, local-only and writes a sanitized structured summary.
+It never stores prompt text, answer text, chunks, vectors, payloads or secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from backend.gateway.observability_contract import PROHIBITED_SIGNAL_KEYS
+from backend.gateway.routing_policy import (
+    FallbackReason,
+    RemoteEscalationPolicy,
+)
+from scripts import run_local_agent
+
+
+GUARD_ENV = "RUN_GATEWAY1_PROOF_OF_LIFE"
+DEFAULT_OUTPUT_DIR = Path("reports/gateway1_smoke")
+CRITERIA_MANIFEST_REF = "docs/sprints/GATEWAY1_DONE_CRITERIA.md"
+GATEWAY_SPRINT = "Gateway-1"
+DEFAULT_LITELLM_BASE_URL = "http://127.0.0.1:4000/v1"
+DEFAULT_QDRANT_URL = "http://127.0.0.1:6333"
+DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
+PROBE_TIMEOUT_SECONDS = 5.0
+REQUIRED_ALIASES = (
+    "local_chat",
+    "local_rag",
+    "local_json",
+    "local_think",
+    "quimera_embed",
+    "local_embed",
+)
+MANDATORY_CRITERIA = {
+    "G1-01": True,
+    "G1-02": True,
+    "G1-03": True,
+    "G1-04": True,
+    "G1-05": True,
+    "G1-06": True,
+    "G1-07": True,
+    "G1-08": True,
+    "G1-09": True,
+    "G1-10": True,
+    "G1-11": True,
+}
+FAKE_SENSITIVE_VALUES = (
+    "FAKE_API_KEY_SHOULD_NOT_APPEAR",
+    "FAKE_AUTH_HEADER_SHOULD_NOT_APPEAR",
+    "FAKE_PROMPT_SHOULD_NOT_APPEAR",
+    "FAKE_CHUNK_SHOULD_NOT_APPEAR",
+    "FAKE_VECTOR_SHOULD_NOT_APPEAR",
+)
+
+
+class FakeQdrantUnavailableError(RuntimeError):
+    """Synthetic Qdrant-like exception used for deterministic degradation."""
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Safe read-only service probe result."""
+
+    service: str
+    ok: bool
+    latency_ms: float
+    error_category: str | None = None
+    missing_aliases: tuple[str, ...] = ()
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted probe metadata."""
+        data: dict[str, object] = {
+            "service": self.service,
+            "ok": self.ok,
+            "latency_ms": self.latency_ms,
+        }
+        if self.error_category is not None:
+            data["error_category"] = self.error_category
+        if self.missing_aliases:
+            data["missing_aliases"] = list(self.missing_aliases)
+        return data
+
+
+@dataclass(frozen=True)
+class RunnerSmokeResult:
+    """Safe Agent-0 smoke result without answer text."""
+
+    name: str
+    ok: bool
+    route: str | None
+    alias: str | None
+    used_rag: bool | None
+    latency_ms: float
+    decision_id: str | None
+    estimated_remote_tokens_avoided: int | float | None
+    answer_length_chars: int | None
+    error_category: str | None = None
+    fallback_applied: bool | None = None
+    fallback_reason: str | None = None
+    model_call_attempted: bool | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted runner smoke metadata."""
+        data: dict[str, object] = {
+            "name": self.name,
+            "ok": self.ok,
+            "latency_ms": self.latency_ms,
+        }
+        optional: dict[str, object | None] = {
+            "route": self.route,
+            "alias": self.alias,
+            "used_rag": self.used_rag,
+            "decision_id": self.decision_id,
+            "estimated_remote_tokens_avoided": (
+                self.estimated_remote_tokens_avoided
+            ),
+            "answer_length_chars": self.answer_length_chars,
+            "error_category": self.error_category,
+            "fallback_applied": self.fallback_applied,
+            "fallback_reason": self.fallback_reason,
+            "model_call_attempted": self.model_call_attempted,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+@dataclass(frozen=True)
+class GatewayProofOfLifeSummary:
+    """Sanitized proof-of-life report."""
+
+    run_id: str
+    timestamp_utc: str
+    gateway_sprint: str
+    criteria_manifest_ref: str
+    service_probes: Mapping[str, ProbeResult]
+    runner_tests: Mapping[str, RunnerSmokeResult]
+    passed: tuple[str, ...]
+    failed: tuple[str, ...]
+    skipped: tuple[str, ...]
+    criteria_met: Mapping[str, bool]
+    overall_passed: bool
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted summary metadata."""
+        return {
+            "run_id": self.run_id,
+            "timestamp_utc": self.timestamp_utc,
+            "gateway_sprint": self.gateway_sprint,
+            "criteria_manifest_ref": self.criteria_manifest_ref,
+            "service_probes": {
+                name: probe.to_json_dict()
+                for name, probe in sorted(self.service_probes.items())
+            },
+            "runner_tests": {
+                name: result.to_json_dict()
+                for name, result in sorted(self.runner_tests.items())
+            },
+            "passed": list(self.passed),
+            "failed": list(self.failed),
+            "skipped": list(self.skipped),
+            "criteria_met": dict(sorted(self.criteria_met.items())),
+            "overall_passed": self.overall_passed,
+        }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse proof-of-life smoke arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the opt-in Gateway-1 proof-of-life smoke.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for the sanitized summary JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def require_guard_enabled() -> bool:
+    """Return whether the live proof-of-life guard is enabled."""
+    return os.environ.get(GUARD_ENV) == "1"
+
+
+async def run_proof_of_life(
+    *,
+    output_dir: Path | str,
+) -> tuple[GatewayProofOfLifeSummary, Path | None]:
+    """Run the Gateway-1 proof-of-life smoke and write a summary if possible."""
+    run_id = uuid4().hex[:12]
+    criteria_met: dict[str, bool] = {criterion: False for criterion in MANDATORY_CRITERIA}
+    skipped: set[str] = set()
+    probes: dict[str, ProbeResult] = {}
+    runner_tests: dict[str, RunnerSmokeResult] = {}
+
+    dry_run = await run_dry_run_smoke()
+    runner_tests["dry_run"] = dry_run
+    criteria_met["G1-01"] = dry_run.ok
+
+    urls = GatewayUrls.from_env()
+    local_guard_ok = urls.are_local_only()
+    criteria_met["G1-02"] = local_guard_ok
+
+    if local_guard_ok:
+        probes["ollama"] = probe_ollama(urls.ollama_api_base)
+        probes["qdrant"] = probe_qdrant(urls.qdrant_url)
+        probes["litellm"] = probe_litellm(
+            urls.litellm_base_url,
+            api_key=os.environ.get("QUIMERA_LLM_API_KEY"),
+        )
+        criteria_met["G1-03"] = probes["ollama"].ok
+        criteria_met["G1-04"] = probes["qdrant"].ok
+        criteria_met["G1-05"] = probes["litellm"].ok
+    else:
+        skipped.update({"G1-03", "G1-04", "G1-05", "G1-06", "G1-07"})
+
+    live_ready = all(
+        criteria_met[criterion] for criterion in ("G1-02", "G1-03", "G1-05")
+    )
+    if live_ready:
+        local_chat = await run_local_chat_smoke()
+        runner_tests["local_chat"] = local_chat
+        criteria_met["G1-06"] = local_chat.ok
+    elif "G1-06" not in skipped:
+        skipped.add("G1-06")
+
+    rag_ready = all(
+        criteria_met[criterion]
+        for criterion in ("G1-02", "G1-03", "G1-04", "G1-05")
+    )
+    if rag_ready:
+        rag_smoke = await run_rag_smoke()
+        runner_tests["rag"] = rag_smoke
+        criteria_met["G1-07"] = rag_smoke.ok
+    elif "G1-07" not in skipped:
+        skipped.add("G1-07")
+
+    forced_degradation = await run_forced_qdrant_degradation_smoke()
+    runner_tests["forced_qdrant_degradation"] = forced_degradation
+    criteria_met["G1-08"] = forced_degradation.ok
+
+    policy_block = await run_policy_block_smoke()
+    runner_tests["policy_block"] = policy_block
+    criteria_met["G1-09"] = policy_block.ok
+
+    try:
+        provisional = _build_summary(
+            run_id=run_id,
+            probes=probes,
+            runner_tests=runner_tests,
+            criteria_met=criteria_met,
+            skipped=skipped,
+        )
+        assert_sanitized(provisional.to_json_dict())
+        criteria_met["G1-10"] = True
+    except ValueError:
+        criteria_met["G1-10"] = False
+
+    summary = _build_summary(
+        run_id=run_id,
+        probes=probes,
+        runner_tests=runner_tests,
+        criteria_met=criteria_met,
+        skipped=skipped,
+    )
+
+    summary_path: Path | None = None
+    try:
+        summary_path = write_summary(output_dir, summary)
+        criteria_met["G1-11"] = True
+    except OSError:
+        criteria_met["G1-11"] = False
+    summary = _build_summary(
+        run_id=run_id,
+        probes=probes,
+        runner_tests=runner_tests,
+        criteria_met=criteria_met,
+        skipped=skipped,
+    )
+    if summary_path is not None:
+        write_summary(output_dir, summary, path=summary_path)
+    return summary, summary_path
+
+
+@dataclass(frozen=True)
+class GatewayUrls:
+    """Local service URLs used by Gateway-1 smoke."""
+
+    litellm_base_url: str
+    qdrant_url: str
+    ollama_api_base: str
+
+    @classmethod
+    def from_env(cls) -> GatewayUrls:
+        """Build URLs from environment with local defaults."""
+        return cls(
+            litellm_base_url=os.environ.get(
+                "QUIMERA_LLM_BASE_URL",
+                DEFAULT_LITELLM_BASE_URL,
+            ),
+            qdrant_url=os.environ.get("QDRANT_URL", DEFAULT_QDRANT_URL),
+            ollama_api_base=os.environ.get(
+                "OLLAMA_API_BASE",
+                DEFAULT_OLLAMA_API_BASE,
+            ),
+        )
+
+    def are_local_only(self) -> bool:
+        """Return true only when all service URLs are local."""
+        return all(
+            is_local_url(url)
+            for url in (self.litellm_base_url, self.qdrant_url, self.ollama_api_base)
+        )
+
+
+def is_local_url(url: str) -> bool:
+    """Return whether ``url`` is an allowed local HTTP URL."""
+    return url.startswith("http://127.0.0.1:") or url.startswith("http://localhost:")
+
+
+def probe_ollama(base_url: str) -> ProbeResult:
+    """Probe Ollama tags endpoint without mutating state."""
+    return _http_probe(
+        service="ollama",
+        url=f"{base_url.rstrip('/')}/api/tags",
+        expected_json_mapping=True,
+    )
+
+
+def probe_qdrant(base_url: str) -> ProbeResult:
+    """Probe Qdrant health endpoint without mutating state."""
+    return _http_probe(
+        service="qdrant",
+        url=f"{base_url.rstrip('/')}/healthz",
+        expected_json_mapping=False,
+    )
+
+
+def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
+    """Probe LiteLLM models endpoint and required aliases."""
+    if not api_key:
+        return ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="authentication",
+        )
+    start = time.perf_counter()
+    try:
+        response = httpx.get(
+            f"{base_url.rstrip('/')}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=PROBE_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        aliases = _extract_model_aliases(payload)
+        missing = tuple(alias for alias in REQUIRED_ALIASES if alias not in aliases)
+        return ProbeResult(
+            service="litellm",
+            ok=not missing,
+            latency_ms=_elapsed_ms(start),
+            error_category="alias_missing" if missing else None,
+            missing_aliases=missing,
+        )
+    except Exception as exc:
+        return ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=_elapsed_ms(start),
+            error_category=categorize_probe_exception(exc),
+        )
+
+
+def _http_probe(
+    *,
+    service: str,
+    url: str,
+    expected_json_mapping: bool,
+) -> ProbeResult:
+    start = time.perf_counter()
+    try:
+        response = httpx.get(url, timeout=PROBE_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        if expected_json_mapping and not isinstance(response.json(), Mapping):
+            return ProbeResult(
+                service=service,
+                ok=False,
+                latency_ms=_elapsed_ms(start),
+                error_category="invalid_response",
+            )
+        return ProbeResult(service=service, ok=True, latency_ms=_elapsed_ms(start))
+    except Exception as exc:
+        return ProbeResult(
+            service=service,
+            ok=False,
+            latency_ms=_elapsed_ms(start),
+            error_category=categorize_probe_exception(exc),
+        )
+
+
+def categorize_probe_exception(exc: Exception) -> str:
+    """Map probe exceptions to safe categories without raw messages."""
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.ConnectError):
+        return "connection"
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code in {401, 403}:
+            return "authentication"
+        return "invalid_response"
+    if isinstance(exc, httpx.RequestError):
+        return "connection"
+    if isinstance(exc, (json.JSONDecodeError, ValueError, TypeError)):
+        return "invalid_response"
+    return "unknown"
+
+
+async def run_dry_run_smoke() -> RunnerSmokeResult:
+    """Run Agent-0 dry-run without live services."""
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica de dry-run.",
+        dry_run=True,
+    )
+    ok = (
+        result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and result.latency_ms == 0.0
+        and result.estimated_remote_tokens_avoided >= 0
+    )
+    return _runner_result("dry_run", result, ok=ok)
+
+
+async def run_local_chat_smoke() -> RunnerSmokeResult:
+    """Run one live Agent-0 default local_chat question."""
+    result = await run_local_agent.run_agent(
+        question="Explique de forma sintetica o que e diversificacao.",
+        max_tokens=128,
+        temperature=0.0,
+    )
+    ok = (
+        result.route == "local"
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+        and result.error_category is None
+        and result.estimated_remote_tokens_avoided >= 0
+    )
+    return _runner_result("local_chat", result, ok=ok)
+
+
+async def run_rag_smoke() -> RunnerSmokeResult:
+    """Run live Agent-0 RAG and accept success or explicit local fallback."""
+    result = await run_local_agent.run_agent(
+        question="Use contexto sintetico para explicar uma politica de risco.",
+        use_rag=True,
+        max_tokens=160,
+        temperature=0.0,
+    )
+    rag_success = (
+        result.alias == run_local_agent.LOCAL_RAG_ALIAS
+        and result.used_rag
+        and result.error_category is None
+        and not result.fallback_applied
+    )
+    explicit_fallback = (
+        result.fallback_applied is True
+        and result.fallback_reason is not None
+        and result.fallback_reason.value in {reason.value for reason in FallbackReason}
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+    )
+    return _runner_result("rag", result, ok=rag_success or explicit_fallback)
+
+
+async def run_forced_qdrant_degradation_smoke() -> RunnerSmokeResult:
+    """Inject a Qdrant-like failure and verify one safe fallback."""
+    rag_calls = 0
+    chat_calls = 0
+
+    async def rag_call(
+        question: str,
+        *,
+        max_tokens: int | None,
+        temperature: float | None,
+    ) -> str:
+        nonlocal rag_calls
+        del question, max_tokens, temperature
+        rag_calls += 1
+        raise FakeQdrantUnavailableError("synthetic local unavailable")
+
+    async def chat_call(
+        question: str,
+        *,
+        alias: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        response_format: Mapping[str, object] | None,
+    ) -> str:
+        nonlocal chat_calls
+        del question, alias, max_tokens, temperature, response_format
+        chat_calls += 1
+        return "Resposta sintetica de fallback local."
+
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica para degradacao.",
+        use_rag=True,
+        chat_call=chat_call,
+        rag_call=rag_call,
+    )
+    ok = (
+        rag_calls == 1
+        and chat_calls == 1
+        and result.fallback_applied is True
+        and result.fallback_reason
+        in {FallbackReason.QDRANT_UNAVAILABLE, FallbackReason.RAG_UNAVAILABLE}
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+        and result.error_category is None
+    )
+    return _runner_result("forced_qdrant_degradation", result, ok=ok)
+
+
+async def run_policy_block_smoke() -> RunnerSmokeResult:
+    """Verify budget policy block happens before model calls."""
+    model_call_attempted = False
+
+    async def chat_call(
+        question: str,
+        *,
+        alias: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        response_format: Mapping[str, object] | None,
+    ) -> str:
+        nonlocal model_call_attempted
+        del question, alias, max_tokens, temperature, response_format
+        model_call_attempted = True
+        return "should not run"
+
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica bloqueada por orcamento.",
+        chat_call=chat_call,
+        policy_loader=lambda: RemoteEscalationPolicy(
+            remote_enabled=False,
+            per_request_token_limit=1,
+        ),
+    )
+    ok = (
+        result.route == "blocked"
+        and result.error_category == "blocked"
+        and result.latency_ms == 0.0
+        and not result.fallback_applied
+        and not model_call_attempted
+    )
+    return _runner_result(
+        "policy_block",
+        result,
+        ok=ok,
+        model_call_attempted=model_call_attempted,
+    )
+
+
+def assert_sanitized(value: object) -> None:
+    """Recursively reject prohibited keys and known fake sensitive values."""
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key).lower()
+            if key_text in PROHIBITED_SIGNAL_KEYS:
+                raise ValueError(f"prohibited key in smoke output: {key_text}")
+            assert_sanitized(nested)
+        return
+    if isinstance(value, list | tuple):
+        for item in value:
+            assert_sanitized(item)
+        return
+    if isinstance(value, str):
+        for marker in FAKE_SENSITIVE_VALUES:
+            if marker in value:
+                raise ValueError("fake sensitive marker leaked into smoke output")
+
+
+def write_summary(
+    output_dir: Path | str,
+    summary: GatewayProofOfLifeSummary,
+    *,
+    path: Path | None = None,
+) -> Path:
+    """Write one sanitized proof-of-life JSON summary."""
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = path or out_dir / f"gateway1_proof_of_life_{summary.run_id}.json"
+    payload = summary.to_json_dict()
+    assert_sanitized(payload)
+    target.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async proof-of-life CLI entrypoint."""
+    args = parse_args(argv)
+    if not require_guard_enabled():
+        sys.stdout.write(
+            "Gateway-1 proof-of-life is opt-in. "
+            "Set RUN_GATEWAY1_PROOF_OF_LIFE=1 to run.\n",
+        )
+        return 2
+    summary, summary_path = await run_proof_of_life(output_dir=args.output_dir)
+    if summary_path is not None:
+        sys.stdout.write(f"summary_json={summary_path}\n")
+    sys.stdout.write(
+        f"overall_passed={str(summary.overall_passed).lower()} "
+        f"passed={len(summary.passed)} failed={len(summary.failed)} "
+        f"skipped={len(summary.skipped)}\n",
+    )
+    return 0 if summary.overall_passed else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def _build_summary(
+    *,
+    run_id: str,
+    probes: Mapping[str, ProbeResult],
+    runner_tests: Mapping[str, RunnerSmokeResult],
+    criteria_met: Mapping[str, bool],
+    skipped: set[str],
+) -> GatewayProofOfLifeSummary:
+    passed = tuple(
+        criterion for criterion, ok in sorted(criteria_met.items()) if ok
+    )
+    failed = tuple(
+        criterion
+        for criterion, mandatory in sorted(MANDATORY_CRITERIA.items())
+        if mandatory and not criteria_met.get(criterion, False) and criterion not in skipped
+    )
+    overall_passed = not failed and all(
+        criteria_met.get(criterion, False)
+        for criterion, mandatory in MANDATORY_CRITERIA.items()
+        if mandatory
+    )
+    return GatewayProofOfLifeSummary(
+        run_id=run_id,
+        timestamp_utc=_utc_now(),
+        gateway_sprint=GATEWAY_SPRINT,
+        criteria_manifest_ref=CRITERIA_MANIFEST_REF,
+        service_probes=probes,
+        runner_tests=runner_tests,
+        passed=passed,
+        failed=failed,
+        skipped=tuple(sorted(skipped)),
+        criteria_met=criteria_met,
+        overall_passed=overall_passed,
+    )
+
+
+def _runner_result(
+    name: str,
+    result: run_local_agent.AgentRunResult,
+    *,
+    ok: bool,
+    model_call_attempted: bool | None = None,
+) -> RunnerSmokeResult:
+    return RunnerSmokeResult(
+        name=name,
+        ok=ok,
+        route=result.route,
+        alias=result.alias,
+        used_rag=result.used_rag,
+        latency_ms=result.latency_ms,
+        decision_id=result.decision_id,
+        estimated_remote_tokens_avoided=result.estimated_remote_tokens_avoided,
+        answer_length_chars=len(result.answer),
+        error_category=result.error_category,
+        fallback_applied=result.fallback_applied,
+        fallback_reason=result.fallback_reason.value if result.fallback_reason else None,
+        model_call_attempted=model_call_attempted,
+    )
+
+
+def _extract_model_aliases(payload: object) -> frozenset[str]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("models response must be a mapping")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise ValueError("models response data must be a list")
+    aliases: set[str] = set()
+    for item in data:
+        if isinstance(item, Mapping) and isinstance(item.get("id"), str):
+            aliases.add(str(item["id"]))
+    return frozenset(aliases)
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_gateway1_proof_of_life.py
+++ b/scripts/test_gateway1_proof_of_life.py
@@ -29,6 +29,9 @@ from backend.gateway.routing_policy import (
 )
 from scripts import run_local_agent
 
+# Smoke summaries must not include "answer" — that key belongs to runner output
+# only and should never surface in observability reports.
+PROHIBITED_SMOKE_SUMMARY_KEYS: frozenset[str] = PROHIBITED_SIGNAL_KEYS | frozenset({"answer"})
 
 GUARD_ENV = "RUN_GATEWAY1_PROOF_OF_LIFE"
 DEFAULT_OUTPUT_DIR = Path("reports/gateway1_smoke")
@@ -580,7 +583,7 @@ def assert_sanitized(value: object) -> None:
     if isinstance(value, Mapping):
         for key, nested in value.items():
             key_text = str(key).lower()
-            if key_text in PROHIBITED_SIGNAL_KEYS:
+            if key_text in PROHIBITED_SMOKE_SUMMARY_KEYS:
                 raise ValueError(f"prohibited key in smoke output: {key_text}")
             assert_sanitized(nested)
         return

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -139,6 +139,12 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError):
             proof.assert_sanitized({"safe_key": "FAKE_PROMPT_SHOULD_NOT_APPEAR"})
 
+    def test_recursive_sanitizer_catches_answer_key_in_smoke_output(self) -> None:
+        # "answer" is legitimate in AgentRunResult but must not appear in smoke
+        # summaries — PROHIBITED_SMOKE_SUMMARY_KEYS extends the base set with it.
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"answer": "some answer text"})
+
     async def test_dry_run_criterion_success(self) -> None:
         result = await proof.run_dry_run_smoke()
         data = result.to_json_dict()

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
+import time
 import unittest
 from collections.abc import Mapping
 from pathlib import Path
@@ -438,6 +440,73 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(sentinel, serialized)
         self.assertNotIn("Authorization", serialized)
         proof.assert_sanitized(result.to_json_dict())
+
+    async def test_probes_run_concurrently_not_sequentially(self) -> None:
+        # Concurrency-shape test: wall time should be ~max(delays), not sum(delays).
+        # Each fake sleeps 50 ms; sequential would be ~150 ms, concurrent ~50 ms.
+        # Threshold is 120 ms — generous to avoid false failures on slow CI.
+        async def slow_probe_ollama(base_url: str) -> proof.ProbeResult:
+            del base_url
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="ollama", ok=True, latency_ms=50.0)
+
+        async def slow_probe_qdrant(base_url: str) -> proof.ProbeResult:
+            del base_url
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="qdrant", ok=True, latency_ms=50.0)
+
+        async def slow_probe_litellm(
+            base_url: str, *, api_key: str | None
+        ) -> proof.ProbeResult:
+            del base_url, api_key
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="litellm", ok=True, latency_ms=50.0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", slow_probe_ollama),
+                patch.object(proof, "probe_qdrant", slow_probe_qdrant),
+                patch.object(proof, "probe_litellm", slow_probe_litellm),
+                patch.object(proof, "run_local_chat_smoke", _fake_runner_smoke("local_chat", True)),
+                patch.object(proof, "run_rag_smoke", _fake_runner_smoke("rag", True)),
+            ):
+                wall_start = time.perf_counter()
+                await proof.run_proof_of_life(output_dir=temp_dir)
+                wall_elapsed = time.perf_counter() - wall_start
+
+        # Sequential would be ~0.15 s; concurrent finishes well under 0.12 s.
+        self.assertLess(
+            wall_elapsed,
+            0.12,
+            "Probes appear to run sequentially — asyncio.gather concurrency broken",
+        )
+
+    def test_probe_latency_ms_is_numeric_and_non_negative(self) -> None:
+        for ok, error_category in [(True, None), (False, "connection")]:
+            result = proof.ProbeResult(
+                service="ollama",
+                ok=ok,
+                latency_ms=12.5,
+                error_category=error_category,
+            )
+            data = result.to_json_dict()
+            latency = data["latency_ms"]
+            self.assertIsInstance(latency, (int, float))
+            self.assertGreaterEqual(latency, 0.0)
+
+        # Edge case: early-return path (api_key=None) produces latency_ms=0.0
+        zero_result = proof.ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="authentication",
+        )
+        self.assertGreaterEqual(zero_result.to_json_dict()["latency_ms"], 0.0)
 
     async def test_remote_url_guard_runs_before_async_probes(self) -> None:
         async def fail_probe(*args: object, **kwargs: object) -> proof.ProbeResult:

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -6,8 +6,11 @@ import tempfile
 import unittest
 from collections.abc import Mapping
 from pathlib import Path
-from typing import cast
+from types import TracebackType
+from typing import Any, Self, cast
 from unittest.mock import patch
+
+import httpx
 
 from backend.gateway.routing_policy import FallbackReason
 from scripts import run_local_agent
@@ -299,9 +302,9 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
                     {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
                     clear=True,
                 ),
-                patch.object(proof, "probe_ollama", return_value=proof.ProbeResult("ollama", True, 1.0)),
-                patch.object(proof, "probe_qdrant", return_value=proof.ProbeResult("qdrant", True, 1.0)),
-                patch.object(proof, "probe_litellm", return_value=proof.ProbeResult("litellm", True, 1.0)),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", True)),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
                 patch.object(proof, "run_local_chat_smoke", fake_local_chat),
                 patch.object(proof, "run_rag_smoke", fake_rag),
                 patch("sys.stdout.write"),
@@ -316,28 +319,189 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(data["overall_passed"])
         proof.assert_sanitized(cast(dict[str, object], data))
 
+    async def test_async_probes_are_gathered_into_all_service_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", True)),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
+                patch.object(proof, "run_local_chat_smoke", _fake_runner_smoke("local_chat", True)),
+                patch.object(proof, "run_rag_smoke", _fake_runner_smoke("rag", True)),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
 
-class GatewayProofOfLifeProbeTests(unittest.TestCase):
-    def test_litellm_probe_reports_missing_aliases(self) -> None:
-        def fake_get(
-            url: str,
-            *,
-            headers: Mapping[str, str],
-            timeout: float,
-        ) -> object:
-            del url, headers, timeout
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        self.assertTrue(summary.service_probes["ollama"].ok)
+        self.assertTrue(summary.service_probes["qdrant"].ok)
+        self.assertTrue(summary.service_probes["litellm"].ok)
 
-            class Response:
-                def raise_for_status(self) -> None:
-                    return None
+    async def test_async_probe_failure_is_converted_to_probe_result(self) -> None:
+        class RaisingAsyncClient:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
 
-                def json(self) -> dict[str, object]:
-                    return {"data": [{"id": "local_chat"}]}
+            async def __aenter__(self) -> Self:
+                return self
 
-            return Response()
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
 
-        with patch("scripts.test_gateway1_proof_of_life.httpx.get", fake_get):
-            result = proof.probe_litellm(
+            async def get(self, url: str, **kwargs: object) -> object:
+                del url, kwargs
+                raise httpx.ConnectError("FAKE_SECRET_MESSAGE")
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", RaisingAsyncClient):
+            result = await proof.probe_ollama("http://127.0.0.1:11434")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_category, "connection")
+        data = result.to_json_dict()
+        self.assertNotIn("FAKE_SECRET_MESSAGE", json.dumps(data))
+        proof.assert_sanitized(data)
+
+    async def test_failed_async_probe_does_not_hide_other_service_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", False, "connection")),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
+
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        self.assertTrue(summary.service_probes["ollama"].ok)
+        self.assertFalse(summary.service_probes["qdrant"].ok)
+        self.assertEqual(summary.service_probes["qdrant"].error_category, "connection")
+        self.assertTrue(summary.service_probes["litellm"].ok)
+
+    async def test_litellm_async_probe_does_not_leak_authorization(self) -> None:
+        sentinel = "FAKE_API_KEY_SHOULD_NOT_APPEAR"
+
+        class Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {"data": [{"id": alias} for alias in proof.REQUIRED_ALIASES]}
+
+        class CapturingAsyncClient:
+            captured_headers: Mapping[str, str] | None = None
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+
+            async def __aenter__(self) -> Self:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
+
+            async def get(
+                self,
+                url: str,
+                *,
+                headers: Mapping[str, str] | None = None,
+            ) -> Response:
+                del url
+                CapturingAsyncClient.captured_headers = headers
+                return Response()
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", CapturingAsyncClient):
+            result = await proof.probe_litellm(
+                "http://127.0.0.1:4000/v1",
+                api_key=sentinel,
+            )
+
+        self.assertTrue(result.ok)
+        self.assertIn("Authorization", CapturingAsyncClient.captured_headers or {})
+        serialized = json.dumps(result.to_json_dict())
+        self.assertNotIn(sentinel, serialized)
+        self.assertNotIn("Authorization", serialized)
+        proof.assert_sanitized(result.to_json_dict())
+
+    async def test_remote_url_guard_runs_before_async_probes(self) -> None:
+        async def fail_probe(*args: object, **kwargs: object) -> proof.ProbeResult:
+            del args, kwargs
+            self.fail("probe should not run after remote URL guard failure")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "RUN_GATEWAY1_PROOF_OF_LIFE": "1",
+                        "QUIMERA_LLM_BASE_URL": "https://api.example.com/v1",
+                    },
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", fail_probe),
+                patch.object(proof, "probe_qdrant", fail_probe),
+                patch.object(proof, "probe_litellm", fail_probe),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
+
+        self.assertFalse(summary.criteria_met["G1-02"])
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        for service_probe in summary.service_probes.values():
+            self.assertFalse(service_probe.ok)
+            self.assertEqual(service_probe.error_category, "local_url_rejected")
+
+
+class GatewayProofOfLifeProbeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_litellm_probe_reports_missing_aliases(self) -> None:
+        class Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {"data": [{"id": "local_chat"}]}
+
+        class AliasAsyncClient:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+
+            async def __aenter__(self) -> Self:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
+
+            async def get(
+                self,
+                url: str,
+                *,
+                headers: Mapping[str, str] | None = None,
+            ) -> Response:
+                del url, headers
+                return Response()
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", AliasAsyncClient):
+            result = await proof.probe_litellm(
                 "http://127.0.0.1:4000/v1",
                 api_key="dev-key",
             )
@@ -345,6 +509,48 @@ class GatewayProofOfLifeProbeTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertEqual(result.error_category, "alias_missing")
         self.assertIn("local_rag", result.missing_aliases)
+
+
+def _fake_probe(
+    service: str,
+    ok: bool,
+    error_category: str | None = None,
+) -> Any:
+    async def fake(base_url: str) -> proof.ProbeResult:
+        del base_url
+        return proof.ProbeResult(
+            service=service,
+            ok=ok,
+            latency_ms=1.0,
+            error_category=error_category,
+        )
+
+    return fake
+
+
+def _fake_litellm_probe(ok: bool) -> Any:
+    async def fake(base_url: str, *, api_key: str | None) -> proof.ProbeResult:
+        del base_url, api_key
+        return proof.ProbeResult(service="litellm", ok=ok, latency_ms=1.0)
+
+    return fake
+
+
+def _fake_runner_smoke(name: str, ok: bool) -> Any:
+    async def fake() -> proof.RunnerSmokeResult:
+        return proof.RunnerSmokeResult(
+            name=name,
+            ok=ok,
+            route="local",
+            alias="local_chat" if name == "local_chat" else "local_rag",
+            used_rag=name == "rag",
+            latency_ms=1.0,
+            decision_id="decision",
+            estimated_remote_tokens_avoided=1,
+            answer_length_chars=20,
+        )
+
+    return fake
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+from backend.gateway.routing_policy import FallbackReason
+from scripts import run_local_agent
+from scripts import test_gateway1_proof_of_life as proof
+
+
+PROBE_KEYS = {
+    "service",
+    "ok",
+    "latency_ms",
+    "error_category",
+    "missing_aliases",
+}
+RUNNER_KEYS = {
+    "name",
+    "ok",
+    "route",
+    "alias",
+    "used_rag",
+    "latency_ms",
+    "decision_id",
+    "estimated_remote_tokens_avoided",
+    "answer_length_chars",
+    "error_category",
+    "fallback_applied",
+    "fallback_reason",
+    "model_call_attempted",
+}
+SUMMARY_KEYS = {
+    "run_id",
+    "timestamp_utc",
+    "gateway_sprint",
+    "criteria_manifest_ref",
+    "service_probes",
+    "runner_tests",
+    "passed",
+    "failed",
+    "skipped",
+    "criteria_met",
+    "overall_passed",
+}
+
+
+def _fake_result(
+    *,
+    alias: str = "local_chat",
+    used_rag: bool = False,
+    answer: str = "resposta sintetica",
+    error_category: str | None = None,
+    fallback_reason: FallbackReason | None = None,
+) -> run_local_agent.AgentRunResult:
+    return run_local_agent.AgentRunResult(
+        answer=answer,
+        route="local",
+        alias=alias,
+        used_rag=used_rag,
+        latency_ms=12.3,
+        decision_id="decision-123",
+        estimated_remote_tokens_avoided=42,
+        error_category=error_category,
+        fallback_applied=fallback_reason is not None,
+        fallback_from_alias="local_rag" if fallback_reason is not None else None,
+        fallback_to_alias="local_chat" if fallback_reason is not None else None,
+        fallback_reason=fallback_reason,
+        fallback_chain=(fallback_reason,) if fallback_reason is not None else None,
+    )
+
+
+class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
+    def test_local_url_guard_accepts_localhost_and_loopback(self) -> None:
+        self.assertTrue(proof.is_local_url("http://127.0.0.1:4000/v1"))
+        self.assertTrue(proof.is_local_url("http://localhost:6333"))
+
+    def test_local_url_guard_rejects_remote_urls(self) -> None:
+        self.assertFalse(proof.is_local_url("https://api.example.com/v1"))
+        self.assertFalse(proof.is_local_url("http://192.168.1.1:4000/v1"))
+
+    def test_probe_result_serialization_is_allowlisted(self) -> None:
+        result = proof.ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=1.2,
+            error_category="alias_missing",
+            missing_aliases=("local_chat",),
+        )
+        data = result.to_json_dict()
+
+        self.assertTrue(set(data).issubset(PROBE_KEYS))
+        proof.assert_sanitized(data)
+
+    def test_summary_serialization_is_allowlisted(self) -> None:
+        summary = proof.GatewayProofOfLifeSummary(
+            run_id="run",
+            timestamp_utc="2026-05-02T00:00:00Z",
+            gateway_sprint="Gateway-1",
+            criteria_manifest_ref=proof.CRITERIA_MANIFEST_REF,
+            service_probes={
+                "ollama": proof.ProbeResult("ollama", True, 1.0),
+            },
+            runner_tests={
+                "dry_run": proof.RunnerSmokeResult(
+                    name="dry_run",
+                    ok=True,
+                    route="local",
+                    alias="local_chat",
+                    used_rag=False,
+                    latency_ms=0.0,
+                    decision_id="decision",
+                    estimated_remote_tokens_avoided=1,
+                    answer_length_chars=20,
+                ),
+            },
+            passed=("G1-01",),
+            failed=(),
+            skipped=(),
+            criteria_met={"G1-01": True},
+            overall_passed=True,
+        )
+        data = summary.to_json_dict()
+
+        self.assertEqual(set(data), SUMMARY_KEYS)
+        proof.assert_sanitized(data)
+
+    def test_recursive_sanitizer_catches_prohibited_key(self) -> None:
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"nested": {"api_key": "x"}})
+
+    def test_recursive_sanitizer_catches_fake_sensitive_value(self) -> None:
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"safe_key": "FAKE_PROMPT_SHOULD_NOT_APPEAR"})
+
+    async def test_dry_run_criterion_success(self) -> None:
+        result = await proof.run_dry_run_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertEqual(data["latency_ms"], 0.0)
+        proof.assert_sanitized(data)
+
+    async def test_local_chat_criterion_success_with_fake_runner(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertFalse(kwargs.get("use_rag", False))
+            return _fake_result(alias="local_chat", used_rag=False)
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_local_chat_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_chat")
+        proof.assert_sanitized(result.to_json_dict())
+
+    async def test_rag_success_outcome_is_accepted(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertTrue(kwargs.get("use_rag"))
+            return _fake_result(alias="local_rag", used_rag=True)
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_rag_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_rag")
+
+    async def test_rag_fallback_outcome_is_accepted(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertTrue(kwargs.get("use_rag"))
+            return _fake_result(
+                alias="local_chat",
+                used_rag=False,
+                fallback_reason=FallbackReason.QDRANT_UNAVAILABLE,
+            )
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_rag_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_chat")
+        self.assertEqual(result.fallback_reason, "qdrant_unavailable")
+
+    async def test_forced_degradation_uses_fallback_metadata(self) -> None:
+        result = await proof.run_forced_qdrant_degradation_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertEqual(data["used_rag"], False)
+        self.assertIn(
+            data["fallback_reason"],
+            {"qdrant_unavailable", "rag_unavailable"},
+        )
+        proof.assert_sanitized(data)
+
+    async def test_policy_block_verifies_no_model_call(self) -> None:
+        result = await proof.run_policy_block_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["route"], "blocked")
+        self.assertEqual(data["error_category"], "blocked")
+        self.assertEqual(data["model_call_attempted"], False)
+        proof.assert_sanitized(data)
+
+    def test_overall_passed_logic_requires_mandatory_criteria(self) -> None:
+        criteria = {criterion: True for criterion in proof.MANDATORY_CRITERIA}
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+        self.assertTrue(summary.overall_passed)
+
+        criteria["G1-06"] = False
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+        self.assertFalse(summary.overall_passed)
+        self.assertIn("G1-06", summary.failed)
+
+    def test_summary_json_writes_to_tmp_path(self) -> None:
+        criteria = {criterion: True for criterion in proof.MANDATORY_CRITERIA}
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = proof.write_summary(temp_dir, summary)
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(loaded["run_id"], "run")
+        self.assertTrue(loaded["overall_passed"])
+
+    async def test_guard_env_prevents_accidental_runs(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await proof.main_async(["--output-dir", "/tmp/unused"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("opt-in", write_mock.call_args.args[0])
+
+    async def test_main_writes_summary_when_guard_enabled_with_fakes(self) -> None:
+        async def fake_local_chat() -> proof.RunnerSmokeResult:
+            return proof.RunnerSmokeResult(
+                name="local_chat",
+                ok=True,
+                route="local",
+                alias="local_chat",
+                used_rag=False,
+                latency_ms=1.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=1,
+                answer_length_chars=20,
+            )
+
+        async def fake_rag() -> proof.RunnerSmokeResult:
+            return proof.RunnerSmokeResult(
+                name="rag",
+                ok=True,
+                route="local",
+                alias="local_rag",
+                used_rag=True,
+                latency_ms=1.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=1,
+                answer_length_chars=20,
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", return_value=proof.ProbeResult("ollama", True, 1.0)),
+                patch.object(proof, "probe_qdrant", return_value=proof.ProbeResult("qdrant", True, 1.0)),
+                patch.object(proof, "probe_litellm", return_value=proof.ProbeResult("litellm", True, 1.0)),
+                patch.object(proof, "run_local_chat_smoke", fake_local_chat),
+                patch.object(proof, "run_rag_smoke", fake_rag),
+                patch("sys.stdout.write"),
+            ):
+                exit_code = await proof.main_async(["--output-dir", temp_dir])
+
+            self.assertEqual(exit_code, 0)
+            summaries = list(Path(temp_dir).glob("gateway1_proof_of_life_*.json"))
+            self.assertEqual(len(summaries), 1)
+            data = json.loads(summaries[0].read_text(encoding="utf-8"))
+
+        self.assertTrue(data["overall_passed"])
+        proof.assert_sanitized(cast(dict[str, object], data))
+
+
+class GatewayProofOfLifeProbeTests(unittest.TestCase):
+    def test_litellm_probe_reports_missing_aliases(self) -> None:
+        def fake_get(
+            url: str,
+            *,
+            headers: Mapping[str, str],
+            timeout: float,
+        ) -> object:
+            del url, headers, timeout
+
+            class Response:
+                def raise_for_status(self) -> None:
+                    return None
+
+                def json(self) -> dict[str, object]:
+                    return {"data": [{"id": "local_chat"}]}
+
+            return Response()
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.get", fake_get):
+            result = proof.probe_litellm(
+                "http://127.0.0.1:4000/v1",
+                api_key="dev-key",
+            )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_category, "alias_missing")
+        self.assertIn("local_rag", result.missing_aliases)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds GW-20, the final Gateway-1 operational proof-of-life smoke. The new opt-in command validates the local stack as a unit and writes a sanitized structured summary JSON.

```bash
RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
```

Closes #65.

## Scope

Included:

- Gateway-1 done criteria manifest G1-01 through G1-11.
- Local-only URL guards for Ollama, Qdrant and LiteLLM.
- Read-only service probes for Ollama `/api/tags`, Qdrant `/healthz`, and LiteLLM `/v1/models`.
- Agent-0 dry-run validation.
- Live Agent-0 `local_chat` validation.
- Live Agent-0 `--rag` validation accepting either `local_rag` success or explicit GW-17 fallback.
- Deterministic forced Qdrant degradation using runner injection, not by stopping services.
- Policy block check proving no model call occurs.
- Sanitized summary JSON report.
- Offline deterministic unit tests.
- Operator documentation and memory handoff updates.

Excluded:

- Remote providers or remote calls.
- OpenTelemetry, dashboards, Prometheus or Grafana.
- New runtime architecture.
- Qdrant mutation, reindexing or `openclaw_knowledge` access.
- Real portfolio data, real tickers, real companies or real funds.

## Live Proof Result

Completed locally on 2026-05-02 with local services running:

```bash
QUIMERA_LLM_API_KEY=dev-local-key-change-me RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
```

Result: PASSED — 11 passed, 0 failed, 0 skipped.

Summary file:

```text
/tmp/openclaw_gateway1_smoke/gateway1_proof_of_life_9f23ce3df3f2.json
```

Observed live latencies:

| Check | Latency |
|---|---:|
| Ollama probe | 28.6 ms |
| Qdrant probe | 9.4 ms |
| LiteLLM probe | 26.1 ms |
| Agent-0 `local_chat` | 8790.5 ms |
| Agent-0 `local_rag` | 32162.8 ms |
| Forced degradation | 0.03 ms |

## Validation

```bash
git diff --check
uv run python scripts/test_gateway1_proof_of_life.py --help
uv run pytest tests/unit/test_gateway1_proof_of_life.py -v
uv run pytest -v
uv run mypy --strict .
uv run pyright
uv run pytest tests/smoke/ -v
```

Results:

- `uv run pytest tests/unit/test_gateway1_proof_of_life.py -v`: 17 passed.
- `uv run pytest -v`: 315 passed, 7 skipped, 139 subtests passed.
- `uv run mypy --strict .`: OK.
- `uv run pyright`: OK.
- `uv run pytest tests/smoke/ -v`: 5 passed, 7 skipped.

## Security

- No secrets committed.
- No `.env` changes.
- No remote provider enabled.
- No remote calls added.
- Summary stores no answer text, prompt, question, chunks, vectors, payloads, Authorization headers, API keys, raw exceptions or tracebacks.
- Forced degradation does not stop Docker, mutate Qdrant or touch `openclaw_knowledge`.
