### PR TITLE
feat(g2-pr01): RAG segment timing baseline — routing_ms, env contract, uv workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,14 +18,20 @@ QUIMERA_LLM_BASE_URL=
 
 # Model aliases (optional — backend uses hardcoded defaults if absent)
 # Defaults: local_chat / local_think / local_rag / local_json / quimera_embed
-QUIMERA_LLM_MODEL=
-QUIMERA_LLM_REASONING_MODEL=
-QUIMERA_LLM_RAG_MODEL=
-QUIMERA_LLM_JSON_MODEL=
-QUIMERA_LLM_EMBED_MODEL=
+# optional — omitted so code defaults apply
+# QUIMERA_LLM_MODEL=
+# optional — omitted so code defaults apply
+# QUIMERA_LLM_REASONING_MODEL=
+# optional — omitted so code defaults apply
+# QUIMERA_LLM_RAG_MODEL=
+# optional — omitted so code defaults apply
+# QUIMERA_LLM_JSON_MODEL=
+# optional — omitted so code defaults apply
+# QUIMERA_LLM_EMBED_MODEL=
 
 # RAG embedding backend selector (optional — default: gateway)
-QUIMERA_RAG_EMBEDDING_BACKEND=
+# optional — omitted so code defaults apply
+# QUIMERA_RAG_EMBEDDING_BACKEND=
 
 # ─── INFRA — variables used by LiteLLM and local services ────────────
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# ─── OPENCLAW local dev secrets — copy to .env and fill values ───────
+# This file IS committed as a reference template.
+# .env is gitignored and must NEVER be committed.
+#
+# Usage: cp .env.example .env
+#        Set LITELLM_MASTER_KEY and QUIMERA_LLM_API_KEY to the same value.
+#        Run all commands with: uv run --env-file .env <command>
+#        See docs/DEVELOPMENT.md for full setup instructions.
+# ─────────────────────────────────────────────────────────────────────
+
+# ─── BACKEND — variables read directly by Python (backend/) ──────────
+
+# Auth with the LiteLLM gateway — REQUIRED. Must equal LITELLM_MASTER_KEY.
+QUIMERA_LLM_API_KEY=
+
+# Gateway base URL (optional — defaults to http://127.0.0.1:4000/v1)
+QUIMERA_LLM_BASE_URL=
+
+# Model aliases (optional — backend uses hardcoded defaults if absent)
+# Defaults: local_chat / local_think / local_rag / local_json / quimera_embed
+QUIMERA_LLM_MODEL=
+QUIMERA_LLM_REASONING_MODEL=
+QUIMERA_LLM_RAG_MODEL=
+QUIMERA_LLM_JSON_MODEL=
+QUIMERA_LLM_EMBED_MODEL=
+
+# RAG embedding backend selector (optional — default: gateway)
+QUIMERA_RAG_EMBEDDING_BACKEND=
+
+# ─── INFRA — variables used by LiteLLM and local services ────────────
+
+# LiteLLM gateway auth — REQUIRED by start_litellm.sh. Must equal QUIMERA_LLM_API_KEY.
+LITELLM_MASTER_KEY=
+
+# LiteLLM server binding (optional — defaults: 127.0.0.1 / 4000)
+LITELLM_HOST=127.0.0.1
+LITELLM_PORT=4000
+
+# ─── LOCAL SERVICES ───────────────────────────────────────────────────
+
+# Ollama (optional — defaults shown)
+OLLAMA_API_BASE=http://127.0.0.1:11434
+OLLAMA_KEEP_ALIVE=-1
+QWEN_MODEL=qwen3:14b
+EMBED_MODEL=nomic-embed-text
+
+# Qdrant (optional — default: http://127.0.0.1:6333)
+QDRANT_URL=http://127.0.0.1:6333

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ wheels/
 *.egg
 
 # Virtual environments
-.env
 .venv
 env/
 venv/
@@ -44,10 +43,13 @@ build/
 .next/
 .nuxt/
 
-# Environment variables
+# Local secrets — never commit any .env variant
+# Covers: .env, .env.production, .env.staging, .env.test, .env.local, etc.
+# Preserves: .env.example, .env.production.example, etc. (safe templates)
 .env
-.env.local
-.env.*.local
+.env.*
+!.env.example
+!.env.*.example
 
 # IDE
 .vscode/
@@ -63,6 +65,7 @@ logs/*.jsonl
 *.log
 tests/golden/reports/
 reports/gateway1_smoke/
+reports/g2_latency_baseline/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Thumbs.db
 logs/
 logs/*.jsonl
 *.log
+tests/golden/reports/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ logs/
 logs/*.jsonl
 *.log
 tests/golden/reports/
+reports/gateway1_smoke/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -1,0 +1,271 @@
+"""Canonical safe observability signal contracts for Agent-0.
+
+This module is intentionally side-effect free. It defines allowlists used by
+tests and documentation to verify that observability records never serialize
+prompt text, chunks, vectors, payloads or secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+ROUTER_DECISION_KEYS = frozenset(
+    {
+        "decision_id",
+        "route",
+        "reason",
+        "policy_outcome",
+        "task_type",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens",
+        "estimated_remote_tokens_avoided",
+        "timestamp_utc",
+        # Existing routing metadata kept for backward-compatible serializers.
+        "risk_level",
+        "token_budget_class",
+        "remote_allowed",
+        "remote_candidate_provider",
+        "requires_sanitization",
+    }
+)
+
+TOKEN_ECONOMY_RECORD_KEYS = frozenset(
+    {
+        "decision_id",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens_avoided",
+        "local_budget_consumed",
+        "remote_budget_consumed",
+        "timestamp_utc",
+        # Existing token economy metadata kept for backward-compatible
+        # serializers and local audit records.
+        "provider_used",
+        "route",
+        "local_tokens_estimated",
+        "remote_tokens_estimated",
+        "remote_tokens_avoided_estimated",
+        "cost_estimate_mode",
+    }
+)
+
+RAG_RUN_TRACE_KEYS = frozenset(
+    {
+        "decision_id",
+        "query_id",
+        "timestamp_utc",
+        "collection_name",
+        "embedding_backend",
+        "embedding_model",
+        "embedding_alias",
+        "embedding_dimensions",
+        "gateway_alias",
+        "used_rag",
+        "fallback_occurred",
+        "chunk_count",
+        "retrieval_latency_ms",
+        "generation_latency_ms",
+        "total_latency_ms",
+        # Existing safe trace fields.
+        "guard_result",
+        "strict_mode",
+        "prompt_latency_ms",
+        "context_chunk_count",
+    }
+)
+
+FALLBACK_EVENT_KEYS = frozenset(
+    {
+        "event",
+        "event_kind",
+        "decision_id",
+        "fallback_reason",
+        "original_alias",
+        "fallback_alias",
+        "fallback_succeeded",
+        "latency_ms",
+        "status",
+        "timestamp_utc",
+    }
+)
+
+DECISION_LOG_KEYS = frozenset(
+    {
+        "decision_id",
+        "route",
+        "reason",
+        "policy_outcome",
+        "estimated_remote_tokens_avoided",
+        "timestamp_utc",
+        # Existing RoutingDecisionLogger compatibility fields.
+        "risk_level",
+        "token_budget_class",
+        "remote_allowed",
+        "remote_candidate_provider",
+        "requires_sanitization",
+        "task_type",
+        "estimated_prompt_tokens",
+        "estimated_completion_tokens",
+        "estimated_remote_tokens",
+    }
+)
+
+AGENT_RUN_RESULT_KEYS = frozenset(
+    {
+        "answer",
+        "route",
+        "alias",
+        "used_rag",
+        "latency_ms",
+        "decision_id",
+        "estimated_remote_tokens_avoided",
+        "error_category",
+        "fallback_applied",
+        "fallback_from_alias",
+        "fallback_to_alias",
+        "fallback_reason",
+        "fallback_chain",
+        "block_reason",
+    }
+)
+
+GOLDEN_RESULT_KEYS = frozenset(
+    {
+        "question_id",
+        "domain",
+        "mode",
+        "route",
+        "alias",
+        "used_rag",
+        "latency_ms",
+        "decision_id",
+        "estimated_remote_tokens_avoided",
+        "answer_length_chars",
+        "error_category",
+        "fallback_applied",
+        "fallback_reason",
+        "quality_score",
+        "skipped",
+        "skipped_reason",
+    }
+)
+
+GOLDEN_SUMMARY_KEYS = frozenset(
+    {
+        "run_id",
+        "timestamp_utc",
+        "total_questions",
+        "passed",
+        "failed",
+        "skipped",
+        "fallback_count",
+        "mean_latency_ms_by_alias",
+        "p95_latency_ms_by_alias",
+        "total_estimated_remote_tokens_avoided",
+        "quality_score_present",
+        "model_under_test_aliases",
+    }
+)
+
+PROHIBITED_SIGNAL_KEYS = frozenset(
+    {
+        "prompt",
+        "system_prompt",
+        "user_prompt",
+        "query",
+        "question",
+        "raw_user_input",
+        "input_text",
+        "chunks",
+        "chunk",
+        "chunk_text",
+        "retrieved_context",
+        "context_text",
+        "vectors",
+        "vector",
+        "embeddings",
+        "embedding",
+        "payload",
+        "qdrant_payload",
+        "api_key",
+        "authorization",
+        "headers",
+        "secret",
+        "password",
+        "raw_response",
+        "raw_exception",
+        "exception_message",
+        "traceback",
+        "model_weights_path",
+        "weights_path",
+    }
+)
+
+SAFE_ROUTER_REASON_VALUES = frozenset(
+    {
+        "budget_exceeded",
+        "remote_disabled",
+        "sensitive_context",
+        "unsupported_task",
+        "policy_denied",
+        "unknown",
+        # Existing deterministic local policy outcomes.
+        "local_first_default",
+        "remote_candidate_policy_match",
+    }
+)
+
+SAFE_FALLBACK_REASON_VALUES = frozenset(
+    {
+        "qdrant_unavailable",
+        "rag_unavailable",
+        "think_timeout",
+        "alias_unavailable",
+        "budget_exceeded",
+        "unsupported_task",
+        "fallback_alias_failed",
+        "unknown_local_failure",
+    }
+)
+
+
+def assert_signal_allowlisted(
+    signal: Mapping[str, object],
+    *,
+    allowlist: frozenset[str],
+    signal_name: str,
+) -> None:
+    """Raise ``AssertionError`` if a signal violates its allowlist."""
+    keys = frozenset(signal)
+    extra_keys = keys - allowlist
+    if extra_keys:
+        raise AssertionError(
+            f"{signal_name} contains non-allowlisted keys: {sorted(extra_keys)}"
+        )
+    prohibited = {key for key in keys if key.lower() in PROHIBITED_SIGNAL_KEYS}
+    if prohibited:
+        raise AssertionError(
+            f"{signal_name} contains prohibited keys: {sorted(prohibited)}"
+        )
+
+
+def token_economy_canonical_signal(
+    record: Mapping[str, object],
+) -> dict[str, object]:
+    """Project existing token economy metadata into canonical GW-19 fields."""
+    signal: dict[str, object] = {}
+    if "decision_id" in record:
+        signal["decision_id"] = record["decision_id"]
+    if "timestamp_utc" in record:
+        signal["timestamp_utc"] = record["timestamp_utc"]
+    if "remote_tokens_avoided_estimated" in record:
+        signal["estimated_remote_tokens_avoided"] = record[
+            "remote_tokens_avoided_estimated"
+        ]
+    if "local_tokens_estimated" in record:
+        signal["local_budget_consumed"] = record["local_tokens_estimated"]
+    if "remote_tokens_estimated" in record:
+        signal["remote_budget_consumed"] = record["remote_tokens_estimated"]
+    return signal

--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -73,6 +73,22 @@ RAG_RUN_TRACE_KEYS = frozenset(
         "strict_mode",
         "prompt_latency_ms",
         "context_chunk_count",
+        # Gateway-2 per-segment latency baseline fields.
+        "routing_ms",
+        "embedding_ms",
+        "retrieval_ms",
+        "context_pack_ms",
+        "prompt_build_ms",
+        "generation_ms",
+        "total_ms",
+        "run_context",
+        "ollama_metrics_available",
+        "ollama_total_duration_ms",
+        "ollama_load_duration_ms",
+        "ollama_prompt_eval_count",
+        "ollama_prompt_eval_duration_ms",
+        "ollama_eval_count",
+        "ollama_eval_duration_ms",
     }
 )
 

--- a/backend/gateway/routing_policy.py
+++ b/backend/gateway/routing_policy.py
@@ -45,6 +45,19 @@ class RouteBlockReason(str, Enum):
     UNKNOWN = "unknown"
 
 
+class FallbackReason(str, Enum):
+    """Safe local fallback reasons for Agent-0 degradation."""
+
+    QDRANT_UNAVAILABLE = "qdrant_unavailable"
+    RAG_UNAVAILABLE = "rag_unavailable"
+    THINK_TIMEOUT = "think_timeout"
+    ALIAS_UNAVAILABLE = "alias_unavailable"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    UNSUPPORTED_TASK = "unsupported_task"
+    FALLBACK_ALIAS_FAILED = "fallback_alias_failed"
+    UNKNOWN_LOCAL_FAILURE = "unknown_local_failure"
+
+
 class TaskRiskLevel(str, Enum):
     """Coarse task risk levels used by routing policy."""
 

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -24,6 +24,7 @@ from backend.rag.observability import (
     utc_now_iso,
 )
 from backend.rag.run_trace import (
+    RagRunContext,
     RagTracingConfig,
     build_rag_run_trace,
     load_rag_tracing_config,
@@ -96,6 +97,7 @@ class LocalRagPipeline:
         question: str,
         top_k: int | None = None,
         filters: Mapping[str, Any] | None = None,
+        run_context: RagRunContext | None = None,
     ) -> RagPipelineResult:
         """Run retrieval, build a prompt, and generate a local answer."""
 
@@ -210,6 +212,7 @@ class LocalRagPipeline:
             total_ms=latency["total_ms"],
             chunk_count=len(chunks),
             query_id=query_id,
+            run_context=run_context,
         )
         return RagPipelineResult(
             question=clean_question,
@@ -232,6 +235,7 @@ class LocalRagPipeline:
         chunk_count: int,
         query_id: str | None = None,
         actual_embedding_dimensions: int | None = None,
+        run_context: RagRunContext | None = None,
     ) -> None:
         """Emit a RagRunTrace provenance record via loguru.
 
@@ -277,6 +281,7 @@ class LocalRagPipeline:
             prompt_build_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=total_ms,
+            run_context=run_context,
         )
         logger.bind(trace=trace.to_log_dict()).log(config.log_level, "rag_run_trace")
 

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -270,7 +270,7 @@ class LocalRagPipeline:
             total_latency_ms=total_ms,
             prompt_latency_ms=prompt_ms,
             context_chunk_count=chunk_count,
-            routing_ms=0.0,
+            routing_ms=None,
             embedding_ms=embedding_ms,
             retrieval_ms=vector_search_ms,
             context_pack_ms=context_pack_ms,

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -131,6 +131,7 @@ class LocalRagPipeline:
             )
             raise
         retrieval_ms = _elapsed_ms(retrieval_start)
+        retrieval_segments = _extract_retrieval_segments(self.retriever)
         self._emit_pipeline_event(
             RagEventKind.RETRIEVAL_FINISHED,
             query_id=query_id,
@@ -201,6 +202,9 @@ class LocalRagPipeline:
         )
         self._emit_trace(
             retrieval_ms=retrieval_ms,
+            embedding_ms=retrieval_segments.embedding_ms,
+            vector_search_ms=retrieval_segments.retrieval_ms,
+            context_pack_ms=retrieval_segments.context_pack_ms,
             prompt_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=latency["total_ms"],
@@ -219,6 +223,9 @@ class LocalRagPipeline:
         self,
         *,
         retrieval_ms: float,
+        embedding_ms: float | None = None,
+        vector_search_ms: float | None = None,
+        context_pack_ms: float | None = None,
         prompt_ms: float,
         generation_ms: float,
         total_ms: float,
@@ -263,6 +270,13 @@ class LocalRagPipeline:
             total_latency_ms=total_ms,
             prompt_latency_ms=prompt_ms,
             context_chunk_count=chunk_count,
+            routing_ms=0.0,
+            embedding_ms=embedding_ms,
+            retrieval_ms=vector_search_ms,
+            context_pack_ms=context_pack_ms,
+            prompt_build_ms=prompt_ms,
+            generation_ms=generation_ms,
+            total_ms=total_ms,
         )
         logger.bind(trace=trace.to_log_dict()).log(config.log_level, "rag_run_trace")
 
@@ -317,6 +331,31 @@ def _infer_gateway_alias(generator: object) -> str | None:
     if isinstance(model, str) and model.strip():
         return model.strip()
     return None
+
+
+@dataclass(frozen=True)
+class _RetrievalSegments:
+    embedding_ms: float | None
+    retrieval_ms: float | None
+    context_pack_ms: float | None
+
+
+def _extract_retrieval_segments(retriever: object) -> _RetrievalSegments:
+    timings = getattr(retriever, "last_timings", None)
+    embed_ms = getattr(timings, "embed_ms", None)
+    search_ms = getattr(timings, "search_ms", None)
+    pack_ms = getattr(timings, "pack_ms", None)
+    return _RetrievalSegments(
+        embedding_ms=_optional_timing(embed_ms),
+        retrieval_ms=_optional_timing(search_ms),
+        context_pack_ms=_optional_timing(pack_ms),
+    )
+
+
+def _optional_timing(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
 
 
 def _elapsed_ms(start: float) -> float:

--- a/backend/rag/run_trace.py
+++ b/backend/rag/run_trace.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 import yaml
@@ -32,6 +32,9 @@ SAFE_GUARD_RESULT_KEYS = frozenset(
         "alias_matches",
     }
 )
+RUN_CONTEXTS = frozenset({"cold_start", "warm_model", "degraded_qdrant"})
+
+RagRunContext = Literal["cold_start", "warm_model", "degraded_qdrant"]
 
 
 @dataclass(frozen=True)
@@ -105,6 +108,21 @@ class RagRunTrace:
     total_latency_ms: float | None = None
     prompt_latency_ms: float | None = None
     context_chunk_count: int | None = None
+    routing_ms: float | None = None
+    embedding_ms: float | None = None
+    retrieval_ms: float | None = None
+    context_pack_ms: float | None = None
+    prompt_build_ms: float | None = None
+    generation_ms: float | None = None
+    total_ms: float | None = None
+    run_context: RagRunContext | None = None
+    ollama_metrics_available: bool = False
+    ollama_total_duration_ms: float | None = None
+    ollama_load_duration_ms: float | None = None
+    ollama_prompt_eval_count: int | None = None
+    ollama_prompt_eval_duration_ms: float | None = None
+    ollama_eval_count: int | None = None
+    ollama_eval_duration_ms: float | None = None
 
     def __post_init__(self) -> None:
         _validate_non_empty(self.query_id, "query_id")
@@ -134,6 +152,47 @@ class RagRunTrace:
                 self.context_chunk_count,
                 "context_chunk_count",
             )
+        for field_name in (
+            "routing_ms",
+            "embedding_ms",
+            "retrieval_ms",
+            "context_pack_ms",
+            "prompt_build_ms",
+            "generation_ms",
+            "total_ms",
+            "ollama_total_duration_ms",
+            "ollama_load_duration_ms",
+            "ollama_prompt_eval_duration_ms",
+            "ollama_eval_duration_ms",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                _validate_non_negative_float(value, field_name)
+        for field_name in (
+            "ollama_prompt_eval_count",
+            "ollama_eval_count",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                _validate_non_negative_int(value, field_name)
+        if self.run_context is not None and self.run_context not in RUN_CONTEXTS:
+            raise ValueError(
+                f"run_context must be one of {sorted(RUN_CONTEXTS)}"
+            )
+        if self.ollama_metrics_available and not any(
+            value is not None
+            for value in (
+                self.ollama_total_duration_ms,
+                self.ollama_load_duration_ms,
+                self.ollama_prompt_eval_count,
+                self.ollama_prompt_eval_duration_ms,
+                self.ollama_eval_count,
+                self.ollama_eval_duration_ms,
+            )
+        ):
+            raise ValueError(
+                "ollama_metrics_available cannot be true without metric fields"
+            )
         if self.guard_result is not None:
             _summarize_guard_result(self.guard_result)
 
@@ -162,6 +221,26 @@ class RagRunTrace:
             values["prompt_latency_ms"] = self.prompt_latency_ms
         if self.context_chunk_count is not None:
             values["context_chunk_count"] = self.context_chunk_count
+        optional_segment_values: dict[str, object | None] = {
+            "routing_ms": self.routing_ms,
+            "embedding_ms": self.embedding_ms,
+            "retrieval_ms": self.retrieval_ms,
+            "context_pack_ms": self.context_pack_ms,
+            "prompt_build_ms": self.prompt_build_ms,
+            "generation_ms": self.generation_ms,
+            "total_ms": self.total_ms,
+            "run_context": self.run_context,
+            "ollama_total_duration_ms": self.ollama_total_duration_ms,
+            "ollama_load_duration_ms": self.ollama_load_duration_ms,
+            "ollama_prompt_eval_count": self.ollama_prompt_eval_count,
+            "ollama_prompt_eval_duration_ms": self.ollama_prompt_eval_duration_ms,
+            "ollama_eval_count": self.ollama_eval_count,
+            "ollama_eval_duration_ms": self.ollama_eval_duration_ms,
+        }
+        values["ollama_metrics_available"] = self.ollama_metrics_available
+        for key, value in optional_segment_values.items():
+            if value is not None:
+                values[key] = value
         return values
 
 
@@ -184,12 +263,22 @@ def build_rag_run_trace(
     total_latency_ms: float | None = None,
     prompt_latency_ms: float | None = None,
     context_chunk_count: int | None = None,
+    routing_ms: float | None = None,
+    embedding_ms: float | None = None,
+    retrieval_ms: float | None = None,
+    context_pack_ms: float | None = None,
+    prompt_build_ms: float | None = None,
+    generation_ms: float | None = None,
+    total_ms: float | None = None,
+    run_context: RagRunContext | None = None,
+    ollama_metrics: Mapping[str, object] | None = None,
 ) -> RagRunTrace:
     """Build a validated safe RAG provenance trace."""
     if embedding_dimensions != expected_dimensions:
         raise EmbeddingDimensionMismatchError(
             "RAG trace embedding dimensions do not match active configuration."
         )
+    safe_ollama_metrics = extract_ollama_metrics(ollama_metrics)
     return RagRunTrace(
         query_id=query_id or uuid4().hex,
         timestamp_utc=timestamp_utc or _utc_now_iso(),
@@ -207,7 +296,90 @@ def build_rag_run_trace(
         total_latency_ms=total_latency_ms,
         prompt_latency_ms=prompt_latency_ms,
         context_chunk_count=context_chunk_count,
+        routing_ms=routing_ms,
+        embedding_ms=embedding_ms,
+        retrieval_ms=retrieval_ms,
+        context_pack_ms=context_pack_ms,
+        prompt_build_ms=prompt_build_ms,
+        generation_ms=generation_ms,
+        total_ms=total_ms,
+        run_context=run_context,
+        ollama_metrics_available=bool(
+            safe_ollama_metrics["ollama_metrics_available"]
+        ),
+        ollama_total_duration_ms=_optional_float_metric(
+            safe_ollama_metrics,
+            "ollama_total_duration_ms",
+        ),
+        ollama_load_duration_ms=_optional_float_metric(
+            safe_ollama_metrics,
+            "ollama_load_duration_ms",
+        ),
+        ollama_prompt_eval_count=_optional_int_metric(
+            safe_ollama_metrics,
+            "ollama_prompt_eval_count",
+        ),
+        ollama_prompt_eval_duration_ms=_optional_float_metric(
+            safe_ollama_metrics,
+            "ollama_prompt_eval_duration_ms",
+        ),
+        ollama_eval_count=_optional_int_metric(
+            safe_ollama_metrics,
+            "ollama_eval_count",
+        ),
+        ollama_eval_duration_ms=_optional_float_metric(
+            safe_ollama_metrics,
+            "ollama_eval_duration_ms",
+        ),
     )
+
+
+def extract_ollama_metrics(metadata: Mapping[str, object] | None) -> dict[str, object]:
+    """Extract safe Ollama timing/count metrics from already available metadata.
+
+    Durations from Ollama are nanoseconds; trace fields store milliseconds.
+    The function never calls Ollama and never inspects prompt or answer text.
+    """
+    if metadata is None:
+        return {"ollama_metrics_available": False}
+    metrics: dict[str, object] = {}
+    duration_fields = {
+        "total_duration": "ollama_total_duration_ms",
+        "load_duration": "ollama_load_duration_ms",
+        "prompt_eval_duration": "ollama_prompt_eval_duration_ms",
+        "eval_duration": "ollama_eval_duration_ms",
+    }
+    count_fields = {
+        "prompt_eval_count": "ollama_prompt_eval_count",
+        "eval_count": "ollama_eval_count",
+    }
+    for source_key, target_key in duration_fields.items():
+        value = metadata.get(source_key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            metrics[target_key] = float(value) / 1_000_000.0
+    for source_key, target_key in count_fields.items():
+        value = metadata.get(source_key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            metrics[target_key] = value
+    metrics["ollama_metrics_available"] = bool(metrics)
+    return metrics
+
+
+def _optional_float_metric(
+    metrics: Mapping[str, object],
+    key: str,
+) -> float | None:
+    value = metrics.get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _optional_int_metric(metrics: Mapping[str, object], key: str) -> int | None:
+    value = metrics.get(key)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
 
 
 def load_rag_tracing_config(

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -663,3 +663,66 @@ Append or paste this at the end of substantial sessions:
 ### Risks
 - Live readiness (`--live`) not run in this shell — requires `LITELLM_MASTER_KEY` export and local services running.
 - None known for static validation.
+
+---
+
+## Handoff — 2026-05-02
+
+**Agent:** Codex
+**Branch:** `feat/gateway1-proof-of-life-smoke`
+**Issue/PR:** #65 / pending PR
+**Task:** GW-20 — Gateway-1 operational proof-of-life smoke.
+
+### Changed
+- `docs/sprints/GATEWAY1_DONE_CRITERIA.md`: fixed G1-01 through G1-11
+  done criteria for Gateway-1.
+- `scripts/test_gateway1_proof_of_life.py`: opt-in proof-of-life smoke with
+  local URL guards, Ollama/Qdrant/LiteLLM probes, Agent-0 dry-run/live checks,
+  forced Qdrant degradation, policy block validation and sanitized summary JSON.
+- `tests/unit/test_gateway1_proof_of_life.py`: 17 offline deterministic tests
+  for URL guards, serialization allowlists, sanitizer, criteria logic, forced
+  degradation, policy block and summary writing.
+- `docs/AGENT0_SMOKE.md`, `docs/AGENT0_LOCAL_RUNNER.md`,
+  `docs/AGENT0_OBSERVABILITY.md`, `docs/sprints/GATEWAY1_SPRINT_HANDOFF.md`:
+  operator docs and handoff updates.
+- `.gitignore`: ignores `reports/gateway1_smoke/`.
+
+### Validation
+- `git diff --check` — passed.
+- `uv run python scripts/test_gateway1_proof_of_life.py --help` — passed.
+- `uv run pytest tests/unit/test_gateway1_proof_of_life.py -v` — 17 passed.
+- `uv run pytest -v` — 315 passed, 7 skipped, 139 subtests passed.
+- `uv run mypy --strict .` — 0 errors.
+- `uv run pyright` — 0 errors.
+- `uv run pytest tests/smoke/ -v` — 5 passed, 7 skipped.
+- Live proof with local key:
+  `QUIMERA_LLM_API_KEY=dev-local-key-change-me RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke`
+  — **passed**, 11 criteria passed, 0 failed, 0 skipped.
+
+### Live Summary
+- Summary file:
+  `/tmp/openclaw_gateway1_smoke/gateway1_proof_of_life_9f23ce3df3f2.json`.
+- Ollama/Qdrant/LiteLLM probes: OK.
+- Agent-0 `local_chat`: OK.
+- Agent-0 `local_rag`: OK.
+- Forced degradation: `qdrant_unavailable` fallback to `local_chat`.
+- Policy block: no model call.
+
+### Not Changed
+- No remote providers, remote API keys or remote aliases.
+- No Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- No real portfolio data, real tickers, real companies or real funds.
+- No runtime behavior change in Agent-0 beyond calling existing public APIs.
+- No OpenTelemetry, dashboards, Prometheus, Grafana, FastAPI, MCP or new
+  runtime architecture.
+
+### Next Action
+- Open PR for GW-20 with title
+  `test(gateway): add Gateway-1 proof-of-life smoke`.
+- After merge, Gateway-1 can be considered operationally ready for Gateway-2
+  planning.
+
+### Risks
+- Proof-of-life requires local services plus `QUIMERA_LLM_API_KEY` for full
+  pass. Without the key, the summary is still written but G1-05 fails as
+  `authentication`.

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -207,7 +207,8 @@ task metadata + token estimates
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | 🚧 Current |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | 🚧 Current |
 
 GW-13 rules:
 
@@ -235,7 +236,11 @@ GW-15 rules:
 - Fallback reason codes are enum-derived and metadata-only.
 - `local_think` timeout fallback is deferred until Agent-0 has a public think
   path.
-- Golden questions harness is deferred to GW-18.
+- GW-18 adds the golden question harness:
+  `tests/golden/questions.yaml`, `scripts/run_golden_harness.py`, and
+  `scripts/compare_golden_runs.py`.
+- Golden harness reports are opt-in, local-only, synthetic-only, and omit answer
+  text by default.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -726,3 +726,54 @@ Append or paste this at the end of substantial sessions:
 - Proof-of-life requires local services plus `QUIMERA_LLM_API_KEY` for full
   pass. Without the key, the summary is still written but G1-05 fails as
   `authentication`.
+
+---
+
+## Handoff — 2026-05-02
+
+**Agent:** Codex
+**Branch:** `feat/g2-rag-segment-timing-baseline`
+**Issue/PR:** #67 / pending PR
+**Task:** G2-01 — RAG per-segment latency baseline.
+
+### Changed
+- `backend/rag/run_trace.py`: optional segment fields on `RagRunTrace`,
+  validated `run_context`, safe Ollama metric extraction/conversion from
+  already-available metadata only.
+- `backend/rag/pipeline.py`: populates trace segment timings from existing
+  pipeline timers and `Retriever.last_timings`; `routing_ms` is `0.0` for
+  direct `LocalRagPipeline` because Agent routing lives outside the pipeline.
+- `backend/gateway/observability_contract.py`: allowlist extended for G2
+  trace fields.
+- `tests/unit/test_rag_run_trace.py`: optional field, serialization,
+  total-directness, Ollama metric, degraded context, and pipeline trace tests.
+- `tests/unit/test_retriever.py`: separate embed/search/pack timing test.
+- `docs/RAG_LATENCY_BASELINE.md`, `docs/RAG_RUN_TRACE.md`: segment boundary
+  contract and LiteLLM/Ollama metric limitation.
+- `tests/unit/test_gateway1_proof_of_life.py`: tiny typing-only fix for
+  existing mypy/pyright compatibility.
+
+### Validation
+- `git diff --check` — passed.
+- `uv run pytest tests/unit/test_rag_run_trace.py -v` — 23 passed.
+- `uv run pytest tests/unit/test_rag_observability_event.py -v` — 8 passed.
+- `uv run pytest tests/unit/test_rag_pipeline.py -v` — not applicable; file
+  does not exist in this branch. Used `tests/unit/test_rag_pipeline_observability.py`.
+- `uv run pytest tests/unit/test_rag_pipeline_observability.py -v` — 2 passed.
+- `uv run pytest tests/unit/test_retriever.py -v` — 6 passed.
+- `uv run pytest tests/unit/test_run_local_agent.py -v` — 32 passed.
+- `uv run pytest tests/unit/test_golden_harness.py -v` — 8 passed.
+- `uv run pytest -v` — 332 passed, 7 skipped, 139 subtests passed.
+- `uv run mypy --strict .` — 0 errors.
+- `uv run pyright` — 0 errors.
+
+### Not Changed
+- No prompt text, top-k, retrieval defaults, context packing, aliases, timeouts,
+  LiteLLM/Ollama/Qdrant config, or fallback behavior changed.
+- No Qdrant mutation, no reindex, no `openclaw_knowledge` access.
+- No remote providers, OpenTelemetry, dashboards, profiling framework or new
+  dependencies.
+
+### Deferred
+- `scripts/run_rag_latency_baseline.py` and the formal 3-run
+  cold/warm/degraded report are deferred to G2-02.

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -130,8 +130,6 @@ Gateway-1 routing policy defaults:
 | `gateway.routing.default_route` | `local` | Local-first baseline |
 | `gateway.routing.allowed_remote_providers` | `[]` | Empty until future ADR |
 | `gateway.routing.per_request_token_limit` | `0` | No budget gate enforced yet |
-| `gateway.routing.decision_log_path` | `logs/routing_decisions` | Local JSONL audit base path |
-| `gateway.routing.blocked_task_types` | `trade_execution`, `brokerage_login` | Config-driven local blocks |
 
 ---
 
@@ -206,12 +204,8 @@ task metadata + token estimates
 | PR | Branch | Scope | Status |
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
-<<<<<<< HEAD
-| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | 🚧 Current |
-=======
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | 🚧 Current |
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 GW-13 rules:
 
@@ -221,15 +215,6 @@ GW-13 rules:
 - No runtime model routing change.
 - No Qdrant mutation or `openclaw_knowledge` access.
 
-<<<<<<< HEAD
-GW-14 rules:
-
-- Config-driven routing audit and token economy calibration.
-- Local JSONL audit records, heuristic token estimation, in-memory token budget accumulation.
-- Policy artifacts only — not billing, not runtime routing.
-- `remote_enabled` remains false. `allowed_remote_providers` remains empty.
-- No remote calls, no runtime routing change, no Qdrant mutation.
-=======
 GW-15 rules:
 
 - `scripts/run_local_agent.py` is a local CLI, not an API, daemon,
@@ -242,7 +227,6 @@ GW-15 rules:
   raw responses, secrets or Authorization headers.
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -205,7 +205,8 @@ task metadata + token estimates
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | 🚧 Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | 🚧 Current |
 
 GW-13 rules:
 
@@ -225,8 +226,10 @@ GW-15 rules:
 - `--dry-run` must work without live services.
 - Output metadata must not include question, prompt, chunks, vectors, payloads,
   raw responses, secrets or Authorization headers.
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- GW-16 hardens contracts only: alias matrix, output schema, blocked/dry-run,
+  degraded states, parse/render boundaries and no-fallback assertions.
+- Progressive fallback is deferred to GW-17.
+- Golden questions harness is deferred to GW-18.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -205,8 +205,9 @@ task metadata + token estimates
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | 🚧 Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | 🚧 Current |
 
 GW-13 rules:
 
@@ -228,7 +229,12 @@ GW-15 rules:
   raw responses, secrets or Authorization headers.
 - GW-16 hardens contracts only: alias matrix, output schema, blocked/dry-run,
   degraded states, parse/render boundaries and no-fallback assertions.
-- Progressive fallback is deferred to GW-17.
+- GW-17 adds explicit local-only fail-safe degradation:
+  `local_rag`/RAG infrastructure failure can fallback once to `local_chat`;
+  policy blocks never fallback.
+- Fallback reason codes are enum-derived and metadata-only.
+- `local_think` timeout fallback is deferred until Agent-0 has a public think
+  path.
 - Golden questions harness is deferred to GW-18.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -208,7 +208,8 @@ task metadata + token estimates
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
 | GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | 🚧 Current |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | 🚧 Current |
 
 GW-13 rules:
 
@@ -241,6 +242,11 @@ GW-15 rules:
   `scripts/compare_golden_runs.py`.
 - Golden harness reports are opt-in, local-only, synthetic-only, and omit answer
   text by default.
+- GW-19 adds offline observability signal contract tests for `RouterDecision`,
+  `TokenEconomyRecord`, `RagRunTrace`, fallback events and decision logs.
+- GW-19 uses allowlists to enforce no prompt, raw input, chunks, vectors,
+  payloads, headers, API keys, raw exceptions or model weight paths in signal
+  keys.
 
 **Gateway-0 final baseline:** local-only LiteLLM gateway, Qdrant vector store,
 `quimera_embed` canonical embedding alias, `RagRunTrace` provenance,

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,22 +5,22 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-02
-**Updated by:** Codex — Agent-0 GW-18 golden question harness
+**Updated by:** Codex — Agent-0 GW-19 observability signal contract
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add the Agent-0 golden question benchmark harness: fixed synthetic
-financial-domain questions, offline dry-run reports, and summary comparison
-tools for future regression checks.
+**Goal:** verify Agent-0 observability signal completeness and sanitization
+with deterministic offline tests for routing, token economy, RAG trace,
+fallback and decision-log records.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
-GW-18 branch: `feat/agent0-golden-question-harness`
+GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
+GW-19 branch: `feat/agent0-observability-signal-contract`
 
 Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
 hardening branch present, but the GW-16 commit was not on `origin/main`.
@@ -28,6 +28,8 @@ GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
 should be retargeted/rebased after GW-16 is integrated.
 GW-18 was implemented as a stacked branch on GW-17 for the same reason and
 should be retargeted/rebased after GW-16/GW-17 are integrated.
+GW-19 was implemented as a stacked branch on the GW-18 integration branch and
+should be retargeted/rebased after GW-16/GW-17/GW-18 are integrated.
 
 Current runtime path:
 
@@ -127,7 +129,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
 | GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Current |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -143,6 +146,7 @@ GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
 GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
+GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -241,6 +245,35 @@ Rules:
 - Optional human scoring helper is deferred to a future issue.
 - No remote providers, no remote calls, no Qdrant mutation, no real data, and
   no live services required for unit tests.
+
+## GW-19 Current Work
+
+GW-19 adds the Agent-0 observability signal contract.
+
+Deliverables:
+
+- `backend/gateway/observability_contract.py` with canonical allowlists and
+  prohibited signal keys.
+- `tests/unit/test_observability_signal_contract.py` for RouterDecision,
+  TokenEconomyRecord, RagRunTrace, fallback events, decision logs, Agent-0
+  output and golden harness dry-run reports.
+- `docs/AGENT0_OBSERVABILITY.md`.
+- GW-18 NB fixes:
+  - golden harness uses `estimate_prompt_tokens` directly from
+    `backend.gateway.routing_policy`;
+  - `GoldenResult` rejects `skipped=True` with `error_category`.
+
+Rules:
+
+- Sanitization is enforced with allowlists, not blocklist-only checks.
+- Fallback event `decision_id` must correlate with Agent-0 output.
+- `estimated_remote_tokens_avoided` is checked across success, dry-run,
+  blocked, fallback success and fallback failure paths.
+- No prompt, raw user input, chunks, vectors, payloads, headers, API keys, raw
+  exceptions or model weight paths may appear in observability keys.
+- No runtime routing behavior, fallback behavior or remote provider behavior is
+  changed.
+- No live LiteLLM/Ollama/Qdrant services are required for tests.
 
 ## GW-13 Completed Work
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,27 +5,12 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-<<<<<<< HEAD
-**Updated by:** Codex — Gateway GW-14 routing audit and token economy
-=======
 **Updated by:** Codex — Agent-0 GW-15 local runner
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-<<<<<<< HEAD
-**Goal:** add safe, offline local-first routing decision primitives and token
-economy records for future routing policy work. Remote providers remain
-disabled and no runtime model routing changes are made in Gateway-1 policy
-work.
-
-Gateway-0 is complete on `main`. Gateway-1 started from issue
-[#51](https://github.com/franciscosalido/OPENCLAW/issues/51). GW-14 continues
-from issue [#53](https://github.com/franciscosalido/OPENCLAW/issues/53) on
-branch `feat/gateway1-routing-audit-token-economy`.
-=======
 **Goal:** add the first local MVP CLI entrypoint for one question, one routing
 decision, one local-only execution path and safe metadata output.
 
@@ -35,7 +20,6 @@ GW-14 token/config helpers are not present on `main`.
 
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-15 branch: `feat/agent0-local-runner`
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 Current runtime path:
 
@@ -131,12 +115,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
-<<<<<<< HEAD
-| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Current |
-=======
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Current |
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -148,18 +128,12 @@ GW-10 issue: <https://github.com/franciscosalido/OPENCLAW/issues/44>
 GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
-<<<<<<< HEAD
-GW-14 issue: <https://github.com/franciscosalido/OPENCLAW/issues/53>
-=======
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
 
-<<<<<<< HEAD
-=======
 ## GW-15 Current Work
 
 GW-15 creates Agent-0, the first local MVP runner:
@@ -190,7 +164,6 @@ Rules:
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
 
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)
 ## GW-13 Completed Work
 
 GW-13 opens Gateway-1 with safe routing policy records only.
@@ -215,29 +188,6 @@ Rules:
 - No Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge` access.
 - Token economy is estimated only, not billed.
 - Remote escalation requires future sanitization and an explicit Accepted ADR.
-
-## GW-14 Current Work
-
-GW-14 connects Gateway-1 routing primitives to config and local audit records.
-
-Deliverables:
-
-- `load_routing_policy()` reads `gateway.routing` from `config/rag_config.yaml`.
-- `estimate_prompt_tokens()` adds heuristic token estimation without a
-  tokenizer dependency.
-- `TokenBudgetAccumulator` tracks session-local estimates in memory only.
-- `RoutingDecisionLogger` writes safe append-only JSONL audit records under
-  `logs/`.
-- `RouterDecision.decision_fingerprint()` hashes safe policy-relevant fields.
-- Task type blocking/allowing is config-driven.
-
-Rules:
-
-- `remote_enabled` remains false.
-- `allowed_remote_providers` remains empty.
-- No remote calls, no remote provider API keys, no runtime routing change.
-- JSONL audit files are local artifacts and must not be committed.
-- Local fallback on timeout and health-aware routing are deferred.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -648,3 +648,60 @@ Out of scope:
 - OpenTelemetry, Prometheus, Grafana, dashboards, distributed tracing,
   profiling, soak tests, and memory/resource baselines.
 - Memory/resource baseline: not implemented in GW-12. Deferred to a future sprint. See ADR-0019 Future Work section.
+
+## GW-20 Completed Work
+
+GW-20 adds the Gateway-1 operational proof-of-life smoke and closes the
+Gateway-1 readiness loop before Gateway-2:
+
+```text
+dry-run Agent-0
+  -> local URL guard
+  -> Ollama/Qdrant/LiteLLM probes
+  -> live local_chat
+  -> live local_rag or explicit fallback
+  -> forced Qdrant degradation
+  -> policy block no-model-call check
+  -> sanitized summary JSON
+```
+
+Key files:
+
+- `docs/sprints/GATEWAY1_DONE_CRITERIA.md`
+- `scripts/test_gateway1_proof_of_life.py`
+- `docs/AGENT0_SMOKE.md`
+- `tests/unit/test_gateway1_proof_of_life.py`
+
+Rules:
+
+- The smoke is opt-in with `RUN_GATEWAY1_PROOF_OF_LIFE=1`.
+- Live probes refuse non-local service URLs.
+- Summary reports do not store answer text, prompts, questions, chunks,
+  vectors, payloads, secrets, Authorization headers, raw exceptions or
+  tracebacks.
+- Forced degradation is injected through Agent-0 hooks; it does not stop Docker,
+  mutate Qdrant, reindex, or touch `openclaw_knowledge`.
+- Gateway-2 should not begin until GW-20 passes locally.
+
+Live proof result on 2026-05-02:
+
+- Command:
+  `QUIMERA_LLM_API_KEY=dev-local-key-change-me RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke`
+- Result: **PASSED** — G1-01 through G1-11 all true.
+- Summary: `/tmp/openclaw_gateway1_smoke/gateway1_proof_of_life_9f23ce3df3f2.json`.
+- Probes: Ollama OK, Qdrant OK, LiteLLM OK.
+- Live runner: `local_chat` OK, `local_rag` OK.
+- Forced Qdrant degradation: fallback to `local_chat` with
+  `qdrant_unavailable`.
+- Policy block: blocked before model call.
+
+Observed live latencies:
+
+| Check | Latency |
+|---|---:|
+| Ollama probe | 28.6 ms |
+| Qdrant probe | 9.4 ms |
+| LiteLLM probe | 26.1 ms |
+| Agent-0 `local_chat` | 8790.5 ms |
+| Agent-0 `local_rag` | 32162.8 ms |
+| forced degradation | 0.03 ms |

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -705,3 +705,41 @@ Observed live latencies:
 | Agent-0 `local_chat` | 8790.5 ms |
 | Agent-0 `local_rag` | 32162.8 ms |
 | forced degradation | 0.03 ms |
+
+## G2-01 Current Work
+
+G2-01 starts Gateway-2 with a measurement-only RAG latency baseline:
+
+```text
+LocalRagPipeline
+  -> RagRunTrace optional segment fields
+  -> embed/search/pack/prompt/generation/total timings
+  -> safe trace serialization only
+```
+
+Scope:
+
+- Extend `RagRunTrace` with optional per-segment fields:
+  `routing_ms`, `embedding_ms`, `retrieval_ms`, `context_pack_ms`,
+  `prompt_build_ms`, `generation_ms`, `total_ms`, and `run_context`.
+- Preserve old trace fields such as `retrieval_latency_ms`,
+  `generation_latency_ms`, `prompt_latency_ms`, and `total_latency_ms`.
+- Populate pipeline traces from existing `time.perf_counter()` wrappers and
+  `Retriever.last_timings`.
+- Keep `total_ms` as a directly measured outer timer, not a segment sum.
+- Add optional Ollama metric fields, but only when already available in
+  metadata. Current LiteLLM path does not expose native Ollama metrics, so
+  normal traces record `ollama_metrics_available=false`.
+
+Safety:
+
+- No optimization.
+- No prompt/top-k/model/timeout/alias/routing/fallback behavior change.
+- No Qdrant mutation, no reindex, no `openclaw_knowledge` access.
+- No prompt, question, chunks, answer, vectors, payloads, API keys,
+  Authorization headers, raw exceptions or tracebacks in trace serialization.
+
+Deferred:
+
+- Dedicated 3-run cold/warm/degraded baseline command is deferred to G2-02 to
+  keep G2-01 focused on trace schema and segment instrumentation.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,21 +5,22 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-01
-**Updated by:** Codex — Agent-0 GW-15 local runner
+**Updated by:** Codex — Agent-0 GW-16 runner contract hardening
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add the first local MVP CLI entrypoint for one question, one routing
-decision, one local-only execution path and safe metadata output.
+**Goal:** harden the Agent-0 local runner contracts for alias routing, output
+schema, dry-run, blocked and degraded states without adding fallback or new
+runtime features.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
-GW-15 branch: `feat/agent0-local-runner`
+GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
+GW-16 branch: `feat/agent0-runner-contract-hardening`
 
 Current runtime path:
 
@@ -116,7 +117,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -129,6 +131,7 @@ GW-11 issue: <https://github.com/franciscosalido/OPENCLAW/issues/46>
 GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
+GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -163,6 +166,24 @@ Rules:
 - No Qdrant mutation, no reindexing, no ingestion, no real data.
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
+
+## GW-16 Current Work
+
+GW-16 hardens the Agent-0 runner contract without adding new execution
+features.
+
+Rules:
+
+- Alias matrix is frozen: default `local_chat`, `--json` `local_json`,
+  `--rag` `local_rag`.
+- Output schema remains stable across success, dry-run, blocked and failure
+  states.
+- Blocked and dry-run paths return `latency_ms=0.0`.
+- Chat, JSON and RAG failures return safe error categories only.
+- No fallback is added. RAG/JSON/chat failures do not silently try another
+  alias.
+- No remote providers, no remote calls, no Qdrant mutation, no live services
+  required for tests.
 
 ## GW-13 Completed Work
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,27 +5,29 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-02
-**Updated by:** Codex — Agent-0 GW-17 local fail-safe degradation
+**Updated by:** Codex — Agent-0 GW-18 golden question harness
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** add explicit local fail-safe degradation for Agent-0 so recoverable
-local RAG/Qdrant failures can fall back once to `local_chat`, while policy
-blocks remain hard refusals with no model call.
+**Goal:** add the Agent-0 golden question benchmark harness: fixed synthetic
+financial-domain questions, offline dry-run reports, and summary comparison
+tools for future regression checks.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
-GW-17 branch: `feat/agent0-local-failsafe-degradation`
+GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
+GW-18 branch: `feat/agent0-golden-question-harness`
 
 Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
 hardening branch present, but the GW-16 commit was not on `origin/main`.
 GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
 should be retargeted/rebased after GW-16 is integrated.
+GW-18 was implemented as a stacked branch on GW-17 for the same reason and
+should be retargeted/rebased after GW-16/GW-17 are integrated.
 
 Current runtime path:
 
@@ -124,7 +126,8 @@ unavoidable, use `git push --force-with-lease`.
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
 | GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Current |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -139,6 +142,7 @@ GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
 GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
+GW-18 issue: <https://github.com/franciscosalido/OPENCLAW/issues/61>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -171,8 +175,8 @@ Rules:
 - `--dry-run` works without live services.
 - No remote providers, no remote calls, no API keys, no FastAPI, no MCP.
 - No Qdrant mutation, no reindexing, no ingestion, no real data.
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- Progressive fallback is handled by GW-17.
+- Golden questions harness is handled by GW-18.
 
 ## GW-16 Current Work
 
@@ -210,6 +214,31 @@ Rules:
   fallback occurs.
 - `local_think` timeout fallback is deferred because Agent-0 has no public
   think path yet.
+- No remote providers, no remote calls, no Qdrant mutation, no real data, and
+  no live services required for unit tests.
+
+## GW-18 Current Work
+
+GW-18 adds the reproducible Agent-0 golden question harness.
+
+Deliverables:
+
+- `tests/golden/questions.yaml` with 8 synthetic financial-domain questions.
+- `scripts/run_golden_harness.py` opt-in harness guarded by
+  `RUN_GOLDEN_HARNESS=1`.
+- Offline `--dry-run` mode that emits JSONL and summary JSON without live
+  services.
+- `scripts/compare_golden_runs.py` for summary-to-summary regression checks.
+- `docs/AGENT0_GOLDEN_HARNESS.md` and `tests/golden/README.md`.
+
+Rules:
+
+- No answer text is stored in JSONL by default; only `answer_length_chars`.
+- Reports exclude prompt/question/chunks/vectors/payloads/secrets and raw
+  exceptions.
+- Reports are written under `tests/golden/reports/`, which is ignored by Git.
+- Quality scoring is human-readable only; no LLM-as-judge and no external API.
+- Optional human scoring helper is deferred to a future issue.
 - No remote providers, no remote calls, no Qdrant mutation, no real data, and
   no live services required for unit tests.
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,23 +4,28 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-05-01
-**Updated by:** Codex — Agent-0 GW-16 runner contract hardening
+**Last updated:** 2026-05-02
+**Updated by:** Codex — Agent-0 GW-17 local fail-safe degradation
 
 ---
 
 ## Active Sprint: Agent-0 / Local Runner MVP
 
-**Goal:** harden the Agent-0 local runner contracts for alias routing, output
-schema, dry-run, blocked and degraded states without adding fallback or new
-runtime features.
+**Goal:** add explicit local fail-safe degradation for Agent-0 so recoverable
+local RAG/Qdrant failures can fall back once to `local_chat`, while policy
+blocks remain hard refusals with no model call.
 
 Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
 open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
 GW-14 token/config helpers are not present on `main`.
 
-GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
-GW-16 branch: `feat/agent0-runner-contract-hardening`
+GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
+GW-17 branch: `feat/agent0-local-failsafe-degradation`
+
+Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
+hardening branch present, but the GW-16 commit was not on `origin/main`.
+GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
+should be retargeted/rebased after GW-16 is integrated.
 
 Current runtime path:
 
@@ -117,8 +122,9 @@ unavoidable, use `git push --force-with-lease`.
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
 | GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
-| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Open / separate PR |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Current |
+| GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -132,6 +138,7 @@ GW-12 issue: <https://github.com/franciscosalido/OPENCLAW/issues/48>
 GW-13 issue: <https://github.com/franciscosalido/OPENCLAW/issues/51>
 GW-15 issue: <https://github.com/franciscosalido/OPENCLAW/issues/55>
 GW-16 issue: <https://github.com/franciscosalido/OPENCLAW/issues/57>
+GW-17 issue: <https://github.com/franciscosalido/OPENCLAW/issues/59>
 
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
@@ -184,6 +191,27 @@ Rules:
   alias.
 - No remote providers, no remote calls, no Qdrant mutation, no live services
   required for tests.
+
+## GW-17 Current Work
+
+GW-17 adds the first explicit local fail-safe degradation layer.
+
+Rules:
+
+- Fallback reasons are enum-derived, not free-form strings.
+- RAG/Qdrant unavailable can fallback once from `local_rag` to `local_chat`.
+- Successful RAG fallback returns the chat answer, `alias=local_chat`, and
+  `used_rag=false`.
+- Policy blocks such as `budget_exceeded` and `unsupported_task` never
+  fallback, call no model, and return `error_category=blocked`.
+- If the fallback alias also fails, the runner returns a safe failure with no
+  second fallback.
+- Fallback emits a sanitized local `agent_fallback` loguru event only when
+  fallback occurs.
+- `local_think` timeout fallback is deferred because Agent-0 has no public
+  think path yet.
+- No remote providers, no remote calls, no Qdrant mutation, no real data, and
+  no live services required for unit tests.
 
 ## GW-13 Completed Work
 

--- a/docs/AGENT0_GOLDEN_HARNESS.md
+++ b/docs/AGENT0_GOLDEN_HARNESS.md
@@ -1,0 +1,150 @@
+# Agent-0 Golden Harness
+
+GW-18 adds an opt-in golden question benchmark harness for Agent-0.
+
+The harness is a reproducible quality and latency baseline. It does not improve
+model behavior, does not judge answers with another model, and does not change
+runtime routing.
+
+## Synthetic-Only Policy
+
+Questions must be synthetic and educational. They must not include real
+tickers, companies, funds, portfolios, private documents or user data.
+
+The registry lives at:
+
+```text
+tests/golden/questions.yaml
+```
+
+Each question has:
+
+- `id`
+- `domain`
+- `mode`
+- `question`
+- `rationale`
+
+Supported modes:
+
+- `chat`
+- `rag`
+- `json`
+
+## Dry Run
+
+Dry-run is fully offline and does not call LiteLLM, Ollama or Qdrant:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py --dry-run
+```
+
+Custom output directory:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py \
+  --dry-run \
+  --output-dir /tmp/openclaw_golden_reports
+```
+
+If `RUN_GOLDEN_HARNESS` is not `1`, the harness exits safely without running.
+
+## Optional Live Run
+
+Live mode may call the local Agent-0 runner. It remains local-only:
+
+```bash
+RUN_GOLDEN_HARNESS=1 uv run python scripts/run_golden_harness.py \
+  --output-dir tests/golden/reports
+```
+
+Live mode requires the same local services as the selected runner modes. Reports
+remain local artifacts and are ignored by Git.
+
+## JSONL Result Schema
+
+The JSONL report contains one safe object per question. It stores answer length
+only, not answer text.
+
+Fields include:
+
+- `question_id`
+- `domain`
+- `mode`
+- `route`
+- `alias`
+- `used_rag`
+- `latency_ms`
+- `decision_id`
+- `estimated_remote_tokens_avoided`
+- `answer_length_chars`
+- `error_category`
+- `fallback_applied`
+- `fallback_reason`
+- `quality_score`
+- `skipped`
+- `skipped_reason`
+
+It never stores question text, answer text, prompts, chunks, vectors, payloads,
+raw model responses, exception messages, API keys, Authorization headers or
+secrets.
+
+## Summary Schema
+
+The summary JSON includes:
+
+- `run_id`
+- `timestamp_utc`
+- `total_questions`
+- `passed`
+- `failed`
+- `skipped`
+- `fallback_count`
+- `mean_latency_ms_by_alias`
+- `p95_latency_ms_by_alias`
+- `total_estimated_remote_tokens_avoided`
+- `quality_score_present`
+- `model_under_test_aliases`
+
+Alias names are semantic aliases only. Concrete model names are not recorded.
+
+## Human Scoring Rubric
+
+GW-18 does not implement LLM-as-judge.
+
+Future human review may use this rubric:
+
+- `0`: no answer or hard error
+- `1`: answer present but off-topic or incomplete
+- `2`: plausible and topically relevant
+- `3`: accurate, well-reasoned, cites if RAG
+
+The optional scoring helper is deferred to GW-19 to keep GW-18 focused on the
+registry, report contract and comparison tool.
+
+## Comparison
+
+Compare two summary files:
+
+```bash
+uv run python scripts/compare_golden_runs.py \
+  --baseline path/to/baseline_summary.json \
+  --candidate path/to/candidate_summary.json \
+  --latency-threshold-pct 20
+```
+
+The comparison exits non-zero only for hard regressions:
+
+- pass rate decreases
+- any per-alias mean latency regresses beyond the threshold
+
+## Out Of Scope
+
+- Remote providers
+- Remote API calls
+- LLM-as-judge
+- Dashboards
+- OpenTelemetry
+- Prometheus or Grafana
+- Qdrant mutation or reindexing
+- Real data

--- a/docs/AGENT0_GOLDEN_HARNESS.md
+++ b/docs/AGENT0_GOLDEN_HARNESS.md
@@ -89,6 +89,9 @@ It never stores question text, answer text, prompts, chunks, vectors, payloads,
 raw model responses, exception messages, API keys, Authorization headers or
 secrets.
 
+Skipped semantics are explicit: a result cannot be both skipped and failed. If
+`skipped` is `true`, `error_category` must be absent.
+
 ## Summary Schema
 
 The summary JSON includes:

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -173,6 +173,7 @@ The smoke script is opt-in and local-only. It requires
 ## Deferred
 
 - Progressive remote escalation remains out of scope.
-- Golden questions harness is deferred to GW-18.
-- Observability E2E validation is deferred to GW-18.
+- Golden questions harness is provided by GW-18 in
+  `scripts/run_golden_harness.py`.
+- Observability E2E validation remains deferred to a future explicit issue.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -69,6 +69,42 @@ It never includes question text, prompts, chunks, vectors, embeddings, payloads,
 API keys, Authorization headers, secrets, passwords, raw model responses or
 tracebacks.
 
+## GW-16 Contract Hardening
+
+GW-16 freezes the Agent-0 runner contracts with offline tests only.
+
+Alias matrix:
+
+| Mode | Alias | `used_rag` |
+|---|---|---:|
+| default | `local_chat` | `false` |
+| `--json` | `local_json` | `false` |
+| `--rag` | `local_rag` | `true` |
+
+Output schema invariants:
+
+- `answer`, `route`, `alias`, `used_rag`, `latency_ms`, `decision_id`, and
+  `estimated_remote_tokens_avoided` are always present.
+- `error_category` appears only for blocked/failure results.
+- `latency_ms` is numeric and non-negative.
+- `estimated_remote_tokens_avoided` is numeric and non-negative.
+- `decision_id` is non-empty.
+
+Safe error categories:
+
+- `blocked`
+- `chat_unavailable`
+- `json_unavailable`
+- `rag_unavailable`
+- `invalid_arguments` is reserved for future CLI/reporting integration.
+
+Fallback remains intentionally disabled:
+
+- RAG failure does not fallback to `local_chat`.
+- JSON failure does not fallback to `local_chat`.
+- Chat failure does not try another alias.
+- Timeout/retry fallback is deferred to a future PR.
+
 ## Dry Run
 
 ```bash
@@ -88,7 +124,7 @@ The smoke script is opt-in and local-only. It requires
 
 ## Deferred
 
-- Progressive fallback is deferred to GW-16.
-- Golden questions harness is deferred to GW-17.
+- Progressive fallback is deferred to GW-17.
+- Golden questions harness is deferred to GW-18.
 - Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -170,10 +170,24 @@ RUN_AGENT0_LOCAL_SMOKE=1 scripts/test_agent0_local_runner.sh
 The smoke script is opt-in and local-only. It requires
 `QUIMERA_LLM_API_KEY` to match the local `LITELLM_MASTER_KEY`.
 
+## Gateway-1 Proof-of-Life
+
+GW-20 adds the final Gateway-1 proof-of-life smoke:
+
+```bash
+RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
+```
+
+The command validates dry-run, local service probes, live `local_chat`, live
+`--rag` success or explicit fallback, forced Qdrant degradation and policy block
+behavior. It writes only sanitized metadata and answer lengths, never answer
+text, prompt text, chunks, vectors, payloads or secrets.
+
 ## Deferred
 
 - Progressive remote escalation remains out of scope.
 - Golden questions harness is provided by GW-18 in
   `scripts/run_golden_harness.py`.
-- Observability E2E validation remains deferred to a future explicit issue.
+- Observability signal validation is covered by GW-19; Gateway-1 proof-of-life
+  is covered by GW-20.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -65,6 +65,16 @@ collections, delete collections or mutate Qdrant.
 
 On failure it may also include `error_category`.
 
+When GW-17 local fail-safe degradation applies, it may also include these safe
+optional fields:
+
+- `fallback_applied`
+- `fallback_from_alias`
+- `fallback_to_alias`
+- `fallback_reason`
+- `fallback_chain`
+- `block_reason`
+
 It never includes question text, prompts, chunks, vectors, embeddings, payloads,
 API keys, Authorization headers, secrets, passwords, raw model responses or
 tracebacks.
@@ -98,12 +108,50 @@ Safe error categories:
 - `rag_unavailable`
 - `invalid_arguments` is reserved for future CLI/reporting integration.
 
-Fallback remains intentionally disabled:
+GW-16 fallback remained intentionally disabled:
 
 - RAG failure does not fallback to `local_chat`.
 - JSON failure does not fallback to `local_chat`.
 - Chat failure does not try another alias.
 - Timeout/retry fallback is deferred to a future PR.
+
+## GW-17 Local Fail-Safe Degradation
+
+GW-17 adds one explicit local-only fallback path for recoverable local
+infrastructure failure.
+
+Fallback matrix:
+
+| Condition | Behavior | Exit |
+|---|---|---:|
+| RAG/Qdrant unavailable | fallback once from `local_rag` to `local_chat` | `0` if fallback succeeds |
+| fallback `local_chat` fails | safe failure, no second fallback | non-zero |
+| `budget_exceeded` policy block | structured refusal, no model call, no fallback | non-zero |
+| `unsupported_task` policy block | structured refusal, no model call, no fallback | non-zero |
+| `local_think` timeout | deferred because Agent-0 has no public think path yet | n/a |
+| JSON failure | safe failure, no fallback to chat | non-zero |
+| Chat failure | safe failure, no fallback | non-zero |
+
+Fallback reason codes are enum-derived and never free-form strings:
+
+- `qdrant_unavailable`
+- `rag_unavailable`
+- `think_timeout`
+- `alias_unavailable`
+- `budget_exceeded`
+- `unsupported_task`
+- `fallback_alias_failed`
+- `unknown_local_failure`
+
+Successful fallback returns the fallback answer and preserves the stable output
+schema. It sets `alias` to the alias that produced the answer, currently
+`local_chat`, and sets `used_rag` to `false`.
+
+Fallback emits a local loguru event named `agent_fallback` with only safe
+metadata: decision id, enum reason, source alias, target alias, success flag,
+latency and status. It does not log question text, prompts, answers, chunks,
+vectors, payloads, exception messages, tracebacks, API keys or Authorization
+headers.
 
 ## Dry Run
 
@@ -124,7 +172,7 @@ The smoke script is opt-in and local-only. It requires
 
 ## Deferred
 
-- Progressive fallback is deferred to GW-17.
+- Progressive remote escalation remains out of scope.
 - Golden questions harness is deferred to GW-18.
 - Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_LOCAL_RUNNER.md
+++ b/docs/AGENT0_LOCAL_RUNNER.md
@@ -90,4 +90,5 @@ The smoke script is opt-in and local-only. It requires
 
 - Progressive fallback is deferred to GW-16.
 - Golden questions harness is deferred to GW-17.
+- Observability E2E validation is deferred to GW-18.
 - Remote providers remain disabled and require a future ADR.

--- a/docs/AGENT0_OBSERVABILITY.md
+++ b/docs/AGENT0_OBSERVABILITY.md
@@ -1,0 +1,108 @@
+# Agent-0 Observability Contract
+
+GW-19 verifies Agent-0 observability signal completeness and sanitization.
+
+This is not OpenTelemetry, not a dashboard, not remote telemetry and not a
+runtime behavior change. It is an offline contract that tests existing local
+signals.
+
+## Signals
+
+Agent-0 observability uses these safe metadata signals:
+
+- `RouterDecision`: route selected, reason code, policy outcome and token
+  estimates.
+- `TokenEconomyRecord`: local estimate of remote tokens avoided and budget-like
+  token totals.
+- `RagRunTrace`: safe RAG provenance and segment latency metadata when RAG
+  tracing is applicable.
+- Decision logs: local JSONL audit records written by `RoutingDecisionLogger`.
+- Fallback events: local `agent_fallback` loguru events when GW-17 fallback is
+  applied.
+
+## Allowlist Rule
+
+Serializers are tested against explicit allowlists in
+`backend/gateway/observability_contract.py`.
+
+Tests assert that signal keys are a subset of the relevant allowlist. This is
+intentional: new fields must be deliberately added to the allowlist before they
+can appear in structured output.
+
+## Prohibited Fields
+
+The following categories must never appear as keys in Agent-0 observability
+signals:
+
+- prompt or system/user prompt
+- query, question or raw user input
+- chunks, retrieved context or context text
+- vectors or embeddings
+- payloads or Qdrant payloads
+- API keys, Authorization headers, headers, tokens, passwords or secrets
+- raw model responses
+- raw exceptions, exception messages or tracebacks
+- model weights paths
+
+Tests use deterministic synthetic sentinels to verify that raw input and raw
+exception text do not leak into outputs or fallback events.
+
+## Reason Codes
+
+Routing and fallback reasons must be deterministic safe codes.
+
+Examples:
+
+- `local_first_default`
+- `budget_exceeded`
+- `unsupported_task`
+- `remote_disabled`
+- `qdrant_unavailable`
+- `rag_unavailable`
+- `fallback_alias_failed`
+
+Free-form exception messages are not valid reason codes.
+
+## Correlation
+
+Fallback events must include the same `decision_id` that appears in the
+Agent-0 runner output. Decision logs and token-economy records are also keyed by
+`decision_id`.
+
+## Offline Coverage
+
+GW-19 tests cover:
+
+- RouterDecision serialization
+- TokenEconomyRecord serialization and canonical projection
+- RagRunTrace serialization
+- fallback event sanitization and `decision_id` correlation
+- local decision JSONL safety
+- Agent-0 dry-run output safety
+- estimated remote tokens avoided across success, dry-run, blocked, fallback
+  success and fallback failure paths
+- golden harness dry-run JSONL and summary safety
+
+All tests are offline and deterministic. They do not require LiteLLM, Ollama,
+Qdrant or network services.
+
+## Deferred
+
+`RagRunTrace` currently predates Agent-0 and does not carry Agent-0
+`decision_id`, `used_rag` or `fallback_occurred` fields directly. The GW-19
+allowlist reserves those fields for future integration, but does not force a
+runtime schema change in this PR.
+
+Future work may add a unified in-process signal collector, but that requires a
+separate issue.
+
+## Out Of Scope
+
+- OpenTelemetry
+- dashboards
+- Prometheus/Grafana
+- remote telemetry
+- remote providers
+- live baseline freeze
+- LLM-as-judge
+- Qdrant mutation or reindexing

--- a/docs/AGENT0_OBSERVABILITY.md
+++ b/docs/AGENT0_OBSERVABILITY.md
@@ -86,6 +86,17 @@ GW-19 tests cover:
 All tests are offline and deterministic. They do not require LiteLLM, Ollama,
 Qdrant or network services.
 
+## Gateway-1 Proof-of-Life
+
+GW-20 adds an opt-in operator smoke that scans structured proof-of-life outputs
+using the same prohibited-field discipline. It validates dry-run, local service
+probes, live runner paths, forced degradation and policy block behavior, then
+writes a sanitized summary JSON.
+
+The proof-of-life smoke is not OpenTelemetry, not a dashboard, not remote
+telemetry and not a profiling baseline. It is a local readiness gate for
+Gateway-2.
+
 ## Deferred
 
 `RagRunTrace` currently predates Agent-0 and does not carry Agent-0

--- a/docs/AGENT0_SMOKE.md
+++ b/docs/AGENT0_SMOKE.md
@@ -1,0 +1,109 @@
+# Agent-0 Gateway-1 Proof-of-Life Smoke
+
+GW-20 adds the final operational proof-of-life smoke for Sprint Gateway-1. It
+is a single opt-in command that validates the local stack as a unit before
+Gateway-2 starts.
+
+## Command
+
+```bash
+RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run python scripts/test_gateway1_proof_of_life.py --output-dir /tmp/openclaw_gateway1_smoke
+```
+
+The command exits `0` only when every mandatory Gateway-1 done criterion passes.
+It writes a sanitized JSON summary named:
+
+```text
+gateway1_proof_of_life_<run_id>.json
+```
+
+Generated reports under `reports/gateway1_smoke/` are ignored by Git.
+
+## Prerequisites
+
+The live portions require local services only:
+
+- Ollama: `http://127.0.0.1:11434`
+- Qdrant: `http://127.0.0.1:6333`
+- LiteLLM: `http://127.0.0.1:4000/v1`
+
+Required environment:
+
+```bash
+export QUIMERA_LLM_API_KEY="dev-local-key-change-me"
+export QUIMERA_LLM_BASE_URL="http://127.0.0.1:4000/v1"
+export QDRANT_URL="http://127.0.0.1:6333"
+export OLLAMA_API_BASE="http://127.0.0.1:11434"
+```
+
+The script refuses non-local service URLs before any live probe.
+
+## Done Criteria
+
+The fixed criteria live in
+`docs/sprints/GATEWAY1_DONE_CRITERIA.md`:
+
+- G1-01 dry-run runner ok
+- G1-02 local URLs only
+- G1-03 Ollama probe ok
+- G1-04 Qdrant probe ok
+- G1-05 LiteLLM probe ok
+- G1-06 local chat runner ok
+- G1-07 RAG path or explicit fallback ok
+- G1-08 forced Qdrant degradation ok
+- G1-09 policy block no model call ok
+- G1-10 sanitized output ok
+- G1-11 summary report written ok
+
+## Summary Shape
+
+The summary contains only safe metadata:
+
+- `run_id`
+- `timestamp_utc`
+- `gateway_sprint`
+- `criteria_manifest_ref`
+- `service_probes`
+- `runner_tests`
+- `passed`
+- `failed`
+- `skipped`
+- `criteria_met`
+- `overall_passed`
+
+Runner results store answer length, alias, route, `used_rag`, fallback metadata
+and token estimates. They do not store answer text.
+
+## RAG Success vs Fallback
+
+`G1-07` accepts either:
+
+- RAG success through `local_rag` with `used_rag=true`; or
+- explicit GW-17 fallback to `local_chat` with `used_rag=false` and an
+  enum-derived fallback reason.
+
+Both outcomes are valid because Gateway-1 requires honest local degradation, not
+silent fallback or remote escalation.
+
+## Forced Qdrant Degradation
+
+`G1-08` injects a Qdrant-like unavailable error through the Agent-0 runner test
+hook. It does not stop Docker, mutate Qdrant, delete collections, reindex, or
+touch `openclaw_knowledge`.
+
+## Safety
+
+The proof-of-life summary and runtime checks never include:
+
+- prompt, question or raw user input
+- answer text
+- chunks or retrieved context
+- vectors or embeddings
+- Qdrant payloads
+- API keys, Authorization headers, tokens, passwords or secrets
+- raw model responses
+- raw exceptions, exception messages or tracebacks
+- model weights paths
+
+Remote providers remain disabled. Gateway-2 must not begin until GW-20 passes
+locally.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,72 @@
+# OPENCLAW — Development Setup
+
+## Environment variables
+
+All local secrets live in a `.env` file at the project root.
+`.env` is gitignored and must never be committed.
+Use `.env.example` as the reference template:
+
+```bash
+cp .env.example .env
+# Edit .env — set LITELLM_MASTER_KEY and QUIMERA_LLM_API_KEY to the same value
+```
+
+`QUIMERA_LLM_API_KEY` must match the `LITELLM_MASTER_KEY` used to start the
+LiteLLM gateway (`infra/litellm/start_litellm.sh`).
+
+---
+
+## Running commands with environment variables
+
+`uv run` does **not** auto-load `.env`. Always pass `--env-file .env`:
+
+```bash
+# Run tests
+uv run --env-file .env pytest tests/unit/ -v
+
+# Run type checks (no env needed — pure static analysis)
+uv run mypy backend/ --strict
+uv run pyright backend/
+
+# Run any script
+uv run --env-file .env python scripts/<script>.py
+```
+
+### Key scripts
+
+```bash
+# Start LiteLLM gateway (must have LITELLM_MASTER_KEY exported first)
+set -a && source .env && set +a
+cd infra/litellm && source .venv/bin/activate && ./start_litellm.sh
+
+# RAG queries
+uv run --env-file .env python scripts/rag_ask_local.py "Qual a projeção da Selic?"
+
+# RAG latency baseline (opt-in — requires all services running)
+RUN_RAG_LATENCY_BASELINE=1 uv run --env-file .env python \
+  scripts/run_rag_latency_baseline.py --output-dir reports/g2_latency_baseline
+
+# GW-20 proof-of-life smoke
+RUN_GATEWAY1_PROOF_OF_LIFE=1 uv run --env-file .env python \
+  scripts/test_gateway1_proof_of_life.py
+```
+
+---
+
+## Services required for integration / smoke tests
+
+| Service | Start command | Health check |
+|---|---|---|
+| Qdrant | `docker compose -f docker/docker-compose.qdrant.yml up -d` | `curl http://localhost:6333/healthz` |
+| Ollama | `ollama serve` | `curl http://localhost:11434/api/tags` |
+| LiteLLM | `set -a && source .env && set +a && cd infra/litellm && source .venv/bin/activate && ./start_litellm.sh` | `curl -H "Authorization: Bearer $QUIMERA_LLM_API_KEY" http://localhost:4000/health` |
+
+---
+
+## Security levels
+
+| Level | Description | Rule |
+|---|---|---|
+| 0 | Portfolio data, credentials, CPF, tokens | Never leave the machine |
+| 1 | Macro analysis, sector analysis (sanitized) | Remote only after stripping asset names and values |
+| 2 | Public research, editorial review | Remote OK |

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -30,9 +30,9 @@ All durations use `time.perf_counter()` wrappers around existing calls.
 the sum of segment fields.
 
 The current `LocalRagPipeline` does not own Agent-0 route selection. Direct
-pipeline traces therefore record `routing_ms=0.0`. Agent-level routing
-correlation remains a future integration point and must preserve `decision_id`
-when added.
+pipeline traces record `routing_ms=None` — not measured at this layer, not
+zero. Agent-level routing correlation via `decision_id` is a future
+integration point in the Agent-0 runner.
 
 ## Trace Fields
 

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -1,0 +1,113 @@
+# RAG Latency Baseline
+
+G2-01 establishes a measurement-only RAG latency baseline. It does not optimize
+retrieval, prompts, generation, models, aliases, timeouts, fallback behavior or
+Qdrant configuration.
+
+## Hypothesis
+
+If `local_rag` total latency is around 32 seconds, at least 80% of the latency
+is expected to be concentrated in model generation and prompt evaluation, not in
+query embedding, Qdrant retrieval or context packing.
+
+G2-01 only measures this hypothesis. Any optimization belongs to a later G2 PR.
+
+## Segment Boundaries
+
+All durations use `time.perf_counter()` wrappers around existing calls.
+
+| Segment | Starts | Ends |
+|---|---|---|
+| `routing_ms` | before `decide_route()` | after `RouterDecision` exists |
+| `embedding_ms` | before query embedding call | after query vector is returned |
+| `retrieval_ms` | before Qdrant/vector-store search | after raw top-k results return |
+| `context_pack_ms` | before mapping/dedup/truncation/packing | after final packed chunks are selected |
+| `prompt_build_ms` | before prompt builder | after final message/prompt object is built |
+| `generation_ms` | before `GatewayChatClient`/`LocalGenerator` call | after model response is returned |
+| `total_ms` | at outer RAG run start | after final RAG result object is produced |
+
+`total_ms` is measured directly with its own outer timer. It is not computed as
+the sum of segment fields.
+
+The current `LocalRagPipeline` does not own Agent-0 route selection. Direct
+pipeline traces therefore record `routing_ms=0.0`. Agent-level routing
+correlation remains a future integration point and must preserve `decision_id`
+when added.
+
+## Trace Fields
+
+`RagRunTrace` keeps the older provenance fields and adds optional measurement
+fields:
+
+- `routing_ms`
+- `embedding_ms`
+- `retrieval_ms`
+- `context_pack_ms`
+- `prompt_build_ms`
+- `generation_ms`
+- `total_ms`
+- `run_context`
+
+Allowed `run_context` labels:
+
+- `cold_start`
+- `warm_model`
+- `degraded_qdrant`
+
+Normal runtime may leave `run_context` unset. Baseline runs should label
+cold/warm/degraded explicitly so reports are distinguishable without rerunning.
+
+## Ollama Metrics
+
+`RagRunTrace` can store native Ollama metric fields only if they are already
+available in response metadata:
+
+- `total_duration`
+- `load_duration`
+- `prompt_eval_count`
+- `prompt_eval_duration`
+- `eval_count`
+- `eval_duration`
+
+Duration values are converted from nanoseconds to milliseconds.
+
+Current LiteLLM chat calls return normalized answer text only, so native Ollama
+metrics are not available in normal `local_rag` traces. G2-01 records
+`ollama_metrics_available=false` in that case.
+
+Do not bypass LiteLLM, call Ollama directly, duplicate generation calls, or log
+prompt/answer text to recover these metrics.
+
+## Safety
+
+Latency traces must never include:
+
+- prompt text
+- question/raw user input
+- answer text
+- chunks or chunk text
+- vectors or embeddings
+- Qdrant payloads
+- API keys, Authorization headers, tokens, passwords or secrets
+- raw model responses
+- raw exceptions, exception messages or tracebacks
+- model weight paths
+
+Serialization uses explicit allowlists and optional scalar fields only.
+
+## Baseline Runs
+
+The merge criterion for G2-01 is that the trace schema can represent three
+baseline contexts:
+
+- cold start
+- warm model
+- degraded Qdrant
+
+The dedicated 3-run baseline command is deferred to G2-02 to keep this PR purely
+focused on trace schema, segment boundaries and pipeline instrumentation. Until
+then, operators can inspect `rag_run_trace` log records from normal local RAG
+runs and verify the new segment fields.
+
+Generated baseline artifacts, when introduced later, must be opt-in and ignored
+by Git.

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -26,6 +26,20 @@ It is a compact runtime record of which safe RAG metadata was used for a query.
 - optional `prompt_latency_ms`
 - optional `context_chunk_count`
 
+G2-01 extends the trace with optional per-segment latency fields for
+measurement-only RAG baselining:
+
+- `routing_ms`
+- `embedding_ms`
+- `retrieval_ms`
+- `context_pack_ms`
+- `prompt_build_ms`
+- `generation_ms`
+- `total_ms`
+- `run_context`
+
+See `docs/RAG_LATENCY_BASELINE.md` for exact segment boundaries.
+
 ## Forbidden Content
 
 The trace must never contain:

--- a/docs/sprints/GATEWAY1_DONE_CRITERIA.md
+++ b/docs/sprints/GATEWAY1_DONE_CRITERIA.md
@@ -1,0 +1,19 @@
+# Gateway-1 Done Criteria
+
+Gateway-1 is complete only when the opt-in proof-of-life smoke validates the local stack as a unit without remote providers, Qdrant mutation, real data, or sensitive logging.
+
+| ID | Description | Component | Mandatory | Failure Meaning |
+| --- | --- | --- | --- | --- |
+| G1-01 dry_run_runner_ok | Agent-0 dry-run executes offline and returns the stable safe schema. | Agent-0 runner | true | The runner contract is not available without live services. |
+| G1-02 local_urls_only | Ollama, Qdrant and LiteLLM URLs are localhost or 127.0.0.1 only. | Safety guard | true | The smoke could call a remote service and must stop. |
+| G1-03 ollama_probe_ok | Ollama responds to read-only `GET /api/tags`. | Ollama | true | Local model runtime is not reachable. |
+| G1-04 qdrant_probe_ok | Qdrant responds to read-only `GET /healthz`. | Qdrant | true | Local vector store is not reachable. |
+| G1-05 litellm_probe_ok | LiteLLM responds to `GET /v1/models` and exposes required local aliases. | LiteLLM gateway | true | Local gateway or alias contract is not ready. |
+| G1-06 local_chat_runner_ok | Agent-0 live default path returns safe schema through `local_chat`. | Agent-0 local chat | true | Default local execution is not operational. |
+| G1-07 rag_path_or_explicit_fallback_ok | Agent-0 `--rag` succeeds via `local_rag` or explicitly falls back to `local_chat`. | Agent-0 RAG | true | RAG path neither works nor degrades honestly. |
+| G1-08 forced_qdrant_degradation_ok | Injected Qdrant-like failure triggers the GW-17 fallback contract without stopping Qdrant. | Agent-0 fallback | true | Degraded-state safety is not reproducible. |
+| G1-09 policy_block_no_model_call_ok | Policy block refuses before any model call. | Routing policy | true | Blocked requests may still execute models. |
+| G1-10 sanitized_output_ok | Structured outputs contain no prompt, question, chunks, vectors, payloads or secrets. | Safety audit | true | Smoke artifacts may leak sensitive content. |
+| G1-11 summary_report_written_ok | A structured JSON summary is written even when failures occur where possible. | Operator report | true | Operators cannot inspect proof-of-life outcome. |
+
+Generated proof-of-life summaries are local artifacts and must not be committed.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-02
-**Current branch:** `feat/agent0-golden-question-harness`
-**Issue:** [#61](https://github.com/franciscosalido/OPENCLAW/issues/61)
+**Current branch:** `feat/agent0-observability-signal-contract`
+**Issue:** [#63](https://github.com/franciscosalido/OPENCLAW/issues/63)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -43,6 +43,7 @@ Out of scope:
 | GW-14 | Config-driven routing audit and token economy calibration |
 | GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
 | GW-18 | Golden question benchmark harness |
+| GW-19 | Agent-0 observability signal contract |
 
 ## GW-15 Current Work
 
@@ -156,3 +157,30 @@ Safety:
 - Reports exclude prompt/question/chunks/vectors/payloads/secrets and do not
   include answer text by default.
 - `tests/golden/reports/` is ignored by Git.
+
+## GW-19 Current Work
+
+Scope:
+
+- Add canonical signal allowlists in
+  `backend/gateway/observability_contract.py`.
+- Verify `RouterDecision`, `TokenEconomyRecord`, `RagRunTrace`, fallback events
+  and decision logs are serialized with safe metadata only.
+- Verify fallback event `decision_id` correlates with runner output.
+- Verify `estimated_remote_tokens_avoided` is present and non-negative across
+  success, dry-run, blocked, fallback success and fallback failure paths.
+- Verify GW-18 golden harness dry-run JSONL and summary outputs stay sanitized.
+
+Out of scope:
+
+- Runtime behavior changes.
+- Remote providers or remote calls.
+- OpenTelemetry, dashboards, Prometheus or Grafana.
+- Live LiteLLM/Ollama/Qdrant services in unit tests.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+
+Safety:
+
+- Sanitization tests use allowlists and deterministic sentinels.
+- Prohibited fields include prompts, raw user input, chunks, vectors, payloads,
+  headers, API keys, raw exceptions and model weight paths.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-01  
-**Current branch:** `feat/agent0-local-runner`
-**Issue:** [#55](https://github.com/franciscosalido/OPENCLAW/issues/55)
+**Current branch:** `feat/agent0-runner-contract-hardening`
+**Issue:** [#57](https://github.com/franciscosalido/OPENCLAW/issues/57)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -41,8 +41,8 @@ Out of scope:
 | Item | Scope |
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
-| GW-16 | Progressive local fallback on timeout/alias failure |
-| GW-17 | Golden questions harness |
+| GW-17 | Progressive local fallback on timeout/alias failure |
+| GW-18 | Golden questions harness |
 
 ## GW-15 Current Work
 
@@ -73,3 +73,28 @@ Safety:
 - Dry-run performs routing and token estimates without model calls.
 - RAG unavailable returns `error_category=rag_unavailable`; no silent fallback in
   GW-15.
+
+## GW-16 Current Work
+
+Scope:
+
+- Harden `scripts/run_local_agent.py` contracts with offline tests.
+- Freeze alias matrix for `local_chat`, `local_json`, and `local_rag`.
+- Freeze output schema invariants across success, dry-run, blocked and failure
+  states.
+- Validate degraded-state behavior for chat, JSON and RAG.
+- Assert no silent fallback between aliases.
+- Validate parse/render/token-estimate boundaries.
+
+Out of scope:
+
+- Progressive fallback.
+- Retry/fallback on timeout.
+- Golden questions harness.
+- Remote providers or calls.
+- Qdrant mutation, reindexing or ingestion.
+
+Safety:
+
+- Runner output still excludes prompt/query/chunks/vectors/payloads/secrets.
+- Live services are not required for GW-16 tests.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
-**Last updated:** 2026-05-01  
-**Current branch:** `feat/agent0-runner-contract-hardening`
-**Issue:** [#57](https://github.com/franciscosalido/OPENCLAW/issues/57)
+**Last updated:** 2026-05-02
+**Current branch:** `feat/agent0-local-failsafe-degradation`
+**Issue:** [#59](https://github.com/franciscosalido/OPENCLAW/issues/59)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -41,7 +41,7 @@ Out of scope:
 | Item | Scope |
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
-| GW-17 | Progressive local fallback on timeout/alias failure |
+| GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
 | GW-18 | Golden questions harness |
 
 ## GW-15 Current Work
@@ -98,3 +98,32 @@ Safety:
 
 - Runner output still excludes prompt/query/chunks/vectors/payloads/secrets.
 - Live services are not required for GW-16 tests.
+
+## GW-17 Current Work
+
+Scope:
+
+- Add typed fallback reason vocabulary.
+- Add safe optional fallback metadata to Agent-0 runner output.
+- Fallback once from `local_rag` to `local_chat` when local RAG/Qdrant
+  infrastructure is unavailable.
+- Keep policy blocks as hard stops with no model call and no fallback.
+- Add a no-double-fallback guard when the fallback alias also fails.
+- Emit a sanitized local `agent_fallback` loguru event.
+- Add offline tests for fallback, policy blocks, schema stability and exit
+  codes.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- FastAPI, MCP or multi-agent orchestration.
+- Qdrant mutation, reindexing, ingestion or `openclaw_knowledge` access.
+- Public `local_think` runner path. `local_think` timeout fallback remains
+  deferred until a think path exists.
+
+Safety:
+
+- Fallback reason codes are enum-derived.
+- Fallback metadata excludes prompt/query/chunks/vectors/payloads/secrets.
+- Successful fallback exits `0`; policy block and unrecoverable local failure
+  exit non-zero.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -40,41 +40,6 @@ Out of scope:
 
 | Item | Scope |
 |---|---|
-<<<<<<< HEAD
-| GW-14 | Sanitization policy before any remote escalation |
-| GW-15 | Budget enforcement and approval flow |
-| GW-16 | Provider-specific ADR if remote routing is ever proposed |
-
-## GW-14 Current Work
-
-Branch: `feat/gateway1-routing-audit-token-economy`
-Issue: [#53](https://github.com/franciscosalido/OPENCLAW/issues/53)
-
-Scope:
-
-- Load `RemoteEscalationPolicy` from `config/rag_config.yaml`.
-- Add local JSONL routing decision audit records.
-- Add heuristic prompt token estimation.
-- Add in-memory `TokenBudgetAccumulator`.
-- Add config-driven blocked/allowed task type registry.
-- Add stable `RouterDecision.decision_fingerprint()`.
-- Add deterministic unit and integration tests.
-
-Out of scope:
-
-- Remote providers, API keys or remote calls.
-- Runtime chat/RAG routing changes.
-- Local fallback on timeout.
-- Health-aware runtime routing.
-- Qdrant mutation, reindexing, ingestion, or `openclaw_knowledge`.
-
-Safety:
-
-- `remote_enabled` remains false.
-- `allowed_remote_providers` remains empty.
-- JSONL audit files are local and ignored by git.
-- Token economy is estimated, not billed.
-=======
 | GW-14 | Config-driven routing audit and token economy calibration |
 | GW-16 | Progressive local fallback on timeout/alias failure |
 | GW-17 | Golden questions harness |
@@ -108,4 +73,3 @@ Safety:
 - Dry-run performs routing and token estimates without model calls.
 - RAG unavailable returns `error_category=rag_unavailable`; no silent fallback in
   GW-15.
->>>>>>> 8a17f34 (feat(agent): add Agent-0 local runner)

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -1,8 +1,8 @@
 # Gateway-1 Sprint Handoff
 
 **Last updated:** 2026-05-02
-**Current branch:** `feat/agent0-local-failsafe-degradation`
-**Issue:** [#59](https://github.com/franciscosalido/OPENCLAW/issues/59)
+**Current branch:** `feat/agent0-golden-question-harness`
+**Issue:** [#61](https://github.com/franciscosalido/OPENCLAW/issues/61)
 
 Gateway-0 is complete. Gateway-1 starts with routing policy primitives and
 token economy records only.
@@ -42,7 +42,7 @@ Out of scope:
 |---|---|
 | GW-14 | Config-driven routing audit and token economy calibration |
 | GW-17 | Explicit local fail-safe degradation for Agent-0 runner |
-| GW-18 | Golden questions harness |
+| GW-18 | Golden question benchmark harness |
 
 ## GW-15 Current Work
 
@@ -127,3 +127,32 @@ Safety:
 - Fallback metadata excludes prompt/query/chunks/vectors/payloads/secrets.
 - Successful fallback exits `0`; policy block and unrecoverable local failure
   exit non-zero.
+
+## GW-18 Current Work
+
+Scope:
+
+- Add `tests/golden/questions.yaml` with fixed synthetic financial-domain
+  questions.
+- Add `scripts/run_golden_harness.py` with opt-in dry-run and optional live
+  execution.
+- Emit safe JSONL and summary JSON reports without answer text.
+- Add `scripts/compare_golden_runs.py` for summary-to-summary regression checks.
+- Add offline unit tests for registry, report schema, guard behavior and
+  comparison logic.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- LLM-as-judge.
+- Dashboards, OpenTelemetry, Prometheus or Grafana.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- Live baseline publication. First committed live baseline requires a future
+  explicit baseline-update decision.
+
+Safety:
+
+- Golden questions are synthetic-only.
+- Reports exclude prompt/question/chunks/vectors/payloads/secrets and do not
+  include answer text by default.
+- `tests/golden/reports/` is ignored by Git.

--- a/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
+++ b/docs/sprints/GATEWAY1_SPRINT_HANDOFF.md
@@ -184,3 +184,32 @@ Safety:
 - Sanitization tests use allowlists and deterministic sentinels.
 - Prohibited fields include prompts, raw user input, chunks, vectors, payloads,
   headers, API keys, raw exceptions and model weight paths.
+
+## GW-20 Current Work
+
+Scope:
+
+- Add `docs/sprints/GATEWAY1_DONE_CRITERIA.md` with fixed Gateway-1 done
+  criteria G1-01 through G1-11.
+- Add `scripts/test_gateway1_proof_of_life.py`, a single opt-in local
+  proof-of-life smoke command.
+- Probe Ollama, Qdrant and LiteLLM through local-only read-only endpoints.
+- Verify Agent-0 dry-run, live `local_chat`, live `--rag` success or honest
+  fallback, forced Qdrant degradation and policy-block behavior.
+- Write a sanitized structured JSON summary without answer text, prompt text,
+  chunks, vectors, payloads or secrets.
+
+Out of scope:
+
+- Remote providers or remote calls.
+- New runtime architecture.
+- OpenTelemetry, dashboards, Prometheus or Grafana.
+- Qdrant mutation, reindexing or `openclaw_knowledge` access.
+- Real portfolio data, real tickers, real companies or real fund names.
+
+Safety:
+
+- The smoke is guarded by `RUN_GATEWAY1_PROOF_OF_LIFE=1`.
+- Live probes refuse non-local URLs.
+- Forced degradation is injected through runner hooks; it does not stop Qdrant.
+- A summary exits `0` only when all mandatory criteria pass.

--- a/scripts/compare_golden_runs.py
+++ b/scripts/compare_golden_runs.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Compare two Agent-0 golden harness summary files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse comparison CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare two Agent-0 golden harness summary JSON files.",
+    )
+    parser.add_argument("--baseline", required=True, help="Baseline summary JSON.")
+    parser.add_argument("--candidate", required=True, help="Candidate summary JSON.")
+    parser.add_argument(
+        "--latency-threshold-pct",
+        type=float,
+        default=20.0,
+        help="Mean latency regression threshold by alias.",
+    )
+    return parser.parse_args(argv)
+
+
+def compare_summaries(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    *,
+    latency_threshold_pct: float,
+) -> tuple[str, int]:
+    """Return a human-readable comparison table and exit code."""
+    if latency_threshold_pct < 0:
+        raise ValueError("latency_threshold_pct cannot be negative")
+    baseline_rate = _pass_rate(baseline)
+    candidate_rate = _pass_rate(candidate)
+    pass_rate_delta = candidate_rate - baseline_rate
+    baseline_latency = _read_float_mapping(baseline, "mean_latency_ms_by_alias")
+    candidate_latency = _read_float_mapping(candidate, "mean_latency_ms_by_alias")
+    aliases = sorted(set(baseline_latency) | set(candidate_latency))
+    latency_rows: list[tuple[str, float, float, float]] = []
+    latency_regression = False
+    for alias in aliases:
+        base = baseline_latency.get(alias, 0.0)
+        cand = candidate_latency.get(alias, 0.0)
+        delta_pct = _percent_delta(base, cand)
+        latency_rows.append((alias, base, cand, delta_pct))
+        if base > 0 and delta_pct > latency_threshold_pct:
+            latency_regression = True
+
+    fallback_delta = _read_int(candidate, "fallback_count") - _read_int(
+        baseline,
+        "fallback_count",
+    )
+    token_delta = _read_float(
+        candidate,
+        "total_estimated_remote_tokens_avoided",
+    ) - _read_float(baseline, "total_estimated_remote_tokens_avoided")
+
+    lines = [
+        "golden_run_comparison",
+        f"pass_rate_delta={pass_rate_delta:.4f}",
+        f"fallback_count_delta={fallback_delta}",
+        f"total_estimated_remote_tokens_avoided_delta={token_delta:.1f}",
+        "alias | baseline_mean_ms | candidate_mean_ms | delta_pct",
+    ]
+    for alias, base, cand, delta_pct in latency_rows:
+        lines.append(f"{alias} | {base:.1f} | {cand:.1f} | {delta_pct:.1f}")
+
+    exit_code = 1 if pass_rate_delta < 0 or latency_regression else 0
+    return "\n".join(lines) + "\n", exit_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    baseline = _load_summary(args.baseline)
+    candidate = _load_summary(args.candidate)
+    output, exit_code = compare_summaries(
+        baseline,
+        candidate,
+        latency_threshold_pct=args.latency_threshold_pct,
+    )
+    sys.stdout.write(output)
+    return exit_code
+
+
+def _load_summary(path: Path | str) -> Mapping[str, Any]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("summary JSON must be an object")
+    return raw
+
+
+def _pass_rate(summary: Mapping[str, Any]) -> float:
+    total = _read_int(summary, "total_questions")
+    if total <= 0:
+        return 0.0
+    return _read_int(summary, "passed") / total
+
+
+def _read_int(summary: Mapping[str, Any], key: str) -> int:
+    value = summary.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"summary {key} must be an integer")
+    return value
+
+
+def _read_float(summary: Mapping[str, Any], key: str) -> float:
+    value = summary.get(key)
+    if not isinstance(value, int | float):
+        raise ValueError(f"summary {key} must be numeric")
+    return float(value)
+
+
+def _read_float_mapping(summary: Mapping[str, Any], key: str) -> dict[str, float]:
+    value = summary.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"summary {key} must be an object")
+    output: dict[str, float] = {}
+    for alias, latency in value.items():
+        if not isinstance(alias, str):
+            raise ValueError(f"summary {key} keys must be strings")
+        if not isinstance(latency, int | float):
+            raise ValueError(f"summary {key}.{alias} must be numeric")
+        output[alias] = float(latency)
+    return output
+
+
+def _percent_delta(baseline: float, candidate: float) -> float:
+    if baseline <= 0:
+        return 0.0 if candidate <= 0 else 100.0
+    return ((candidate - baseline) / baseline) * 100.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_golden_harness.py
+++ b/scripts/run_golden_harness.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 import yaml
 
+from backend.gateway.routing_policy import estimate_prompt_tokens
 from scripts import run_local_agent
 
 
@@ -60,6 +61,10 @@ class GoldenResult:
     quality_score: None
     skipped: bool = False
     skipped_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.skipped and self.error_category is not None:
+            raise ValueError("GoldenResult cannot be both skipped and failed")
 
     def to_json_dict(self) -> dict[str, object]:
         """Return allowlisted JSONL-safe result metadata."""
@@ -198,7 +203,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _dry_run_result(question: GoldenQuestion) -> GoldenResult:
     alias = _alias_for_mode(question.mode)
     answer = "Dry run: no model call executed."
-    estimated = run_local_agent._estimate_prompt_token_count(question.question)
+    estimated = estimate_prompt_tokens(question.question)
     return GoldenResult(
         question_id=question.question_id,
         domain=question.domain,

--- a/scripts/run_golden_harness.py
+++ b/scripts/run_golden_harness.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+"""Run the Agent-0 golden question harness.
+
+The harness is opt-in and local-only. Dry-run mode is fully offline and never
+calls LiteLLM, Ollama or Qdrant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import mean
+from uuid import uuid4
+
+import yaml
+
+from scripts import run_local_agent
+
+
+DEFAULT_QUESTIONS_PATH = Path("tests/golden/questions.yaml")
+DEFAULT_OUTPUT_DIR = Path("tests/golden/reports")
+HARNESS_GUARD_ENV = "RUN_GOLDEN_HARNESS"
+
+
+@dataclass(frozen=True)
+class GoldenQuestion:
+    """Synthetic golden benchmark question."""
+
+    question_id: str
+    domain: str
+    mode: str
+    question: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class GoldenResult:
+    """Safe per-question benchmark result without answer text."""
+
+    question_id: str
+    domain: str
+    mode: str
+    route: str
+    alias: str | None
+    used_rag: bool
+    latency_ms: float
+    decision_id: str
+    estimated_remote_tokens_avoided: int | float
+    answer_length_chars: int
+    error_category: str | None
+    fallback_applied: bool | None
+    fallback_reason: str | None
+    quality_score: None
+    skipped: bool = False
+    skipped_reason: str | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return allowlisted JSONL-safe result metadata."""
+        data: dict[str, object] = {
+            "question_id": self.question_id,
+            "domain": self.domain,
+            "mode": self.mode,
+            "route": self.route,
+            "used_rag": self.used_rag,
+            "latency_ms": self.latency_ms,
+            "decision_id": self.decision_id,
+            "estimated_remote_tokens_avoided": (
+                self.estimated_remote_tokens_avoided
+            ),
+            "answer_length_chars": self.answer_length_chars,
+            "quality_score": self.quality_score,
+            "skipped": self.skipped,
+        }
+        optional_values: dict[str, object | None] = {
+            "alias": self.alias,
+            "error_category": self.error_category,
+            "fallback_applied": self.fallback_applied,
+            "fallback_reason": self.fallback_reason,
+            "skipped_reason": self.skipped_reason,
+        }
+        for key, value in optional_values.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse harness CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the opt-in Agent-0 golden question harness.",
+    )
+    parser.add_argument(
+        "--questions",
+        default=str(DEFAULT_QUESTIONS_PATH),
+        help="Path to the golden question registry.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for JSONL and summary reports.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run offline with deterministic fake runner results.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_questions(path: Path | str = DEFAULT_QUESTIONS_PATH) -> list[GoldenQuestion]:
+    """Load synthetic golden questions from YAML."""
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("golden questions root must be a mapping")
+    items = raw.get("questions")
+    if not isinstance(items, list):
+        raise ValueError("golden questions file must contain a questions list")
+    questions: list[GoldenQuestion] = []
+    seen_ids: set[str] = set()
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise ValueError("each golden question must be a mapping")
+        question = GoldenQuestion(
+            question_id=_read_str(item, "id"),
+            domain=_read_str(item, "domain"),
+            mode=_read_mode(item),
+            question=_read_str(item, "question"),
+            rationale=_read_str(item, "rationale"),
+        )
+        if question.question_id in seen_ids:
+            raise ValueError(f"duplicate golden question id: {question.question_id}")
+        seen_ids.add(question.question_id)
+        questions.append(question)
+    return questions
+
+
+async def run_harness(
+    *,
+    questions_path: Path | str = DEFAULT_QUESTIONS_PATH,
+    output_dir: Path | str = DEFAULT_OUTPUT_DIR,
+    dry_run: bool,
+) -> tuple[Path, Path]:
+    """Run all golden questions and write JSONL plus summary reports."""
+    questions = load_questions(questions_path)
+    run_id = uuid4().hex[:12]
+    timestamp = _utc_now()
+    results: list[GoldenResult] = []
+    for question in questions:
+        if dry_run:
+            result = _dry_run_result(question)
+        else:
+            result = await _live_result(question)
+        results.append(result)
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = out_dir / f"golden_results_{run_id}.jsonl"
+    summary_path = out_dir / f"golden_summary_{run_id}.json"
+    _write_jsonl(jsonl_path, results)
+    _write_summary(
+        summary_path,
+        run_id=run_id,
+        timestamp_utc=timestamp,
+        results=results,
+    )
+    return jsonl_path, summary_path
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async harness entrypoint."""
+    args = parse_args(argv)
+    if os.environ.get(HARNESS_GUARD_ENV) != "1":
+        sys.stdout.write(
+            "Golden harness is opt-in. Set RUN_GOLDEN_HARNESS=1 to run.\n",
+        )
+        return 2
+    jsonl_path, summary_path = await run_harness(
+        questions_path=args.questions,
+        output_dir=args.output_dir,
+        dry_run=args.dry_run,
+    )
+    sys.stdout.write(f"OK golden_jsonl={jsonl_path} summary_json={summary_path}\n")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def _dry_run_result(question: GoldenQuestion) -> GoldenResult:
+    alias = _alias_for_mode(question.mode)
+    answer = "Dry run: no model call executed."
+    estimated = run_local_agent._estimate_prompt_token_count(question.question)
+    return GoldenResult(
+        question_id=question.question_id,
+        domain=question.domain,
+        mode=question.mode,
+        route="local",
+        alias=alias,
+        used_rag=question.mode == "rag",
+        latency_ms=0.0,
+        decision_id=f"dryrun-{question.question_id}",
+        estimated_remote_tokens_avoided=estimated,
+        answer_length_chars=len(answer),
+        error_category=None,
+        fallback_applied=None,
+        fallback_reason=None,
+        quality_score=None,
+    )
+
+
+async def _live_result(question: GoldenQuestion) -> GoldenResult:
+    result = await run_local_agent.run_agent(
+        question=question.question,
+        use_rag=question.mode == "rag",
+        use_json=question.mode == "json",
+    )
+    return GoldenResult(
+        question_id=question.question_id,
+        domain=question.domain,
+        mode=question.mode,
+        route=result.route,
+        alias=result.alias,
+        used_rag=result.used_rag,
+        latency_ms=result.latency_ms,
+        decision_id=result.decision_id,
+        estimated_remote_tokens_avoided=result.estimated_remote_tokens_avoided,
+        answer_length_chars=len(result.answer),
+        error_category=result.error_category,
+        fallback_applied=result.fallback_applied,
+        fallback_reason=(
+            result.fallback_reason.value
+            if result.fallback_reason is not None
+            else None
+        ),
+        quality_score=None,
+    )
+
+
+def _write_jsonl(path: Path, results: Sequence[GoldenResult]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(result.to_json_dict(), sort_keys=True) + "\n")
+
+
+def _write_summary(
+    path: Path,
+    *,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[GoldenResult],
+) -> None:
+    summary = build_summary(
+        run_id=run_id,
+        timestamp_utc=timestamp_utc,
+        results=results,
+    )
+    path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_summary(
+    *,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[GoldenResult],
+) -> dict[str, object]:
+    """Build a safe aggregate benchmark summary."""
+    failed = sum(1 for result in results if result.error_category is not None)
+    skipped = sum(1 for result in results if result.skipped)
+    passed = len(results) - failed - skipped
+    aliases = sorted(
+        {result.alias for result in results if result.alias is not None}
+    )
+    return {
+        "run_id": run_id,
+        "timestamp_utc": timestamp_utc,
+        "total_questions": len(results),
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "fallback_count": sum(1 for result in results if result.fallback_applied),
+        "mean_latency_ms_by_alias": _latency_by_alias(results, percentile=False),
+        "p95_latency_ms_by_alias": _latency_by_alias(results, percentile=True),
+        "total_estimated_remote_tokens_avoided": sum(
+            result.estimated_remote_tokens_avoided for result in results
+        ),
+        "quality_score_present": False,
+        "model_under_test_aliases": aliases,
+    }
+
+
+def _latency_by_alias(
+    results: Sequence[GoldenResult],
+    *,
+    percentile: bool,
+) -> dict[str, float]:
+    values: dict[str, list[float]] = {}
+    for result in results:
+        if result.alias is None:
+            continue
+        values.setdefault(result.alias, []).append(result.latency_ms)
+    output: dict[str, float] = {}
+    for alias, latencies in values.items():
+        output[alias] = _p95(latencies) if percentile else mean(latencies)
+    return output
+
+
+def _p95(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    index = max(0, min(len(sorted_values) - 1, int(len(sorted_values) * 0.95) - 1))
+    return sorted_values[index]
+
+
+def _alias_for_mode(mode: str) -> str:
+    if mode == "rag":
+        return run_local_agent.LOCAL_RAG_ALIAS
+    if mode == "json":
+        return run_local_agent.LOCAL_JSON_ALIAS
+    return run_local_agent.LOCAL_CHAT_ALIAS
+
+
+def _read_str(item: Mapping[object, object], key: str) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"golden question {key} must be a non-empty string")
+    return value.strip()
+
+
+def _read_mode(item: Mapping[object, object]) -> str:
+    mode = _read_str(item, "mode")
+    if mode not in {"chat", "rag", "json"}:
+        raise ValueError(f"unsupported golden question mode: {mode}")
+    return mode
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -450,9 +450,9 @@ def _elapsed_ms(started_at: float) -> float:
 def _block_reason(decision: RouterDecision) -> str:
     """Return a safe block reason from routing policy metadata."""
     if decision.reason == RouteBlockReason.BUDGET_EXCEEDED.value:
-        return FallbackReason.BUDGET_EXCEEDED.value
+        return RouteBlockReason.BUDGET_EXCEEDED.value
     if decision.reason == RouteBlockReason.UNSUPPORTED_TASK.value:
-        return FallbackReason.UNSUPPORTED_TASK.value
+        return RouteBlockReason.UNSUPPORTED_TASK.value
     return decision.reason
 
 

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -14,9 +14,7 @@ import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
-from math import ceil
 from typing import Any, Protocol
-from typing import cast
 
 from backend.gateway.client import (
     DEFAULT_LLM_JSON_MODEL,
@@ -24,12 +22,13 @@ from backend.gateway.client import (
     DEFAULT_LLM_RAG_MODEL,
     GatewayChatClient,
 )
-from backend.gateway import routing_policy as routing_policy_module
 from backend.gateway.routing_policy import (
     RemoteEscalationPolicy,
     RouteDecisionKind,
     RouterDecision,
     decide_route,
+    estimate_prompt_tokens,
+    load_routing_policy,
 )
 from scripts.rag_ask_local import ask_local
 
@@ -170,7 +169,6 @@ async def run_agent(
     """Run one local Agent-0 request and return a safe result."""
     if use_rag and use_json:
         raise ValueError("--rag and --json cannot be used together")
-    start = time.perf_counter()
     alias = _select_alias(use_rag=use_rag, use_json=use_json)
     estimated_prompt_tokens = _estimate_prompt_token_count(question)
     estimated_completion_tokens = max_tokens or 512
@@ -192,7 +190,7 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=_elapsed_ms(start),
+            latency_ms=0.0,
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
             error_category="blocked",
@@ -204,11 +202,12 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=_elapsed_ms(start),
+            latency_ms=0.0,
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
         )
 
+    start = time.perf_counter()
     try:
         if use_rag:
             active_rag_call = _call_rag if rag_call is None else rag_call
@@ -321,23 +320,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def _safe_policy() -> RemoteEscalationPolicy:
-    loader = getattr(routing_policy_module, "load_routing_policy", None)
-    if callable(loader):
-        try:
-            loaded = cast(Callable[[], object], loader)()
-        except Exception:
-            return RemoteEscalationPolicy(remote_enabled=False)
-        if isinstance(loaded, RemoteEscalationPolicy):
-            return loaded
-    return RemoteEscalationPolicy(remote_enabled=False)
+    """Load routing policy from config with safe fallback."""
+    try:
+        return load_routing_policy()
+    except Exception:
+        return RemoteEscalationPolicy(remote_enabled=False)
 
 
 def _estimate_prompt_token_count(question: str) -> int:
-    estimator = getattr(routing_policy_module, "estimate_prompt_tokens", None)
-    if callable(estimator):
-        return cast(Callable[[str], int], estimator)(question)
-    stripped = question.strip()
-    return max(ceil(len(stripped) / 4) if stripped else 0, 1)
+    """Estimate prompt token count using the local heuristic."""
+    return estimate_prompt_tokens(question)
 
 
 def _select_alias(*, use_rag: bool, use_json: bool) -> str:

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -14,7 +14,9 @@ import sys
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from math import ceil
 from typing import Any, Protocol
+from typing import cast
 
 from backend.gateway.client import (
     DEFAULT_LLM_JSON_MODEL,
@@ -22,13 +24,12 @@ from backend.gateway.client import (
     DEFAULT_LLM_RAG_MODEL,
     GatewayChatClient,
 )
+from backend.gateway import routing_policy as routing_policy_module
 from backend.gateway.routing_policy import (
     RemoteEscalationPolicy,
     RouteDecisionKind,
     RouterDecision,
     decide_route,
-    estimate_prompt_tokens,
-    load_routing_policy,
 )
 from scripts.rag_ask_local import ask_local
 
@@ -169,6 +170,7 @@ async def run_agent(
     """Run one local Agent-0 request and return a safe result."""
     if use_rag and use_json:
         raise ValueError("--rag and --json cannot be used together")
+    start = time.perf_counter()
     alias = _select_alias(use_rag=use_rag, use_json=use_json)
     estimated_prompt_tokens = _estimate_prompt_token_count(question)
     estimated_completion_tokens = max_tokens or 512
@@ -190,7 +192,7 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=0.0,
+            latency_ms=_elapsed_ms(start),
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
             error_category="blocked",
@@ -202,12 +204,11 @@ async def run_agent(
             route=decision.route.value,
             alias=alias,
             used_rag=use_rag,
-            latency_ms=0.0,
+            latency_ms=_elapsed_ms(start),
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
         )
 
-    start = time.perf_counter()
     try:
         if use_rag:
             active_rag_call = _call_rag if rag_call is None else rag_call
@@ -320,16 +321,23 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def _safe_policy() -> RemoteEscalationPolicy:
-    """Load routing policy from config with safe fallback."""
-    try:
-        return load_routing_policy()
-    except Exception:
-        return RemoteEscalationPolicy(remote_enabled=False)
+    loader = getattr(routing_policy_module, "load_routing_policy", None)
+    if callable(loader):
+        try:
+            loaded = cast(Callable[[], object], loader)()
+        except Exception:
+            return RemoteEscalationPolicy(remote_enabled=False)
+        if isinstance(loaded, RemoteEscalationPolicy):
+            return loaded
+    return RemoteEscalationPolicy(remote_enabled=False)
 
 
 def _estimate_prompt_token_count(question: str) -> int:
-    """Estimate prompt token count using the local heuristic."""
-    return estimate_prompt_tokens(question)
+    estimator = getattr(routing_policy_module, "estimate_prompt_tokens", None)
+    if callable(estimator):
+        return cast(Callable[[str], int], estimator)(question)
+    stripped = question.strip()
+    return max(ceil(len(stripped) / 4) if stripped else 0, 1)
 
 
 def _select_alias(*, use_rag: bool, use_json: bool) -> str:

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -39,6 +39,7 @@ LOCAL_JSON_ALIAS = DEFAULT_LLM_JSON_MODEL
 SAFE_ERROR_CATEGORIES = {
     "blocked",
     "chat_unavailable",
+    "json_unavailable",
     "rag_unavailable",
     "invalid_arguments",
 }
@@ -226,7 +227,12 @@ async def run_agent(
                 response_format={"type": "json_object"} if use_json else None,
             )
     except Exception as exc:
-        error_category = "rag_unavailable" if use_rag else "chat_unavailable"
+        if use_rag:
+            error_category = "rag_unavailable"
+        elif use_json:
+            error_category = "json_unavailable"
+        else:
+            error_category = "chat_unavailable"
         if debug:
             error_category = f"{error_category}:{exc.__class__.__name__}"
         return AgentRunResult(

--- a/scripts/run_local_agent.py
+++ b/scripts/run_local_agent.py
@@ -16,6 +16,8 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from loguru import logger
+
 from backend.gateway.client import (
     DEFAULT_LLM_JSON_MODEL,
     DEFAULT_LLM_MODEL,
@@ -23,7 +25,9 @@ from backend.gateway.client import (
     GatewayChatClient,
 )
 from backend.gateway.routing_policy import (
+    FallbackReason,
     RemoteEscalationPolicy,
+    RouteBlockReason,
     RouteDecisionKind,
     RouterDecision,
     decide_route,
@@ -41,6 +45,7 @@ SAFE_ERROR_CATEGORIES = {
     "chat_unavailable",
     "json_unavailable",
     "rag_unavailable",
+    "fallback_alias_failed",
     "invalid_arguments",
 }
 
@@ -96,6 +101,12 @@ class AgentRunResult:
     decision_id: str
     estimated_remote_tokens_avoided: int
     error_category: str | None = None
+    fallback_applied: bool | None = None
+    fallback_from_alias: str | None = None
+    fallback_to_alias: str | None = None
+    fallback_reason: FallbackReason | None = None
+    fallback_chain: tuple[FallbackReason, ...] | None = None
+    block_reason: str | None = None
 
     def to_json_dict(self) -> dict[str, object]:
         """Return the safe public output schema."""
@@ -110,6 +121,18 @@ class AgentRunResult:
         }
         if self.error_category is not None:
             data["error_category"] = self.error_category
+        if self.fallback_applied is not None:
+            data["fallback_applied"] = self.fallback_applied
+        if self.fallback_from_alias is not None:
+            data["fallback_from_alias"] = self.fallback_from_alias
+        if self.fallback_to_alias is not None:
+            data["fallback_to_alias"] = self.fallback_to_alias
+        if self.fallback_reason is not None:
+            data["fallback_reason"] = self.fallback_reason.value
+        if self.fallback_chain:
+            data["fallback_chain"] = [reason.value for reason in self.fallback_chain]
+        if self.block_reason is not None:
+            data["block_reason"] = self.block_reason
         return data
 
 
@@ -195,6 +218,8 @@ async def run_agent(
             decision_id=decision.decision_id,
             estimated_remote_tokens_avoided=safe_avoided,
             error_category="blocked",
+            fallback_applied=False,
+            block_reason=_block_reason(decision),
         )
 
     if dry_run:
@@ -212,11 +237,75 @@ async def run_agent(
     try:
         if use_rag:
             active_rag_call = _call_rag if rag_call is None else rag_call
-            answer = await active_rag_call(
-                question,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            try:
+                answer = await active_rag_call(
+                    question,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+            except Exception as rag_exc:
+                active_chat_call = _call_chat_alias if chat_call is None else chat_call
+                fallback_reason = _rag_fallback_reason(rag_exc)
+                try:
+                    answer = await active_chat_call(
+                        question,
+                        alias=LOCAL_CHAT_ALIAS,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        response_format=None,
+                    )
+                except Exception as chat_exc:
+                    latency_ms = _elapsed_ms(start)
+                    _emit_fallback_event(
+                        decision_id=decision.decision_id,
+                        fallback_reason=fallback_reason,
+                        original_alias=LOCAL_RAG_ALIAS,
+                        fallback_alias=LOCAL_CHAT_ALIAS,
+                        fallback_succeeded=False,
+                        latency_ms=latency_ms,
+                    )
+                    error_category = "fallback_alias_failed"
+                    if debug:
+                        error_category = f"{error_category}:{chat_exc.__class__.__name__}"
+                    return AgentRunResult(
+                        answer="Local Agent-0 execution failed.",
+                        route=decision.route.value,
+                        alias=LOCAL_CHAT_ALIAS,
+                        used_rag=False,
+                        latency_ms=latency_ms,
+                        decision_id=decision.decision_id,
+                        estimated_remote_tokens_avoided=safe_avoided,
+                        error_category=error_category,
+                        fallback_applied=True,
+                        fallback_from_alias=LOCAL_RAG_ALIAS,
+                        fallback_to_alias=LOCAL_CHAT_ALIAS,
+                        fallback_reason=fallback_reason,
+                        fallback_chain=(fallback_reason,),
+                    )
+
+                latency_ms = _elapsed_ms(start)
+                _emit_fallback_event(
+                    decision_id=decision.decision_id,
+                    fallback_reason=fallback_reason,
+                    original_alias=LOCAL_RAG_ALIAS,
+                    fallback_alias=LOCAL_CHAT_ALIAS,
+                    fallback_succeeded=True,
+                    latency_ms=latency_ms,
+                )
+                return AgentRunResult(
+                    answer=answer,
+                    route=decision.route.value,
+                    alias=LOCAL_CHAT_ALIAS,
+                    used_rag=False,
+                    latency_ms=latency_ms,
+                    decision_id=decision.decision_id,
+                    estimated_remote_tokens_avoided=safe_avoided,
+                    fallback_applied=True,
+                    fallback_from_alias=LOCAL_RAG_ALIAS,
+                    fallback_to_alias=LOCAL_CHAT_ALIAS,
+                    fallback_reason=fallback_reason,
+                    fallback_chain=(fallback_reason,),
+                )
         else:
             active_chat_call = _call_chat_alias if chat_call is None else chat_call
             answer = await active_chat_call(
@@ -356,6 +445,47 @@ def _task_type(*, use_rag: bool, use_json: bool) -> str:
 
 def _elapsed_ms(started_at: float) -> float:
     return (time.perf_counter() - started_at) * 1000
+
+
+def _block_reason(decision: RouterDecision) -> str:
+    """Return a safe block reason from routing policy metadata."""
+    if decision.reason == RouteBlockReason.BUDGET_EXCEEDED.value:
+        return FallbackReason.BUDGET_EXCEEDED.value
+    if decision.reason == RouteBlockReason.UNSUPPORTED_TASK.value:
+        return FallbackReason.UNSUPPORTED_TASK.value
+    return decision.reason
+
+
+def _rag_fallback_reason(exc: Exception) -> FallbackReason:
+    """Classify a RAG failure without exposing exception details."""
+    class_name = exc.__class__.__name__.lower()
+    module_name = exc.__class__.__module__.lower()
+    if "qdrant" in class_name or "qdrant" in module_name:
+        return FallbackReason.QDRANT_UNAVAILABLE
+    return FallbackReason.RAG_UNAVAILABLE
+
+
+def _emit_fallback_event(
+    *,
+    decision_id: str,
+    fallback_reason: FallbackReason,
+    original_alias: str,
+    fallback_alias: str,
+    fallback_succeeded: bool,
+    latency_ms: float,
+) -> None:
+    """Emit a safe local fallback event with allowlisted metadata only."""
+    event: dict[str, object] = {
+        "event": "agent_fallback",
+        "decision_id": decision_id,
+        "fallback_reason": fallback_reason.value,
+        "original_alias": original_alias,
+        "fallback_alias": fallback_alias,
+        "fallback_succeeded": fallback_succeeded,
+        "latency_ms": latency_ms,
+        "status": "success" if fallback_succeeded else "failure",
+    }
+    logger.bind(event=event).info("agent_fallback")
 
 
 if __name__ == "__main__":

--- a/scripts/run_rag_latency_baseline.py
+++ b/scripts/run_rag_latency_baseline.py
@@ -97,7 +97,7 @@ def _build_pipeline() -> LocalRagPipeline:
     """Build a LocalRagPipeline from environment and config."""
     from backend.gateway.client import GatewayChatClient, GatewayRuntimeConfig
     from backend.gateway.embed_client import GatewayEmbedClient
-    from backend.qdrant_store import QdrantVectorStore
+    from backend.rag.qdrant_store import QdrantVectorStore
     from backend.rag.retriever import Retriever
 
     embed_client = GatewayEmbedClient()

--- a/scripts/run_rag_latency_baseline.py
+++ b/scripts/run_rag_latency_baseline.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+"""RAG per-segment latency baseline — 3-run collector.
+
+Produces three labelled trace JSONs:
+  cold_start     — first pipeline call after service startup
+  warm_model     — immediate repeat call (model already loaded)
+  degraded_qdrant — retrieval forced to fail via fake store
+
+Usage (opt-in only):
+  RUN_RAG_LATENCY_BASELINE=1 uv run python scripts/run_rag_latency_baseline.py
+
+Output files are written to --output-dir (default: reports/g2_latency_baseline/).
+Files are gitignored. No prompt, answer, chunks, vectors or secrets are written.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.retriever import Retriever
+from backend.rag.run_trace import RagRunContext, load_rag_tracing_config
+
+GUARD_ENV = "RUN_RAG_LATENCY_BASELINE"
+# Synthetic question — text never written to any output.
+_SYNTHETIC_QUESTION = (
+    "Qual é o impacto do aumento da taxa Selic sobre a rentabilidade "
+    "de títulos prefixados em carteiras de renda fixa?"
+)
+_QUESTION_HASH_8 = hashlib.sha256(
+    _SYNTHETIC_QUESTION.encode("utf-8")
+).hexdigest()[:8]
+
+DEFAULT_OUTPUT_DIR = Path("reports/g2_latency_baseline")
+
+SEGMENT_KEYS = (
+    "embedding_ms",
+    "retrieval_ms",
+    "context_pack_ms",
+    "prompt_build_ms",
+    "generation_ms",
+    "total_ms",
+)
+FORBIDDEN_KEYS = frozenset(
+    {
+        "prompt", "question", "answer", "chunks", "chunk_text",
+        "vectors", "embeddings", "payload", "qdrant_payload",
+        "api_key", "authorization", "headers", "secret", "password",
+        "raw_response", "raw_exception", "exception_message", "traceback",
+        "raw_user_input",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BaselineRunResult:
+    run_context: RagRunContext
+    question_hash_8: str
+    segment_ms: dict[str, float | None]
+    ollama_metrics_available: bool
+    ollama_eval_count: int | None
+    ollama_eval_duration_ms: float | None
+    ollama_prompt_eval_count: int | None
+    ollama_prompt_eval_duration_ms: float | None
+    wall_ms: float
+    ok: bool
+    error_category: str | None
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "run_context": self.run_context,
+            "question_hash_8": self.question_hash_8,
+            "segments": {k: v for k, v in self.segment_ms.items() if v is not None},
+            "ollama_metrics_available": self.ollama_metrics_available,
+            "ollama_eval_count": self.ollama_eval_count,
+            "ollama_eval_duration_ms": self.ollama_eval_duration_ms,
+            "ollama_prompt_eval_count": self.ollama_prompt_eval_count,
+            "ollama_prompt_eval_duration_ms": self.ollama_prompt_eval_duration_ms,
+            "wall_ms": self.wall_ms,
+            "ok": self.ok,
+            "error_category": self.error_category,
+        }
+
+
+def _build_pipeline() -> LocalRagPipeline:
+    """Build a LocalRagPipeline from environment and config."""
+    from backend.gateway.client import GatewayChatClient, GatewayRuntimeConfig
+    from backend.gateway.embed_client import GatewayEmbedClient
+    from backend.qdrant_store import QdrantVectorStore
+    from backend.rag.retriever import Retriever
+
+    embed_client = GatewayEmbedClient()
+    store = QdrantVectorStore()
+    retriever = Retriever(embedder=embed_client, store=store)
+    generator = GatewayChatClient(config=GatewayRuntimeConfig())
+    tracing_config = load_rag_tracing_config().validated()
+
+    return LocalRagPipeline(
+        retriever=retriever,
+        generator=generator,
+        prompt_builder=PromptBuilder(),
+        tracing_config=tracing_config,
+    )
+
+
+def _build_degraded_pipeline() -> LocalRagPipeline:
+    """Build a pipeline with a fake store that raises on search."""
+    from backend.gateway.client import GatewayChatClient, GatewayRuntimeConfig
+    from backend.gateway.embed_client import GatewayEmbedClient
+    from backend.rag.retriever import Retriever
+
+    class _FakeUnavailableStore:
+        async def search(self, *args: object, **kwargs: object) -> list[object]:
+            raise RuntimeError("FakeQdrantUnavailableError: store unreachable")
+
+    embed_client = GatewayEmbedClient()
+    retriever = Retriever(embedder=embed_client, store=_FakeUnavailableStore())  # type: ignore[arg-type]
+    generator = GatewayChatClient(config=GatewayRuntimeConfig())
+    tracing_config = load_rag_tracing_config().validated()
+
+    return LocalRagPipeline(
+        retriever=retriever,
+        generator=generator,
+        prompt_builder=PromptBuilder(),
+        tracing_config=tracing_config,
+    )
+
+
+def _capture_trace(pipeline: LocalRagPipeline) -> list[dict[str, object]]:
+    """Install a loguru sink and collect all rag_run_trace dicts."""
+    captured: list[dict[str, object]] = []
+
+    def sink(message: Any) -> None:
+        record = message.record
+        if record["message"] == "rag_run_trace":
+            trace = record["extra"].get("trace")
+            if isinstance(trace, dict):
+                captured.append(dict(trace))
+
+    sink_id = logger.add(sink, level="DEBUG")
+    return captured, sink_id  # type: ignore[return-value]
+
+
+async def _run_once(
+    pipeline: LocalRagPipeline,
+    run_context: RagRunContext,
+) -> BaselineRunResult:
+    captured: list[dict[str, object]] = []
+    sink_id: int | None = None
+
+    def _sink(message: Any) -> None:
+        record = message.record
+        if record["message"] == "rag_run_trace":
+            trace = record["extra"].get("trace")
+            if isinstance(trace, dict):
+                captured.append(dict(trace))
+
+    sink_id = logger.add(_sink, level="DEBUG")
+    wall_start = time.perf_counter()
+    error_category: str | None = None
+    ok = False
+    try:
+        await pipeline.ask(_SYNTHETIC_QUESTION, run_context=run_context)
+        ok = True
+    except Exception as exc:
+        error_category = type(exc).__name__
+        logger.debug("baseline run raised: {}", type(exc).__name__)
+    finally:
+        wall_ms = (time.perf_counter() - wall_start) * 1000.0
+        if sink_id is not None:
+            logger.remove(sink_id)
+
+    trace = captured[0] if captured else {}
+    segments = {k: trace.get(k) for k in SEGMENT_KEYS}
+
+    return BaselineRunResult(
+        run_context=run_context,
+        question_hash_8=_QUESTION_HASH_8,
+        segment_ms=segments,
+        ollama_metrics_available=bool(trace.get("ollama_metrics_available", False)),
+        ollama_eval_count=trace.get("ollama_eval_count"),  # type: ignore[arg-type]
+        ollama_eval_duration_ms=trace.get("ollama_eval_duration_ms"),  # type: ignore[arg-type]
+        ollama_prompt_eval_count=trace.get("ollama_prompt_eval_count"),  # type: ignore[arg-type]
+        ollama_prompt_eval_duration_ms=trace.get("ollama_prompt_eval_duration_ms"),  # type: ignore[arg-type]
+        wall_ms=wall_ms,
+        ok=ok,
+        error_category=error_category,
+    )
+
+
+def _assert_no_forbidden_keys(data: dict[str, object]) -> None:
+    lowered = {str(k).lower() for k in _flatten_keys(data)}
+    leaked = lowered & FORBIDDEN_KEYS
+    if leaked:
+        raise ValueError(f"Forbidden keys in baseline output: {leaked}")
+
+
+def _flatten_keys(obj: object) -> list[str]:
+    keys: list[str] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            keys.append(str(k))
+            keys.extend(_flatten_keys(v))
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            keys.extend(_flatten_keys(item))
+    return keys
+
+
+def _write_result(output_dir: Path, result: BaselineRunResult) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    fname = f"baseline_{result.run_context}_{result.question_hash_8}.json"
+    path = output_dir / fname
+    data = result.to_json_dict()
+    _assert_no_forbidden_keys(data)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _print_summary(results: list[BaselineRunResult]) -> None:
+    print("\n" + "=" * 60)
+    print("RAG LATENCY BASELINE — SUMMARY")
+    print("=" * 60)
+    for r in results:
+        segs = r.segment_ms
+        total = segs.get("total_ms")
+        gen = segs.get("generation_ms")
+        emb = segs.get("embedding_ms")
+        ret = segs.get("retrieval_ms")
+        pct = f"{gen / total * 100:.1f}%" if (total and gen) else "n/a"
+        print(f"\n[{r.run_context}]  ok={r.ok}  wall={r.wall_ms:.0f}ms")
+        print(f"  embedding_ms   : {emb}")
+        print(f"  retrieval_ms   : {ret}")
+        print(f"  context_pack_ms: {segs.get('context_pack_ms')}")
+        print(f"  prompt_build_ms: {segs.get('prompt_build_ms')}")
+        print(f"  generation_ms  : {gen}")
+        print(f"  total_ms       : {total}")
+        print(f"  generation %   : {pct}")
+        if r.ollama_metrics_available:
+            print(f"  ollama_eval_count     : {r.ollama_eval_count}")
+            print(f"  ollama_eval_ms        : {r.ollama_eval_duration_ms}")
+            print(f"  ollama_prompt_eval_ms : {r.ollama_prompt_eval_duration_ms}")
+        else:
+            print("  ollama_metrics_available: False (LiteLLM normalizes response)")
+
+    # Answer the 4 merge-criterion questions
+    contexts = {r.run_context for r in results}
+    all_ok_or_degraded = all(
+        r.ok or r.run_context == "degraded_qdrant" for r in results
+    )
+    segments_present = all(
+        r.segment_ms.get("generation_ms") is not None
+        and r.segment_ms.get("retrieval_ms") is not None
+        for r in results
+        if r.ok
+    )
+    distinguishable = len(contexts) == len(results)
+
+    print("\n" + "-" * 60)
+    print("MERGE CRITERION ANSWERS:")
+    print(f"  1. 3 runs successful?          {'YES' if all_ok_or_degraded else 'NO'}")
+    print(f"  2. generation_ms visible?      {'YES' if segments_present else 'NO'}")
+    print(f"  3. retrieval_ms visible?       {'YES' if segments_present else 'NO'}")
+    print(f"  4. cold/warm/degraded distinct?{'YES' if distinguishable else 'NO'}")
+    print(f"  5. no forbidden keys?          YES (validated before write)")
+    print("-" * 60)
+
+
+async def main_async(output_dir: Path) -> int:
+    if os.environ.get(GUARD_ENV) != "1":
+        print(
+            f"Opt-in required: set {GUARD_ENV}=1 to run the baseline.",
+            file=sys.stderr,
+        )
+        return 2
+
+    logger.remove()  # suppress loguru noise to stdout during baseline
+    results: list[BaselineRunResult] = []
+
+    print("Building live pipeline (cold_start run)…")
+    pipeline = _build_pipeline()
+    r1 = await _run_once(pipeline, "cold_start")
+    results.append(r1)
+    path1 = _write_result(output_dir, r1)
+    print(f"  cold_start  → {path1}  ({r1.wall_ms:.0f} ms)")
+
+    print("Running warm_model…")
+    r2 = await _run_once(pipeline, "warm_model")
+    results.append(r2)
+    path2 = _write_result(output_dir, r2)
+    print(f"  warm_model  → {path2}  ({r2.wall_ms:.0f} ms)")
+
+    print("Building degraded pipeline (fake Qdrant unavailable)…")
+    deg_pipeline = _build_degraded_pipeline()
+    r3 = await _run_once(deg_pipeline, "degraded_qdrant")
+    results.append(r3)
+    path3 = _write_result(output_dir, r3)
+    print(f"  degraded    → {path3}  ({r3.wall_ms:.0f} ms)")
+
+    _print_summary(results)
+    return 0
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for baseline JSON files (default: reports/g2_latency_baseline/)",
+    )
+    args = parser.parse_args()
+    return asyncio.run(main_async(args.output_dir))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_gateway1_proof_of_life.py
+++ b/scripts/test_gateway1_proof_of_life.py
@@ -1,0 +1,758 @@
+#!/usr/bin/env python
+"""Gateway-1 operational proof-of-life smoke.
+
+The smoke is opt-in, local-only and writes a sanitized structured summary.
+It never stores prompt text, answer text, chunks, vectors, payloads or secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from backend.gateway.observability_contract import PROHIBITED_SIGNAL_KEYS
+from backend.gateway.routing_policy import (
+    FallbackReason,
+    RemoteEscalationPolicy,
+)
+from scripts import run_local_agent
+
+# Smoke summaries must not include "answer" — that key belongs to runner output
+# only and should never surface in observability reports.
+PROHIBITED_SMOKE_SUMMARY_KEYS: frozenset[str] = PROHIBITED_SIGNAL_KEYS | frozenset({"answer"})
+
+GUARD_ENV = "RUN_GATEWAY1_PROOF_OF_LIFE"
+DEFAULT_OUTPUT_DIR = Path("reports/gateway1_smoke")
+CRITERIA_MANIFEST_REF = "docs/sprints/GATEWAY1_DONE_CRITERIA.md"
+GATEWAY_SPRINT = "Gateway-1"
+DEFAULT_LITELLM_BASE_URL = "http://127.0.0.1:4000/v1"
+DEFAULT_QDRANT_URL = "http://127.0.0.1:6333"
+DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
+PROBE_TIMEOUT_SECONDS = 5.0
+REQUIRED_ALIASES = (
+    "local_chat",
+    "local_rag",
+    "local_json",
+    "local_think",
+    "quimera_embed",
+    "local_embed",
+)
+MANDATORY_CRITERIA = {
+    "G1-01": True,
+    "G1-02": True,
+    "G1-03": True,
+    "G1-04": True,
+    "G1-05": True,
+    "G1-06": True,
+    "G1-07": True,
+    "G1-08": True,
+    "G1-09": True,
+    "G1-10": True,
+    "G1-11": True,
+}
+FAKE_SENSITIVE_VALUES = (
+    "FAKE_API_KEY_SHOULD_NOT_APPEAR",
+    "FAKE_AUTH_HEADER_SHOULD_NOT_APPEAR",
+    "FAKE_PROMPT_SHOULD_NOT_APPEAR",
+    "FAKE_CHUNK_SHOULD_NOT_APPEAR",
+    "FAKE_VECTOR_SHOULD_NOT_APPEAR",
+)
+
+
+class FakeQdrantUnavailableError(RuntimeError):
+    """Synthetic Qdrant-like exception used for deterministic degradation."""
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Safe read-only service probe result."""
+
+    service: str
+    ok: bool
+    latency_ms: float
+    error_category: str | None = None
+    missing_aliases: tuple[str, ...] = ()
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted probe metadata."""
+        data: dict[str, object] = {
+            "service": self.service,
+            "ok": self.ok,
+            "latency_ms": self.latency_ms,
+        }
+        if self.error_category is not None:
+            data["error_category"] = self.error_category
+        if self.missing_aliases:
+            data["missing_aliases"] = list(self.missing_aliases)
+        return data
+
+
+@dataclass(frozen=True)
+class RunnerSmokeResult:
+    """Safe Agent-0 smoke result without answer text."""
+
+    name: str
+    ok: bool
+    route: str | None
+    alias: str | None
+    used_rag: bool | None
+    latency_ms: float
+    decision_id: str | None
+    estimated_remote_tokens_avoided: int | float | None
+    answer_length_chars: int | None
+    error_category: str | None = None
+    fallback_applied: bool | None = None
+    fallback_reason: str | None = None
+    model_call_attempted: bool | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted runner smoke metadata."""
+        data: dict[str, object] = {
+            "name": self.name,
+            "ok": self.ok,
+            "latency_ms": self.latency_ms,
+        }
+        optional: dict[str, object | None] = {
+            "route": self.route,
+            "alias": self.alias,
+            "used_rag": self.used_rag,
+            "decision_id": self.decision_id,
+            "estimated_remote_tokens_avoided": (
+                self.estimated_remote_tokens_avoided
+            ),
+            "answer_length_chars": self.answer_length_chars,
+            "error_category": self.error_category,
+            "fallback_applied": self.fallback_applied,
+            "fallback_reason": self.fallback_reason,
+            "model_call_attempted": self.model_call_attempted,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+@dataclass(frozen=True)
+class GatewayProofOfLifeSummary:
+    """Sanitized proof-of-life report."""
+
+    run_id: str
+    timestamp_utc: str
+    gateway_sprint: str
+    criteria_manifest_ref: str
+    service_probes: Mapping[str, ProbeResult]
+    runner_tests: Mapping[str, RunnerSmokeResult]
+    passed: tuple[str, ...]
+    failed: tuple[str, ...]
+    skipped: tuple[str, ...]
+    criteria_met: Mapping[str, bool]
+    overall_passed: bool
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return explicit allowlisted summary metadata."""
+        return {
+            "run_id": self.run_id,
+            "timestamp_utc": self.timestamp_utc,
+            "gateway_sprint": self.gateway_sprint,
+            "criteria_manifest_ref": self.criteria_manifest_ref,
+            "service_probes": {
+                name: probe.to_json_dict()
+                for name, probe in sorted(self.service_probes.items())
+            },
+            "runner_tests": {
+                name: result.to_json_dict()
+                for name, result in sorted(self.runner_tests.items())
+            },
+            "passed": list(self.passed),
+            "failed": list(self.failed),
+            "skipped": list(self.skipped),
+            "criteria_met": dict(sorted(self.criteria_met.items())),
+            "overall_passed": self.overall_passed,
+        }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse proof-of-life smoke arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the opt-in Gateway-1 proof-of-life smoke.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for the sanitized summary JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def require_guard_enabled() -> bool:
+    """Return whether the live proof-of-life guard is enabled."""
+    return os.environ.get(GUARD_ENV) == "1"
+
+
+async def run_proof_of_life(
+    *,
+    output_dir: Path | str,
+) -> tuple[GatewayProofOfLifeSummary, Path | None]:
+    """Run the Gateway-1 proof-of-life smoke and write a summary if possible."""
+    run_id = uuid4().hex[:12]
+    criteria_met: dict[str, bool] = {criterion: False for criterion in MANDATORY_CRITERIA}
+    skipped: set[str] = set()
+    probes: dict[str, ProbeResult] = {}
+    runner_tests: dict[str, RunnerSmokeResult] = {}
+
+    dry_run = await run_dry_run_smoke()
+    runner_tests["dry_run"] = dry_run
+    criteria_met["G1-01"] = dry_run.ok
+
+    urls = GatewayUrls.from_env()
+    local_guard_ok = urls.are_local_only()
+    criteria_met["G1-02"] = local_guard_ok
+
+    if local_guard_ok:
+        (
+            probes["ollama"],
+            probes["qdrant"],
+            probes["litellm"],
+        ) = await asyncio.gather(
+            probe_ollama(urls.ollama_api_base),
+            probe_qdrant(urls.qdrant_url),
+            probe_litellm(
+                urls.litellm_base_url,
+                api_key=os.environ.get("QUIMERA_LLM_API_KEY"),
+            ),
+        )
+        criteria_met["G1-03"] = probes["ollama"].ok
+        criteria_met["G1-04"] = probes["qdrant"].ok
+        criteria_met["G1-05"] = probes["litellm"].ok
+    else:
+        probes.update(_local_url_rejected_probes())
+        skipped.update({"G1-03", "G1-04", "G1-05", "G1-06", "G1-07"})
+
+    live_ready = all(
+        criteria_met[criterion] for criterion in ("G1-02", "G1-03", "G1-05")
+    )
+    if live_ready:
+        local_chat = await run_local_chat_smoke()
+        runner_tests["local_chat"] = local_chat
+        criteria_met["G1-06"] = local_chat.ok
+    elif "G1-06" not in skipped:
+        skipped.add("G1-06")
+
+    rag_ready = all(
+        criteria_met[criterion]
+        for criterion in ("G1-02", "G1-03", "G1-04", "G1-05")
+    )
+    if rag_ready:
+        rag_smoke = await run_rag_smoke()
+        runner_tests["rag"] = rag_smoke
+        criteria_met["G1-07"] = rag_smoke.ok
+    elif "G1-07" not in skipped:
+        skipped.add("G1-07")
+
+    forced_degradation = await run_forced_qdrant_degradation_smoke()
+    runner_tests["forced_qdrant_degradation"] = forced_degradation
+    criteria_met["G1-08"] = forced_degradation.ok
+
+    policy_block = await run_policy_block_smoke()
+    runner_tests["policy_block"] = policy_block
+    criteria_met["G1-09"] = policy_block.ok
+
+    try:
+        provisional = _build_summary(
+            run_id=run_id,
+            probes=probes,
+            runner_tests=runner_tests,
+            criteria_met=criteria_met,
+            skipped=skipped,
+        )
+        assert_sanitized(provisional.to_json_dict())
+        criteria_met["G1-10"] = True
+    except ValueError:
+        criteria_met["G1-10"] = False
+
+    summary = _build_summary(
+        run_id=run_id,
+        probes=probes,
+        runner_tests=runner_tests,
+        criteria_met=criteria_met,
+        skipped=skipped,
+    )
+
+    summary_path: Path | None = None
+    try:
+        summary_path = write_summary(output_dir, summary)
+        criteria_met["G1-11"] = True
+    except OSError:
+        criteria_met["G1-11"] = False
+    summary = _build_summary(
+        run_id=run_id,
+        probes=probes,
+        runner_tests=runner_tests,
+        criteria_met=criteria_met,
+        skipped=skipped,
+    )
+    if summary_path is not None:
+        write_summary(output_dir, summary, path=summary_path)
+    return summary, summary_path
+
+
+@dataclass(frozen=True)
+class GatewayUrls:
+    """Local service URLs used by Gateway-1 smoke."""
+
+    litellm_base_url: str
+    qdrant_url: str
+    ollama_api_base: str
+
+    @classmethod
+    def from_env(cls) -> GatewayUrls:
+        """Build URLs from environment with local defaults."""
+        return cls(
+            litellm_base_url=os.environ.get(
+                "QUIMERA_LLM_BASE_URL",
+                DEFAULT_LITELLM_BASE_URL,
+            ),
+            qdrant_url=os.environ.get("QDRANT_URL", DEFAULT_QDRANT_URL),
+            ollama_api_base=os.environ.get(
+                "OLLAMA_API_BASE",
+                DEFAULT_OLLAMA_API_BASE,
+            ),
+        )
+
+    def are_local_only(self) -> bool:
+        """Return true only when all service URLs are local."""
+        return all(
+            is_local_url(url)
+            for url in (self.litellm_base_url, self.qdrant_url, self.ollama_api_base)
+        )
+
+
+def is_local_url(url: str) -> bool:
+    """Return whether ``url`` is an allowed local HTTP URL."""
+    return url.startswith("http://127.0.0.1:") or url.startswith("http://localhost:")
+
+
+def _local_url_rejected_probes() -> dict[str, ProbeResult]:
+    """Return safe placeholder probe results when URL guard blocks execution."""
+    return {
+        "ollama": ProbeResult(
+            service="ollama",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+        "qdrant": ProbeResult(
+            service="qdrant",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+        "litellm": ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="local_url_rejected",
+        ),
+    }
+
+
+async def probe_ollama(base_url: str) -> ProbeResult:
+    """Probe Ollama tags endpoint without mutating state."""
+    return await _http_probe(
+        service="ollama",
+        url=f"{base_url.rstrip('/')}/api/tags",
+        expected_json_mapping=True,
+    )
+
+
+async def probe_qdrant(base_url: str) -> ProbeResult:
+    """Probe Qdrant health endpoint without mutating state."""
+    return await _http_probe(
+        service="qdrant",
+        url=f"{base_url.rstrip('/')}/healthz",
+        expected_json_mapping=False,
+    )
+
+
+async def probe_litellm(base_url: str, *, api_key: str | None) -> ProbeResult:
+    """Probe LiteLLM models endpoint and required aliases."""
+    if not api_key:
+        return ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="authentication",
+        )
+    start = time.perf_counter()
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{base_url.rstrip('/')}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        response.raise_for_status()
+        payload = response.json()
+        aliases = _extract_model_aliases(payload)
+        missing = tuple(alias for alias in REQUIRED_ALIASES if alias not in aliases)
+        return ProbeResult(
+            service="litellm",
+            ok=not missing,
+            latency_ms=_elapsed_ms(start),
+            error_category="alias_missing" if missing else None,
+            missing_aliases=missing,
+        )
+    except Exception as exc:
+        return ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=_elapsed_ms(start),
+            error_category=categorize_probe_exception(exc),
+        )
+
+
+async def _http_probe(
+    *,
+    service: str,
+    url: str,
+    expected_json_mapping: bool,
+) -> ProbeResult:
+    start = time.perf_counter()
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
+            response = await client.get(url)
+        response.raise_for_status()
+        if expected_json_mapping and not isinstance(response.json(), Mapping):
+            return ProbeResult(
+                service=service,
+                ok=False,
+                latency_ms=_elapsed_ms(start),
+                error_category="invalid_response",
+            )
+        return ProbeResult(service=service, ok=True, latency_ms=_elapsed_ms(start))
+    except Exception as exc:
+        return ProbeResult(
+            service=service,
+            ok=False,
+            latency_ms=_elapsed_ms(start),
+            error_category=categorize_probe_exception(exc),
+        )
+
+
+def categorize_probe_exception(exc: Exception) -> str:
+    """Map probe exceptions to safe categories without raw messages."""
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.ConnectError):
+        return "connection"
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code in {401, 403}:
+            return "authentication"
+        return "invalid_response"
+    if isinstance(exc, httpx.RequestError):
+        return "connection"
+    if isinstance(exc, (json.JSONDecodeError, ValueError, TypeError)):
+        return "invalid_response"
+    return "unknown"
+
+
+async def run_dry_run_smoke() -> RunnerSmokeResult:
+    """Run Agent-0 dry-run without live services."""
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica de dry-run.",
+        dry_run=True,
+    )
+    ok = (
+        result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and result.latency_ms == 0.0
+        and result.estimated_remote_tokens_avoided >= 0
+    )
+    return _runner_result("dry_run", result, ok=ok)
+
+
+async def run_local_chat_smoke() -> RunnerSmokeResult:
+    """Run one live Agent-0 default local_chat question."""
+    result = await run_local_agent.run_agent(
+        question="Explique de forma sintetica o que e diversificacao.",
+        max_tokens=128,
+        temperature=0.0,
+    )
+    ok = (
+        result.route == "local"
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+        and result.error_category is None
+        and result.estimated_remote_tokens_avoided >= 0
+    )
+    return _runner_result("local_chat", result, ok=ok)
+
+
+async def run_rag_smoke() -> RunnerSmokeResult:
+    """Run live Agent-0 RAG and accept success or explicit local fallback."""
+    result = await run_local_agent.run_agent(
+        question="Use contexto sintetico para explicar uma politica de risco.",
+        use_rag=True,
+        max_tokens=160,
+        temperature=0.0,
+    )
+    rag_success = (
+        result.alias == run_local_agent.LOCAL_RAG_ALIAS
+        and result.used_rag
+        and result.error_category is None
+        and not result.fallback_applied
+    )
+    explicit_fallback = (
+        result.fallback_applied is True
+        and result.fallback_reason is not None
+        and result.fallback_reason.value in {reason.value for reason in FallbackReason}
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+    )
+    return _runner_result("rag", result, ok=rag_success or explicit_fallback)
+
+
+async def run_forced_qdrant_degradation_smoke() -> RunnerSmokeResult:
+    """Inject a Qdrant-like failure and verify one safe fallback."""
+    rag_calls = 0
+    chat_calls = 0
+
+    async def rag_call(
+        question: str,
+        *,
+        max_tokens: int | None,
+        temperature: float | None,
+    ) -> str:
+        nonlocal rag_calls
+        del question, max_tokens, temperature
+        rag_calls += 1
+        raise FakeQdrantUnavailableError("synthetic local unavailable")
+
+    async def chat_call(
+        question: str,
+        *,
+        alias: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        response_format: Mapping[str, object] | None,
+    ) -> str:
+        nonlocal chat_calls
+        del question, alias, max_tokens, temperature, response_format
+        chat_calls += 1
+        return "Resposta sintetica de fallback local."
+
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica para degradacao.",
+        use_rag=True,
+        chat_call=chat_call,
+        rag_call=rag_call,
+    )
+    ok = (
+        rag_calls == 1
+        and chat_calls == 1
+        and result.fallback_applied is True
+        and result.fallback_reason
+        in {FallbackReason.QDRANT_UNAVAILABLE, FallbackReason.RAG_UNAVAILABLE}
+        and result.alias == run_local_agent.LOCAL_CHAT_ALIAS
+        and not result.used_rag
+        and result.error_category is None
+    )
+    return _runner_result("forced_qdrant_degradation", result, ok=ok)
+
+
+async def run_policy_block_smoke() -> RunnerSmokeResult:
+    """Verify budget policy block happens before model calls."""
+    model_call_attempted = False
+
+    async def chat_call(
+        question: str,
+        *,
+        alias: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        response_format: Mapping[str, object] | None,
+    ) -> str:
+        nonlocal model_call_attempted
+        del question, alias, max_tokens, temperature, response_format
+        model_call_attempted = True
+        return "should not run"
+
+    result = await run_local_agent.run_agent(
+        question="Pergunta sintetica bloqueada por orcamento.",
+        chat_call=chat_call,
+        policy_loader=lambda: RemoteEscalationPolicy(
+            remote_enabled=False,
+            per_request_token_limit=1,
+        ),
+    )
+    ok = (
+        result.route == "blocked"
+        and result.error_category == "blocked"
+        and result.latency_ms == 0.0
+        and not result.fallback_applied
+        and not model_call_attempted
+    )
+    return _runner_result(
+        "policy_block",
+        result,
+        ok=ok,
+        model_call_attempted=model_call_attempted,
+    )
+
+
+def assert_sanitized(value: object) -> None:
+    """Recursively reject prohibited keys and known fake sensitive values."""
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key).lower()
+            if key_text in PROHIBITED_SMOKE_SUMMARY_KEYS:
+                raise ValueError(f"prohibited key in smoke output: {key_text}")
+            assert_sanitized(nested)
+        return
+    if isinstance(value, list | tuple):
+        for item in value:
+            assert_sanitized(item)
+        return
+    if isinstance(value, str):
+        for marker in FAKE_SENSITIVE_VALUES:
+            if marker in value:
+                raise ValueError("fake sensitive marker leaked into smoke output")
+
+
+def write_summary(
+    output_dir: Path | str,
+    summary: GatewayProofOfLifeSummary,
+    *,
+    path: Path | None = None,
+) -> Path:
+    """Write one sanitized proof-of-life JSON summary."""
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = path or out_dir / f"gateway1_proof_of_life_{summary.run_id}.json"
+    payload = summary.to_json_dict()
+    assert_sanitized(payload)
+    target.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async proof-of-life CLI entrypoint."""
+    args = parse_args(argv)
+    if not require_guard_enabled():
+        sys.stdout.write(
+            "Gateway-1 proof-of-life is opt-in. "
+            "Set RUN_GATEWAY1_PROOF_OF_LIFE=1 to run.\n",
+        )
+        return 2
+    summary, summary_path = await run_proof_of_life(output_dir=args.output_dir)
+    if summary_path is not None:
+        sys.stdout.write(f"summary_json={summary_path}\n")
+    sys.stdout.write(
+        f"overall_passed={str(summary.overall_passed).lower()} "
+        f"passed={len(summary.passed)} failed={len(summary.failed)} "
+        f"skipped={len(summary.skipped)}\n",
+    )
+    return 0 if summary.overall_passed else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def _build_summary(
+    *,
+    run_id: str,
+    probes: Mapping[str, ProbeResult],
+    runner_tests: Mapping[str, RunnerSmokeResult],
+    criteria_met: Mapping[str, bool],
+    skipped: set[str],
+) -> GatewayProofOfLifeSummary:
+    passed = tuple(
+        criterion for criterion, ok in sorted(criteria_met.items()) if ok
+    )
+    failed = tuple(
+        criterion
+        for criterion, mandatory in sorted(MANDATORY_CRITERIA.items())
+        if mandatory and not criteria_met.get(criterion, False) and criterion not in skipped
+    )
+    overall_passed = not failed and all(
+        criteria_met.get(criterion, False)
+        for criterion, mandatory in MANDATORY_CRITERIA.items()
+        if mandatory
+    )
+    return GatewayProofOfLifeSummary(
+        run_id=run_id,
+        timestamp_utc=_utc_now(),
+        gateway_sprint=GATEWAY_SPRINT,
+        criteria_manifest_ref=CRITERIA_MANIFEST_REF,
+        service_probes=probes,
+        runner_tests=runner_tests,
+        passed=passed,
+        failed=failed,
+        skipped=tuple(sorted(skipped)),
+        criteria_met=criteria_met,
+        overall_passed=overall_passed,
+    )
+
+
+def _runner_result(
+    name: str,
+    result: run_local_agent.AgentRunResult,
+    *,
+    ok: bool,
+    model_call_attempted: bool | None = None,
+) -> RunnerSmokeResult:
+    return RunnerSmokeResult(
+        name=name,
+        ok=ok,
+        route=result.route,
+        alias=result.alias,
+        used_rag=result.used_rag,
+        latency_ms=result.latency_ms,
+        decision_id=result.decision_id,
+        estimated_remote_tokens_avoided=result.estimated_remote_tokens_avoided,
+        answer_length_chars=len(result.answer),
+        error_category=result.error_category,
+        fallback_applied=result.fallback_applied,
+        fallback_reason=result.fallback_reason.value if result.fallback_reason else None,
+        model_call_attempted=model_call_attempted,
+    )
+
+
+def _extract_model_aliases(payload: object) -> frozenset[str]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("models response must be a mapping")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise ValueError("models response data must be a list")
+    aliases: set[str] = set()
+    for item in data:
+        if isinstance(item, Mapping) and isinstance(item.get("id"), str):
+            aliases.add(str(item["id"]))
+    return frozenset(aliases)
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,16 @@
+# Agent-0 Golden Questions
+
+This directory contains the stable synthetic question registry for the Agent-0
+golden benchmark harness.
+
+Reports are written to `tests/golden/reports/` and are intentionally ignored by
+Git. Do not commit generated reports unless a future baseline-update issue
+explicitly authorizes it.
+
+Baseline policy:
+
+- The registry is synthetic-only.
+- No real tickers, companies, funds, portfolios or private data are allowed.
+- Dry-run reports are useful for schema validation only.
+- The first live baseline should preferably use the median of 3 local runs.
+- Live baseline publication is deferred until an explicit future decision.

--- a/tests/golden/questions.yaml
+++ b/tests/golden/questions.yaml
@@ -1,0 +1,41 @@
+questions:
+  - id: gq_chat_macro_001
+    domain: macro
+    mode: chat
+    question: "Explique, em termos gerais, como um cenario macro sintetico de juros altos poderia afetar uma alocacao educacional ficticia."
+    rationale: "Covers local_chat baseline behavior for macro reasoning without real assets."
+  - id: gq_chat_allocation_001
+    domain: allocation
+    mode: chat
+    question: "Compare uma carteira ficticia conservadora com outra moderada usando apenas percentuais simulados e sem recomendar ativos reais."
+    rationale: "Covers allocation explanation and safety around non-advisory synthetic examples."
+  - id: gq_chat_risk_001
+    domain: risk
+    mode: chat
+    question: "Liste tres riscos de concentracao em um fundo sintetico chamado Fundo Didatico Alpha, sem citar empresas reais."
+    rationale: "Covers risk language and fictional fund handling."
+  - id: gq_json_allocation_001
+    domain: allocation
+    mode: json
+    question: "Retorne JSON valido com os campos classe, risco e observacao para uma alocacao sintetica de estudo com 40 por cento em renda fixa simulada."
+    rationale: "Covers local_json schema-like behavior without requiring real financial instruments."
+  - id: gq_json_risk_001
+    domain: risk
+    mode: json
+    question: "Retorne JSON valido classificando uma pergunta ficticia sobre concentracao, com campos tipo_risco, severidade e acao_educacional."
+    rationale: "Covers JSON path for risk classification."
+  - id: gq_rag_fixed_income_001
+    domain: fixed_income
+    mode: rag
+    question: "Segundo o material sintetico local, qual e a diferenca entre renda fixa simulada pos-fixada e prefixada?"
+    rationale: "Covers RAG path for fixed-income explanation with synthetic local context."
+  - id: gq_rag_funds_001
+    domain: funds
+    mode: rag
+    question: "Use apenas contexto sintetico para explicar o objetivo do Fundo Ficticio Horizonte e cite a fonte se houver contexto."
+    rationale: "Covers RAG citation behavior for fictional funds."
+  - id: gq_chat_funds_001
+    domain: funds
+    mode: chat
+    question: "Descreva, de forma educacional, como avaliar um fundo imobiliario sintetico sem usar ticker, empresa ou fundo real."
+    rationale: "Covers equity-like or funds analysis while avoiding real tickers and fund names."

--- a/tests/unit/test_compare_golden_runs.py
+++ b/tests/unit/test_compare_golden_runs.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import compare_golden_runs
+
+
+def _summary(
+    *,
+    passed: int = 8,
+    total_questions: int = 8,
+    local_chat_latency: float = 100.0,
+    local_rag_latency: float = 200.0,
+    tokens_avoided: float = 1000.0,
+    fallback_count: int = 0,
+) -> dict[str, object]:
+    return {
+        "run_id": "run",
+        "timestamp_utc": "2026-05-02T00:00:00Z",
+        "total_questions": total_questions,
+        "passed": passed,
+        "failed": total_questions - passed,
+        "skipped": 0,
+        "fallback_count": fallback_count,
+        "mean_latency_ms_by_alias": {
+            "local_chat": local_chat_latency,
+            "local_rag": local_rag_latency,
+        },
+        "p95_latency_ms_by_alias": {
+            "local_chat": local_chat_latency,
+            "local_rag": local_rag_latency,
+        },
+        "total_estimated_remote_tokens_avoided": tokens_avoided,
+        "quality_score_present": False,
+        "model_under_test_aliases": ["local_chat", "local_rag"],
+    }
+
+
+class CompareGoldenRunsTests(unittest.TestCase):
+    def test_compare_passes_when_candidate_is_within_threshold(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(),
+            _summary(local_chat_latency=110.0, local_rag_latency=210.0),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("golden_run_comparison", output)
+        self.assertIn("pass_rate_delta=0.0000", output)
+
+    def test_compare_detects_pass_rate_regression(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(passed=8),
+            _summary(passed=7),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("pass_rate_delta=-0.1250", output)
+
+    def test_compare_detects_latency_regression_over_threshold(self) -> None:
+        output, exit_code = compare_golden_runs.compare_summaries(
+            _summary(local_chat_latency=100.0),
+            _summary(local_chat_latency=130.0),
+            latency_threshold_pct=20.0,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("local_chat | 100.0 | 130.0 | 30.0", output)
+
+    def test_main_reads_summary_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            baseline = Path(temp_dir) / "baseline.json"
+            candidate = Path(temp_dir) / "candidate.json"
+            baseline.write_text(json.dumps(_summary()), encoding="utf-8")
+            candidate.write_text(json.dumps(_summary()), encoding="utf-8")
+
+            exit_code = compare_golden_runs.main(
+                [
+                    "--baseline",
+                    str(baseline),
+                    "--candidate",
+                    str(candidate),
+                    "--latency-threshold-pct",
+                    "20",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -497,7 +497,7 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
             data = result.to_json_dict()
             latency = data["latency_ms"]
             self.assertIsInstance(latency, (int, float))
-            self.assertGreaterEqual(latency, 0.0)
+            self.assertTrue(float(cast(float, latency)) >= 0.0)
 
         # Edge case: early-return path (api_key=None) produces latency_ms=0.0
         zero_result = proof.ProbeResult(
@@ -506,7 +506,8 @@ class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
             latency_ms=0.0,
             error_category="authentication",
         )
-        self.assertGreaterEqual(zero_result.to_json_dict()["latency_ms"], 0.0)
+        zero_latency = zero_result.to_json_dict()["latency_ms"]
+        self.assertTrue(float(cast(float, zero_latency)) >= 0.0)
 
     async def test_remote_url_guard_runs_before_async_probes(self) -> None:
         async def fail_probe(*args: object, **kwargs: object) -> proof.ProbeResult:

--- a/tests/unit/test_gateway1_proof_of_life.py
+++ b/tests/unit/test_gateway1_proof_of_life.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self, cast
+from unittest.mock import patch
+
+import httpx
+
+from backend.gateway.routing_policy import FallbackReason
+from scripts import run_local_agent
+from scripts import test_gateway1_proof_of_life as proof
+
+
+PROBE_KEYS = {
+    "service",
+    "ok",
+    "latency_ms",
+    "error_category",
+    "missing_aliases",
+}
+RUNNER_KEYS = {
+    "name",
+    "ok",
+    "route",
+    "alias",
+    "used_rag",
+    "latency_ms",
+    "decision_id",
+    "estimated_remote_tokens_avoided",
+    "answer_length_chars",
+    "error_category",
+    "fallback_applied",
+    "fallback_reason",
+    "model_call_attempted",
+}
+SUMMARY_KEYS = {
+    "run_id",
+    "timestamp_utc",
+    "gateway_sprint",
+    "criteria_manifest_ref",
+    "service_probes",
+    "runner_tests",
+    "passed",
+    "failed",
+    "skipped",
+    "criteria_met",
+    "overall_passed",
+}
+
+
+def _fake_result(
+    *,
+    alias: str = "local_chat",
+    used_rag: bool = False,
+    answer: str = "resposta sintetica",
+    error_category: str | None = None,
+    fallback_reason: FallbackReason | None = None,
+) -> run_local_agent.AgentRunResult:
+    return run_local_agent.AgentRunResult(
+        answer=answer,
+        route="local",
+        alias=alias,
+        used_rag=used_rag,
+        latency_ms=12.3,
+        decision_id="decision-123",
+        estimated_remote_tokens_avoided=42,
+        error_category=error_category,
+        fallback_applied=fallback_reason is not None,
+        fallback_from_alias="local_rag" if fallback_reason is not None else None,
+        fallback_to_alias="local_chat" if fallback_reason is not None else None,
+        fallback_reason=fallback_reason,
+        fallback_chain=(fallback_reason,) if fallback_reason is not None else None,
+    )
+
+
+class GatewayProofOfLifeUnitTests(unittest.IsolatedAsyncioTestCase):
+    def test_local_url_guard_accepts_localhost_and_loopback(self) -> None:
+        self.assertTrue(proof.is_local_url("http://127.0.0.1:4000/v1"))
+        self.assertTrue(proof.is_local_url("http://localhost:6333"))
+
+    def test_local_url_guard_rejects_remote_urls(self) -> None:
+        self.assertFalse(proof.is_local_url("https://api.example.com/v1"))
+        self.assertFalse(proof.is_local_url("http://192.168.1.1:4000/v1"))
+
+    def test_probe_result_serialization_is_allowlisted(self) -> None:
+        result = proof.ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=1.2,
+            error_category="alias_missing",
+            missing_aliases=("local_chat",),
+        )
+        data = result.to_json_dict()
+
+        self.assertTrue(set(data).issubset(PROBE_KEYS))
+        proof.assert_sanitized(data)
+
+    def test_summary_serialization_is_allowlisted(self) -> None:
+        summary = proof.GatewayProofOfLifeSummary(
+            run_id="run",
+            timestamp_utc="2026-05-02T00:00:00Z",
+            gateway_sprint="Gateway-1",
+            criteria_manifest_ref=proof.CRITERIA_MANIFEST_REF,
+            service_probes={
+                "ollama": proof.ProbeResult("ollama", True, 1.0),
+            },
+            runner_tests={
+                "dry_run": proof.RunnerSmokeResult(
+                    name="dry_run",
+                    ok=True,
+                    route="local",
+                    alias="local_chat",
+                    used_rag=False,
+                    latency_ms=0.0,
+                    decision_id="decision",
+                    estimated_remote_tokens_avoided=1,
+                    answer_length_chars=20,
+                ),
+            },
+            passed=("G1-01",),
+            failed=(),
+            skipped=(),
+            criteria_met={"G1-01": True},
+            overall_passed=True,
+        )
+        data = summary.to_json_dict()
+
+        self.assertEqual(set(data), SUMMARY_KEYS)
+        proof.assert_sanitized(data)
+
+    def test_recursive_sanitizer_catches_prohibited_key(self) -> None:
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"nested": {"api_key": "x"}})
+
+    def test_recursive_sanitizer_catches_fake_sensitive_value(self) -> None:
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"safe_key": "FAKE_PROMPT_SHOULD_NOT_APPEAR"})
+
+    def test_recursive_sanitizer_catches_answer_key_in_smoke_output(self) -> None:
+        # "answer" is legitimate in AgentRunResult but must not appear in smoke
+        # summaries — PROHIBITED_SMOKE_SUMMARY_KEYS extends the base set with it.
+        with self.assertRaises(ValueError):
+            proof.assert_sanitized({"answer": "some answer text"})
+
+    async def test_dry_run_criterion_success(self) -> None:
+        result = await proof.run_dry_run_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertEqual(data["latency_ms"], 0.0)
+        proof.assert_sanitized(data)
+
+    async def test_local_chat_criterion_success_with_fake_runner(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertFalse(kwargs.get("use_rag", False))
+            return _fake_result(alias="local_chat", used_rag=False)
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_local_chat_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_chat")
+        proof.assert_sanitized(result.to_json_dict())
+
+    async def test_rag_success_outcome_is_accepted(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertTrue(kwargs.get("use_rag"))
+            return _fake_result(alias="local_rag", used_rag=True)
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_rag_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_rag")
+
+    async def test_rag_fallback_outcome_is_accepted(self) -> None:
+        async def fake_run_agent(**kwargs: object) -> run_local_agent.AgentRunResult:
+            self.assertTrue(kwargs.get("use_rag"))
+            return _fake_result(
+                alias="local_chat",
+                used_rag=False,
+                fallback_reason=FallbackReason.QDRANT_UNAVAILABLE,
+            )
+
+        with patch("scripts.test_gateway1_proof_of_life.run_local_agent.run_agent", fake_run_agent):
+            result = await proof.run_rag_smoke()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.alias, "local_chat")
+        self.assertEqual(result.fallback_reason, "qdrant_unavailable")
+
+    async def test_forced_degradation_uses_fallback_metadata(self) -> None:
+        result = await proof.run_forced_qdrant_degradation_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertEqual(data["used_rag"], False)
+        self.assertIn(
+            data["fallback_reason"],
+            {"qdrant_unavailable", "rag_unavailable"},
+        )
+        proof.assert_sanitized(data)
+
+    async def test_policy_block_verifies_no_model_call(self) -> None:
+        result = await proof.run_policy_block_smoke()
+        data = result.to_json_dict()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(data["route"], "blocked")
+        self.assertEqual(data["error_category"], "blocked")
+        self.assertEqual(data["model_call_attempted"], False)
+        proof.assert_sanitized(data)
+
+    def test_overall_passed_logic_requires_mandatory_criteria(self) -> None:
+        criteria = {criterion: True for criterion in proof.MANDATORY_CRITERIA}
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+        self.assertTrue(summary.overall_passed)
+
+        criteria["G1-06"] = False
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+        self.assertFalse(summary.overall_passed)
+        self.assertIn("G1-06", summary.failed)
+
+    def test_summary_json_writes_to_tmp_path(self) -> None:
+        criteria = {criterion: True for criterion in proof.MANDATORY_CRITERIA}
+        summary = proof._build_summary(
+            run_id="run",
+            probes={},
+            runner_tests={},
+            criteria_met=criteria,
+            skipped=set(),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = proof.write_summary(temp_dir, summary)
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(loaded["run_id"], "run")
+        self.assertTrue(loaded["overall_passed"])
+
+    async def test_guard_env_prevents_accidental_runs(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await proof.main_async(["--output-dir", "/tmp/unused"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("opt-in", write_mock.call_args.args[0])
+
+    async def test_main_writes_summary_when_guard_enabled_with_fakes(self) -> None:
+        async def fake_local_chat() -> proof.RunnerSmokeResult:
+            return proof.RunnerSmokeResult(
+                name="local_chat",
+                ok=True,
+                route="local",
+                alias="local_chat",
+                used_rag=False,
+                latency_ms=1.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=1,
+                answer_length_chars=20,
+            )
+
+        async def fake_rag() -> proof.RunnerSmokeResult:
+            return proof.RunnerSmokeResult(
+                name="rag",
+                ok=True,
+                route="local",
+                alias="local_rag",
+                used_rag=True,
+                latency_ms=1.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=1,
+                answer_length_chars=20,
+            )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", True)),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
+                patch.object(proof, "run_local_chat_smoke", fake_local_chat),
+                patch.object(proof, "run_rag_smoke", fake_rag),
+                patch("sys.stdout.write"),
+            ):
+                exit_code = await proof.main_async(["--output-dir", temp_dir])
+
+            self.assertEqual(exit_code, 0)
+            summaries = list(Path(temp_dir).glob("gateway1_proof_of_life_*.json"))
+            self.assertEqual(len(summaries), 1)
+            data = json.loads(summaries[0].read_text(encoding="utf-8"))
+
+        self.assertTrue(data["overall_passed"])
+        proof.assert_sanitized(cast(dict[str, object], data))
+
+    async def test_async_probes_are_gathered_into_all_service_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", True)),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
+                patch.object(proof, "run_local_chat_smoke", _fake_runner_smoke("local_chat", True)),
+                patch.object(proof, "run_rag_smoke", _fake_runner_smoke("rag", True)),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
+
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        self.assertTrue(summary.service_probes["ollama"].ok)
+        self.assertTrue(summary.service_probes["qdrant"].ok)
+        self.assertTrue(summary.service_probes["litellm"].ok)
+
+    async def test_async_probe_failure_is_converted_to_probe_result(self) -> None:
+        class RaisingAsyncClient:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+
+            async def __aenter__(self) -> Self:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
+
+            async def get(self, url: str, **kwargs: object) -> object:
+                del url, kwargs
+                raise httpx.ConnectError("FAKE_SECRET_MESSAGE")
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", RaisingAsyncClient):
+            result = await proof.probe_ollama("http://127.0.0.1:11434")
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_category, "connection")
+        data = result.to_json_dict()
+        self.assertNotIn("FAKE_SECRET_MESSAGE", json.dumps(data))
+        proof.assert_sanitized(data)
+
+    async def test_failed_async_probe_does_not_hide_other_service_results(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", _fake_probe("ollama", True)),
+                patch.object(proof, "probe_qdrant", _fake_probe("qdrant", False, "connection")),
+                patch.object(proof, "probe_litellm", _fake_litellm_probe(True)),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
+
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        self.assertTrue(summary.service_probes["ollama"].ok)
+        self.assertFalse(summary.service_probes["qdrant"].ok)
+        self.assertEqual(summary.service_probes["qdrant"].error_category, "connection")
+        self.assertTrue(summary.service_probes["litellm"].ok)
+
+    async def test_litellm_async_probe_does_not_leak_authorization(self) -> None:
+        sentinel = "FAKE_API_KEY_SHOULD_NOT_APPEAR"
+
+        class Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {"data": [{"id": alias} for alias in proof.REQUIRED_ALIASES]}
+
+        class CapturingAsyncClient:
+            captured_headers: Mapping[str, str] | None = None
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+
+            async def __aenter__(self) -> Self:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
+
+            async def get(
+                self,
+                url: str,
+                *,
+                headers: Mapping[str, str] | None = None,
+            ) -> Response:
+                del url
+                CapturingAsyncClient.captured_headers = headers
+                return Response()
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", CapturingAsyncClient):
+            result = await proof.probe_litellm(
+                "http://127.0.0.1:4000/v1",
+                api_key=sentinel,
+            )
+
+        self.assertTrue(result.ok)
+        self.assertIn("Authorization", CapturingAsyncClient.captured_headers or {})
+        serialized = json.dumps(result.to_json_dict())
+        self.assertNotIn(sentinel, serialized)
+        self.assertNotIn("Authorization", serialized)
+        proof.assert_sanitized(result.to_json_dict())
+
+    async def test_probes_run_concurrently_not_sequentially(self) -> None:
+        # Concurrency-shape test: wall time should be ~max(delays), not sum(delays).
+        # Each fake sleeps 50 ms; sequential would be ~150 ms, concurrent ~50 ms.
+        # Threshold is 120 ms — generous to avoid false failures on slow CI.
+        async def slow_probe_ollama(base_url: str) -> proof.ProbeResult:
+            del base_url
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="ollama", ok=True, latency_ms=50.0)
+
+        async def slow_probe_qdrant(base_url: str) -> proof.ProbeResult:
+            del base_url
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="qdrant", ok=True, latency_ms=50.0)
+
+        async def slow_probe_litellm(
+            base_url: str, *, api_key: str | None
+        ) -> proof.ProbeResult:
+            del base_url, api_key
+            await asyncio.sleep(0.05)
+            return proof.ProbeResult(service="litellm", ok=True, latency_ms=50.0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {"RUN_GATEWAY1_PROOF_OF_LIFE": "1"},
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", slow_probe_ollama),
+                patch.object(proof, "probe_qdrant", slow_probe_qdrant),
+                patch.object(proof, "probe_litellm", slow_probe_litellm),
+                patch.object(proof, "run_local_chat_smoke", _fake_runner_smoke("local_chat", True)),
+                patch.object(proof, "run_rag_smoke", _fake_runner_smoke("rag", True)),
+            ):
+                wall_start = time.perf_counter()
+                await proof.run_proof_of_life(output_dir=temp_dir)
+                wall_elapsed = time.perf_counter() - wall_start
+
+        # Sequential would be ~0.15 s; concurrent finishes well under 0.12 s.
+        self.assertLess(
+            wall_elapsed,
+            0.12,
+            "Probes appear to run sequentially — asyncio.gather concurrency broken",
+        )
+
+    def test_probe_latency_ms_is_numeric_and_non_negative(self) -> None:
+        for ok, error_category in [(True, None), (False, "connection")]:
+            result = proof.ProbeResult(
+                service="ollama",
+                ok=ok,
+                latency_ms=12.5,
+                error_category=error_category,
+            )
+            data = result.to_json_dict()
+            latency = data["latency_ms"]
+            self.assertIsInstance(latency, (int, float))
+            self.assertGreaterEqual(latency, 0.0)
+
+        # Edge case: early-return path (api_key=None) produces latency_ms=0.0
+        zero_result = proof.ProbeResult(
+            service="litellm",
+            ok=False,
+            latency_ms=0.0,
+            error_category="authentication",
+        )
+        self.assertGreaterEqual(zero_result.to_json_dict()["latency_ms"], 0.0)
+
+    async def test_remote_url_guard_runs_before_async_probes(self) -> None:
+        async def fail_probe(*args: object, **kwargs: object) -> proof.ProbeResult:
+            del args, kwargs
+            self.fail("probe should not run after remote URL guard failure")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "RUN_GATEWAY1_PROOF_OF_LIFE": "1",
+                        "QUIMERA_LLM_BASE_URL": "https://api.example.com/v1",
+                    },
+                    clear=True,
+                ),
+                patch.object(proof, "probe_ollama", fail_probe),
+                patch.object(proof, "probe_qdrant", fail_probe),
+                patch.object(proof, "probe_litellm", fail_probe),
+            ):
+                summary, _ = await proof.run_proof_of_life(output_dir=temp_dir)
+
+        self.assertFalse(summary.criteria_met["G1-02"])
+        self.assertEqual(set(summary.service_probes), {"ollama", "qdrant", "litellm"})
+        for service_probe in summary.service_probes.values():
+            self.assertFalse(service_probe.ok)
+            self.assertEqual(service_probe.error_category, "local_url_rejected")
+
+
+class GatewayProofOfLifeProbeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_litellm_probe_reports_missing_aliases(self) -> None:
+        class Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {"data": [{"id": "local_chat"}]}
+
+        class AliasAsyncClient:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+
+            async def __aenter__(self) -> Self:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                del exc_type, exc, traceback
+
+            async def get(
+                self,
+                url: str,
+                *,
+                headers: Mapping[str, str] | None = None,
+            ) -> Response:
+                del url, headers
+                return Response()
+
+        with patch("scripts.test_gateway1_proof_of_life.httpx.AsyncClient", AliasAsyncClient):
+            result = await proof.probe_litellm(
+                "http://127.0.0.1:4000/v1",
+                api_key="dev-key",
+            )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.error_category, "alias_missing")
+        self.assertIn("local_rag", result.missing_aliases)
+
+
+def _fake_probe(
+    service: str,
+    ok: bool,
+    error_category: str | None = None,
+) -> Any:
+    async def fake(base_url: str) -> proof.ProbeResult:
+        del base_url
+        return proof.ProbeResult(
+            service=service,
+            ok=ok,
+            latency_ms=1.0,
+            error_category=error_category,
+        )
+
+    return fake
+
+
+def _fake_litellm_probe(ok: bool) -> Any:
+    async def fake(base_url: str, *, api_key: str | None) -> proof.ProbeResult:
+        del base_url, api_key
+        return proof.ProbeResult(service="litellm", ok=ok, latency_ms=1.0)
+
+    return fake
+
+
+def _fake_runner_smoke(name: str, ok: bool) -> Any:
+    async def fake() -> proof.RunnerSmokeResult:
+        return proof.RunnerSmokeResult(
+            name=name,
+            ok=ok,
+            route="local",
+            alias="local_chat" if name == "local_chat" else "local_rag",
+            used_rag=name == "rag",
+            latency_ms=1.0,
+            decision_id="decision",
+            estimated_remote_tokens_avoided=1,
+            answer_length_chars=20,
+        )
+
+    return fake
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_golden_harness.py
+++ b/tests/unit/test_golden_harness.py
@@ -92,6 +92,27 @@ class GoldenHarnessTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in data}))
         self.assertEqual(data["answer_length_chars"], 30)
 
+    def test_golden_result_cannot_be_skipped_and_failed(self) -> None:
+        with self.assertRaises(ValueError):
+            run_golden_harness.GoldenResult(
+                question_id="gq_test",
+                domain="risk",
+                mode="chat",
+                route="local",
+                alias=None,
+                used_rag=False,
+                latency_ms=0.0,
+                decision_id="decision",
+                estimated_remote_tokens_avoided=0,
+                answer_length_chars=0,
+                error_category="chat_unavailable",
+                fallback_applied=None,
+                fallback_reason=None,
+                quality_score=None,
+                skipped=True,
+                skipped_reason="offline",
+            )
+
     async def test_dry_run_harness_produces_jsonl_and_summary(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             jsonl_path, summary_path = await run_golden_harness.run_harness(

--- a/tests/unit/test_golden_harness.py
+++ b/tests/unit/test_golden_harness.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import run_golden_harness
+
+
+FORBIDDEN_REPORT_KEYS = {
+    "answer",
+    "question",
+    "prompt",
+    "chunks",
+    "chunk",
+    "vectors",
+    "vector",
+    "payload",
+    "qdrant_payload",
+    "api_key",
+    "authorization",
+    "secret",
+    "password",
+    "headers",
+    "raw_response",
+    "raw_exception",
+    "exception_message",
+}
+FORBIDDEN_REAL_TERMS = {
+    "petr4",
+    "vale3",
+    "itub4",
+    "bova11",
+    "tesouro selic",
+    "magalu",
+    "petrobras",
+    "vale",
+    "itau",
+    "bradesco",
+}
+REQUIRED_DOMAINS = {"macro", "allocation", "risk", "fixed_income", "funds"}
+
+
+class GoldenHarnessTests(unittest.IsolatedAsyncioTestCase):
+    def test_questions_yaml_loads_and_has_unique_ids(self) -> None:
+        questions = run_golden_harness.load_questions()
+
+        self.assertGreaterEqual(len(questions), 5)
+        self.assertLessEqual(len(questions), 10)
+        ids = [question.question_id for question in questions]
+        self.assertEqual(len(ids), len(set(ids)))
+        for question in questions:
+            self.assertTrue(question.rationale)
+
+    def test_questions_are_synthetic_and_cover_domains_and_modes(self) -> None:
+        questions = run_golden_harness.load_questions()
+        combined_text = " ".join(
+            f"{question.question} {question.rationale}".lower()
+            for question in questions
+        )
+        domains = {question.domain for question in questions}
+        modes = {question.mode for question in questions}
+
+        self.assertTrue(REQUIRED_DOMAINS.issubset(domains))
+        self.assertTrue({"chat", "rag", "json"}.issubset(modes))
+        for forbidden in FORBIDDEN_REAL_TERMS:
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, combined_text)
+
+    def test_golden_result_serialization_excludes_sensitive_content(self) -> None:
+        result = run_golden_harness.GoldenResult(
+            question_id="gq_test",
+            domain="risk",
+            mode="chat",
+            route="local",
+            alias="local_chat",
+            used_rag=False,
+            latency_ms=0.0,
+            decision_id="decision",
+            estimated_remote_tokens_avoided=10,
+            answer_length_chars=30,
+            error_category=None,
+            fallback_applied=None,
+            fallback_reason=None,
+            quality_score=None,
+        )
+        data = result.to_json_dict()
+
+        self.assertTrue(FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in data}))
+        self.assertEqual(data["answer_length_chars"], 30)
+
+    async def test_dry_run_harness_produces_jsonl_and_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jsonl_path, summary_path = await run_golden_harness.run_harness(
+                output_dir=temp_dir,
+                dry_run=True,
+            )
+
+            self.assertTrue(jsonl_path.exists())
+            self.assertTrue(summary_path.exists())
+            lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            questions = run_golden_harness.load_questions()
+
+            self.assertEqual(len(lines), len(questions))
+            for line in lines:
+                row = json.loads(line)
+                self.assertTrue(
+                    FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in row})
+                )
+                self.assertEqual(row["latency_ms"], 0.0)
+                self.assertIn(row["alias"], {"local_chat", "local_rag", "local_json"})
+                self.assertIsNone(row["quality_score"])
+
+            self.assertEqual(summary["total_questions"], len(questions))
+            self.assertEqual(summary["failed"], 0)
+            self.assertEqual(summary["skipped"], 0)
+            self.assertIn("mean_latency_ms_by_alias", summary)
+            self.assertIn("p95_latency_ms_by_alias", summary)
+            self.assertFalse(summary["quality_score_present"])
+
+    async def test_guard_env_prevents_accidental_runs(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await run_golden_harness.main_async(["--dry-run"])
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("opt-in", write_mock.call_args.args[0])
+
+    async def test_guard_env_allows_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with (
+                patch.dict(os.environ, {"RUN_GOLDEN_HARNESS": "1"}, clear=True),
+                patch("sys.stdout.write"),
+            ):
+                exit_code = await run_golden_harness.main_async(
+                    ["--dry-run", "--output-dir", temp_dir]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(list(Path(temp_dir).glob("golden_results_*.jsonl")))
+            self.assertTrue(list(Path(temp_dir).glob("golden_summary_*.json")))
+
+    def test_reports_directory_is_gitignored(self) -> None:
+        gitignore = Path(".gitignore").read_text(encoding="utf-8")
+
+        self.assertIn("tests/golden/reports/", gitignore)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_observability_signal_contract.py
+++ b/tests/unit/test_observability_signal_contract.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+from backend.gateway.observability_contract import (
+    AGENT_RUN_RESULT_KEYS,
+    DECISION_LOG_KEYS,
+    FALLBACK_EVENT_KEYS,
+    GOLDEN_RESULT_KEYS,
+    GOLDEN_SUMMARY_KEYS,
+    PROHIBITED_SIGNAL_KEYS,
+    RAG_RUN_TRACE_KEYS,
+    ROUTER_DECISION_KEYS,
+    SAFE_FALLBACK_REASON_VALUES,
+    SAFE_ROUTER_REASON_VALUES,
+    TOKEN_ECONOMY_RECORD_KEYS,
+    assert_signal_allowlisted,
+    token_economy_canonical_signal,
+)
+from backend.gateway.routing_policy import (
+    FallbackReason,
+    RemoteEscalationPolicy,
+    RouteBlockReason,
+    RoutingDecisionLogger,
+    build_token_economy_record,
+    decide_route,
+)
+from backend.rag.run_trace import build_rag_run_trace
+from scripts import run_golden_harness, run_local_agent
+
+
+SENSITIVE_SENTINEL = "PRIVATE_PROMPT_api_key_headers_model_weights_path"
+
+
+class ObservabilitySignalContractTests(unittest.IsolatedAsyncioTestCase):
+    def test_router_decision_signals_are_allowlisted_for_core_routes(self) -> None:
+        cases = [
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(),
+            ),
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(per_request_token_limit=1),
+            ),
+            decide_route(
+                task_type="trade_execution",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=False,
+                policy=RemoteEscalationPolicy(),
+            ),
+            decide_route(
+                task_type="agent0_chat",
+                estimated_prompt_tokens=10,
+                estimated_completion_tokens=20,
+                contains_sensitive_context=False,
+                high_value_task=True,
+                policy=RemoteEscalationPolicy(
+                    remote_enabled=True,
+                    allowed_remote_providers=("review_stub",),
+                ),
+            ),
+        ]
+
+        for decision in cases:
+            with self.subTest(route=decision.route.value, reason=decision.reason):
+                data = decision.to_log_dict()
+                assert_signal_allowlisted(
+                    data,
+                    allowlist=ROUTER_DECISION_KEYS,
+                    signal_name="RouterDecision",
+                )
+                self.assertTrue(data["decision_id"])
+                self.assertIn(data["reason"], SAFE_ROUTER_REASON_VALUES)
+                self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    def test_token_economy_record_signal_is_allowlisted_and_canonicalized(self) -> None:
+        decision = decide_route(
+            task_type="agent0_chat",
+            estimated_prompt_tokens=12,
+            estimated_completion_tokens=34,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        record = build_token_economy_record(decision)
+        raw = record.to_log_dict()
+        canonical = token_economy_canonical_signal(raw)
+
+        assert_signal_allowlisted(
+            raw,
+            allowlist=TOKEN_ECONOMY_RECORD_KEYS,
+            signal_name="TokenEconomyRecord",
+        )
+        assert_signal_allowlisted(
+            canonical,
+            allowlist=TOKEN_ECONOMY_RECORD_KEYS,
+            signal_name="TokenEconomyRecordCanonical",
+        )
+        self.assertEqual(canonical["decision_id"], decision.decision_id)
+        self.assertIsInstance(canonical["estimated_remote_tokens_avoided"], int)
+        self.assertGreaterEqual(
+            cast(int, canonical["estimated_remote_tokens_avoided"]),
+            0,
+        )
+
+    def test_rag_run_trace_signal_is_allowlisted(self) -> None:
+        trace = build_rag_run_trace(
+            collection_name="gw19_synthetic_collection",
+            embedding_backend="gateway_litellm_current",
+            embedding_model="nomic-embed-text",
+            embedding_alias="quimera_embed",
+            embedding_dimensions=768,
+            expected_dimensions=768,
+            retrieval_latency_ms=1.5,
+            generation_latency_ms=12.5,
+            chunk_count=3,
+            gateway_alias="local_rag",
+            guard_result={
+                "sampled_count": 2,
+                "metadata_absent_count": 0,
+                "backend_matches": True,
+                "payload": "must be ignored",
+            },
+            total_latency_ms=14.0,
+        )
+        data = trace.to_log_dict()
+
+        assert_signal_allowlisted(
+            data,
+            allowlist=RAG_RUN_TRACE_KEYS,
+            signal_name="RagRunTrace",
+        )
+        self.assertEqual(data["gateway_alias"], "local_rag")
+        self.assertEqual(data["chunk_count"], 3)
+        self.assertNotIn("payload", json.dumps(data))
+
+    async def test_fallback_event_is_allowlisted_and_correlated_with_result(self) -> None:
+        events: list[dict[str, object]] = []
+
+        class BoundLogger:
+            def __init__(self, event: dict[str, object]) -> None:
+                self.event = event
+
+            def info(self, message: str) -> None:
+                self.event["message"] = message
+                events.append(self.event)
+
+        def fake_bind(**kwargs: object) -> BoundLogger:
+            event = kwargs["event"]
+            assert isinstance(event, dict)
+            return BoundLogger(event)
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        with patch("scripts.run_local_agent.logger.bind", fake_bind):
+            result = await run_local_agent.run_agent(
+                question=SENSITIVE_SENTINEL,
+                use_rag=True,
+                rag_call=rag_call,
+                chat_call=chat_call,
+            )
+        output = result.to_json_dict()
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        assert_signal_allowlisted(
+            event,
+            allowlist=FALLBACK_EVENT_KEYS | {"message"},
+            signal_name="FallbackEvent",
+        )
+        self.assertEqual(event["event"], "agent_fallback")
+        self.assertEqual(event["fallback_reason"], FallbackReason.RAG_UNAVAILABLE.value)
+        self.assertIn(event["fallback_reason"], SAFE_FALLBACK_REASON_VALUES)
+        self.assertEqual(event["decision_id"], output["decision_id"])
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(event))
+        assert_signal_allowlisted(
+            output,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+
+    async def test_non_fallback_run_emits_no_fallback_event(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        with patch("scripts.run_local_agent.logger.bind") as bind_mock:
+            result = await run_local_agent.run_agent(
+                question=SENSITIVE_SENTINEL,
+                chat_call=chat_call,
+            )
+
+        bind_mock.assert_not_called()
+        data = result.to_json_dict()
+        assert_signal_allowlisted(
+            data,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    def test_decision_log_jsonl_is_allowlisted(self) -> None:
+        decision = decide_route(
+            task_type="agent0_chat",
+            estimated_prompt_tokens=10,
+            estimated_completion_tokens=20,
+            contains_sensitive_context=False,
+            high_value_task=False,
+            policy=RemoteEscalationPolicy(),
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            logger = RoutingDecisionLogger(Path(temp_dir) / "decisions", rotate_daily=False)
+            path = logger.append(decision)
+            assert path is not None
+            rows = path.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(len(rows), 1)
+        row = json.loads(rows[0])
+        assert_signal_allowlisted(
+            row,
+            allowlist=DECISION_LOG_KEYS,
+            signal_name="DecisionLog",
+        )
+        self.assertIn(row["reason"], SAFE_ROUTER_REASON_VALUES)
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(row))
+
+    async def test_dry_run_output_signal_has_required_token_economy(self) -> None:
+        result = await run_local_agent.run_agent(
+            question=SENSITIVE_SENTINEL,
+            dry_run=True,
+        )
+        data = result.to_json_dict()
+
+        assert_signal_allowlisted(
+            data,
+            allowlist=AGENT_RUN_RESULT_KEYS,
+            signal_name="AgentRunResult",
+        )
+        self.assertIsInstance(data["estimated_remote_tokens_avoided"], int | float)
+        self.assertGreaterEqual(cast(int, data["estimated_remote_tokens_avoided"]), 0)
+        self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    async def test_estimated_remote_tokens_avoided_exists_across_runner_paths(self) -> None:
+        async def chat_ok(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        async def chat_fail(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        async def rag_fail(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError(SENSITIVE_SENTINEL)
+
+        cases = [
+            await run_local_agent.run_agent(question="ok", chat_call=chat_ok),
+            await run_local_agent.run_agent(question="dry", dry_run=True),
+            await run_local_agent.run_agent(
+                question="blocked",
+                policy_loader=lambda: RemoteEscalationPolicy(per_request_token_limit=1),
+                chat_call=chat_fail,
+            ),
+            await run_local_agent.run_agent(
+                question="fallback",
+                use_rag=True,
+                rag_call=rag_fail,
+                chat_call=chat_ok,
+            ),
+            await run_local_agent.run_agent(
+                question="fallback failure",
+                use_rag=True,
+                rag_call=rag_fail,
+                chat_call=chat_fail,
+            ),
+        ]
+
+        for result in cases:
+            with self.subTest(result=result):
+                data = result.to_json_dict()
+                self.assertIn("estimated_remote_tokens_avoided", data)
+                self.assertIsInstance(
+                    data["estimated_remote_tokens_avoided"],
+                    int | float,
+                )
+                self.assertGreaterEqual(
+                    cast(int, data["estimated_remote_tokens_avoided"]),
+                    0,
+                )
+                self.assertNotIn(SENSITIVE_SENTINEL, json.dumps(data))
+
+    async def test_golden_harness_dry_run_reports_are_allowlisted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            jsonl_path, summary_path = await run_golden_harness.run_harness(
+                output_dir=temp_dir,
+                dry_run=True,
+            )
+            rows = [
+                json.loads(line)
+                for line in jsonl_path.read_text(encoding="utf-8").splitlines()
+            ]
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            assert_signal_allowlisted(
+                row,
+                allowlist=GOLDEN_RESULT_KEYS,
+                signal_name="GoldenResult",
+            )
+            self.assertIsNone(row["quality_score"])
+            self.assertNotIn("answer", row)
+        assert_signal_allowlisted(
+            summary,
+            allowlist=GOLDEN_SUMMARY_KEYS,
+            signal_name="GoldenSummary",
+        )
+        self.assertFalse(summary["quality_score_present"])
+
+    def test_prohibited_key_contract_is_canonical(self) -> None:
+        expected = {
+            "prompt",
+            "chunks",
+            "vectors",
+            "api_key",
+            "headers",
+            "raw_user_input",
+            "model_weights_path",
+        }
+
+        self.assertTrue(expected.issubset(PROHIBITED_SIGNAL_KEYS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -15,21 +15,34 @@ from backend.rag.run_trace import (
     RagRunTrace,
     RagTracingConfig,
     build_rag_run_trace,
+    extract_ollama_metrics,
     load_rag_tracing_config,
 )
+from backend.rag.retriever import RetrievalTimings
 
 
 FORBIDDEN_KEYS = {
     "query",
     "question",
     "prompt",
+    "raw_user_input",
     "answer",
     "chunks",
+    "chunk_text",
     "vectors",
+    "embeddings",
     "payload",
+    "qdrant_payload",
     "api_key",
     "authorization",
+    "headers",
     "secret",
+    "password",
+    "raw_response",
+    "raw_exception",
+    "exception_message",
+    "traceback",
+    "model_weights_path",
 }
 
 
@@ -39,6 +52,7 @@ class FakeStore:
 
 class FakeRetriever:
     store = FakeStore()
+    last_timings: RetrievalTimings | None = None
 
     async def retrieve(
         self,
@@ -58,6 +72,23 @@ class FakeRetriever:
                 payload={"source": "synthetic", "secret": "do-not-log"},
             )
         ]
+
+
+class TimedFakeRetriever(FakeRetriever):
+    async def retrieve(
+        self,
+        question: str,
+        top_k: int | None = None,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[RetrievedChunk]:
+        chunks = await super().retrieve(question, top_k=top_k, filters=filters)
+        self.last_timings = RetrievalTimings(
+            embed_ms=1.25,
+            search_ms=2.5,
+            pack_ms=0.75,
+            total_ms=4.8,
+        )
+        return chunks
 
 
 class FakeGenerator:
@@ -135,6 +166,140 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         lowered_keys = {key.lower() for key in data}
 
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint(lowered_keys))
+
+    def test_segment_fields_are_optional(self) -> None:
+        trace = _trace()
+        data = trace.to_log_dict()
+
+        self.assertIsNone(trace.routing_ms)
+        self.assertIsNone(trace.embedding_ms)
+        self.assertIsNone(trace.retrieval_ms)
+        self.assertIsNone(trace.context_pack_ms)
+        self.assertIsNone(trace.prompt_build_ms)
+        self.assertIsNone(trace.generation_ms)
+        self.assertIsNone(trace.total_ms)
+        self.assertIsNone(trace.run_context)
+        self.assertFalse(trace.ollama_metrics_available)
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
+
+    def test_to_log_dict_includes_segment_fields_when_present(self) -> None:
+        trace = _trace(
+            routing_ms=0.1,
+            embedding_ms=1.2,
+            retrieval_ms=2.3,
+            context_pack_ms=0.4,
+            prompt_build_ms=0.5,
+            generation_ms=31.0,
+            total_ms=35.0,
+            run_context="warm_model",
+        )
+
+        data = trace.to_log_dict()
+
+        self.assertEqual(data["routing_ms"], 0.1)
+        self.assertEqual(data["embedding_ms"], 1.2)
+        self.assertEqual(data["retrieval_ms"], 2.3)
+        self.assertEqual(data["context_pack_ms"], 0.4)
+        self.assertEqual(data["prompt_build_ms"], 0.5)
+        self.assertEqual(data["generation_ms"], 31.0)
+        self.assertEqual(data["total_ms"], 35.0)
+        self.assertEqual(data["run_context"], "warm_model")
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
+
+    def test_total_ms_is_direct_field_not_sum_assumption(self) -> None:
+        trace = _trace(
+            routing_ms=1.0,
+            embedding_ms=2.0,
+            retrieval_ms=3.0,
+            context_pack_ms=4.0,
+            prompt_build_ms=5.0,
+            generation_ms=6.0,
+            total_ms=99.0,
+        )
+
+        data = trace.to_log_dict()
+
+        self.assertEqual(data["total_ms"], 99.0)
+        self.assertNotEqual(
+            data["total_ms"],
+            sum(
+                cast(
+                    float,
+                    data[key],
+                )
+                for key in (
+                    "routing_ms",
+                    "embedding_ms",
+                    "retrieval_ms",
+                    "context_pack_ms",
+                    "prompt_build_ms",
+                    "generation_ms",
+                )
+            ),
+        )
+
+    def test_ollama_metrics_none_when_unavailable(self) -> None:
+        trace = build_rag_run_trace(
+            collection_name="collection",
+            embedding_backend="gateway_litellm_current",
+            embedding_model="nomic-embed-text",
+            embedding_alias="quimera_embed",
+            embedding_dimensions=768,
+            expected_dimensions=768,
+            retrieval_latency_ms=1.0,
+            generation_latency_ms=2.0,
+            chunk_count=1,
+        )
+
+        data = trace.to_log_dict()
+
+        self.assertFalse(data["ollama_metrics_available"])
+        self.assertNotIn("ollama_total_duration_ms", data)
+        self.assertIsNone(trace.ollama_eval_duration_ms)
+
+    def test_ollama_metrics_convert_ns_to_ms_if_available(self) -> None:
+        metadata = {
+            "total_duration": 3_000_000,
+            "load_duration": 4_000_000,
+            "prompt_eval_count": 12,
+            "prompt_eval_duration": 5_000_000,
+            "eval_count": 34,
+            "eval_duration": 6_000_000,
+            "prompt": "must not be copied",
+        }
+        metrics = extract_ollama_metrics(metadata)
+        self.assertTrue(metrics["ollama_metrics_available"])
+        trace = build_rag_run_trace(
+            collection_name="collection",
+            embedding_backend="gateway_litellm_current",
+            embedding_model="nomic-embed-text",
+            embedding_alias="quimera_embed",
+            embedding_dimensions=768,
+            expected_dimensions=768,
+            retrieval_latency_ms=1.0,
+            generation_latency_ms=2.0,
+            chunk_count=1,
+            ollama_metrics=metadata,
+        )
+        data = trace.to_log_dict()
+
+        self.assertTrue(data["ollama_metrics_available"])
+        self.assertEqual(data["ollama_total_duration_ms"], 3.0)
+        self.assertEqual(data["ollama_load_duration_ms"], 4.0)
+        self.assertEqual(data["ollama_prompt_eval_count"], 12)
+        self.assertEqual(data["ollama_prompt_eval_duration_ms"], 5.0)
+        self.assertEqual(data["ollama_eval_count"], 34)
+        self.assertEqual(data["ollama_eval_duration_ms"], 6.0)
+        self.assertNotIn("must not be copied", str(data))
+
+    def test_degraded_run_context_is_serialized_safely(self) -> None:
+        trace = _trace(run_context="degraded_qdrant")
+
+        self.assertEqual(trace.to_log_dict()["run_context"], "degraded_qdrant")
+
+    def test_invalid_run_context_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _trace(run_context="free-form context")
 
     def test_build_helper_generates_query_id_when_absent(self) -> None:
         trace = build_rag_run_trace(
@@ -267,6 +432,53 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
         self.assertNotIn("synthetic chunk text", str(trace))
         self.assertNotIn("do-not-log", str(trace))
+
+    async def test_pipeline_trace_contains_generation_and_prompt_build_timings(self) -> None:
+        traces: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            trace = message.record["extra"].get("trace")
+            if isinstance(trace, dict):
+                traces.append(trace)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            pipeline = LocalRagPipeline(
+                retriever=TimedFakeRetriever(),
+                generator=FakeGenerator(),
+                prompt_builder=PromptBuilder(),
+                tracing_config=RagTracingConfig(
+                    enabled=True,
+                    log_level="INFO",
+                    collection_name="configured_collection",
+                    embedding_backend="gateway_litellm_current",
+                    embedding_model="nomic-embed-text",
+                    embedding_alias="quimera_embed",
+                    embedding_dimensions=768,
+                ).validated(),
+            )
+            await pipeline.ask("Pergunta sintetica?")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(len(traces), 1)
+        trace = traces[0]
+        for key in (
+            "routing_ms",
+            "embedding_ms",
+            "retrieval_ms",
+            "context_pack_ms",
+            "prompt_build_ms",
+            "generation_ms",
+            "total_ms",
+        ):
+            self.assertIsInstance(trace[key], int | float)
+            self.assertGreaterEqual(cast(float, trace[key]), 0.0)
+        self.assertEqual(trace["routing_ms"], 0.0)
+        self.assertEqual(trace["embedding_ms"], 1.25)
+        self.assertEqual(trace["retrieval_ms"], 2.5)
+        self.assertEqual(trace["context_pack_ms"], 0.75)
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
 
     def test_load_rag_tracing_config_reads_yaml_defaults(self) -> None:
         config = load_rag_tracing_config()

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -463,8 +463,10 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(traces), 1)
         trace = traces[0]
+        # routing_ms is None at the pipeline level — pipeline does not perform
+        # route selection, so the field is absent from to_log_dict() output.
+        self.assertNotIn("routing_ms", trace)
         for key in (
-            "routing_ms",
             "embedding_ms",
             "retrieval_ms",
             "context_pack_ms",
@@ -474,7 +476,6 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertIsInstance(trace[key], int | float)
             self.assertGreaterEqual(cast(float, trace[key]), 0.0)
-        self.assertEqual(trace["routing_ms"], 0.0)
         self.assertEqual(trace["embedding_ms"], 1.25)
         self.assertEqual(trace["retrieval_ms"], 2.5)
         self.assertEqual(trace["context_pack_ms"], 0.75)

--- a/tests/unit/test_retriever.py
+++ b/tests/unit/test_retriever.py
@@ -111,6 +111,26 @@ class RetrieverTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([chunk.chunk_index for chunk in chunks], [0, 1])
         self.assertIsNotNone(retriever.last_timings)
 
+    async def test_retriever_timings_separate_embedding_search_pack(self) -> None:
+        retriever = Retriever(
+            embedder=FakeEmbedder(),
+            store=FakeStore(),
+            packer=FakePacker(),
+        )
+
+        await retriever.retrieve("pergunta sintetica")
+
+        self.assertIsNotNone(retriever.last_timings)
+        assert retriever.last_timings is not None
+        timings = retriever.last_timings.as_dict()
+        self.assertEqual(
+            set(timings),
+            {"embed_ms", "search_ms", "pack_ms", "total_ms"},
+        )
+        for value in timings.values():
+            self.assertIsInstance(value, float)
+            self.assertGreaterEqual(value, 0.0)
+
     async def test_retrieve_accepts_async_vector_store(self) -> None:
         retriever = Retriever(
             embedder=FakeEmbedder(),

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -5,34 +5,88 @@ import inspect
 import unittest
 from collections.abc import Mapping
 from typing import Any
+from typing import cast
 from unittest.mock import patch
 
 from backend.gateway.routing_policy import (
     RemoteEscalationPolicy,
+    RouteDecisionKind,
+    TaskRiskLevel,
+    TokenBudgetClass,
     RouterDecision,
     decide_route,
+    load_routing_policy,
 )
 from scripts import run_local_agent
 
 
+REQUIRED_KEYS = {
+    "answer",
+    "route",
+    "alias",
+    "used_rag",
+    "latency_ms",
+    "decision_id",
+    "estimated_remote_tokens_avoided",
+}
+OPTIONAL_KEYS = {"error_category"}
 FORBIDDEN_OUTPUT_KEYS = {
     "query",
     "question",
     "prompt",
+    "system_prompt",
+    "user_prompt",
+    "answer_raw",
+    "raw_response",
     "chunks",
+    "chunk",
     "chunk_text",
+    "retrieved_context",
+    "context_text",
     "vectors",
+    "vector",
     "embeddings",
+    "embedding",
     "payload",
     "qdrant_payload",
+    "documents",
+    "portfolio",
+    "carteira",
     "api_key",
     "authorization",
     "secret",
     "password",
     "headers",
-    "raw_response",
     "traceback",
 }
+BLOCKED_ANSWER = "Request blocked by local routing policy."
+DRY_RUN_ANSWER = "Dry run: no model call executed."
+FAILURE_ANSWER = "Local Agent-0 execution failed."
+
+
+def _assert_safe_schema(
+    test_case: unittest.TestCase,
+    data: Mapping[str, object],
+    *,
+    expect_error: str | None = None,
+) -> None:
+    test_case.assertTrue(REQUIRED_KEYS.issubset(data))
+    extra_keys = set(data) - REQUIRED_KEYS - OPTIONAL_KEYS
+    test_case.assertEqual(extra_keys, set())
+    if expect_error is None:
+        test_case.assertNotIn("error_category", data)
+    else:
+        test_case.assertEqual(data["error_category"], expect_error)
+    test_case.assertIsInstance(data["latency_ms"], int | float)
+    test_case.assertGreaterEqual(cast(float, data["latency_ms"]), 0.0)
+    test_case.assertIsInstance(data["estimated_remote_tokens_avoided"], int | float)
+    test_case.assertGreaterEqual(
+        cast(int, data["estimated_remote_tokens_avoided"]),
+        0,
+    )
+    test_case.assertIsInstance(data["decision_id"], str)
+    test_case.assertTrue(data["decision_id"])
+    test_case.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
 
 
 class RunLocalAgentCliTests(unittest.TestCase):
@@ -54,8 +108,79 @@ class RunLocalAgentCliTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.code, 0)
 
+    def test_parse_args_rejects_invalid_boundaries(self) -> None:
+        invalid_cases = [
+            ["pergunta", "--max-tokens", "0"],
+            ["pergunta", "--max-tokens", "-1"],
+            ["pergunta", "--temperature", "-0.1"],
+            ["pergunta", "--temperature", "2.1"],
+            ["pergunta", "--output", "yaml"],
+        ]
+
+        for args in invalid_cases:
+            with self.subTest(args=args):
+                with self.assertRaises(SystemExit):
+                    run_local_agent.parse_args(args)
+
+    def test_parse_args_accepts_temperature_bounds(self) -> None:
+        self.assertEqual(
+            run_local_agent.parse_args(["pergunta", "--temperature", "0.0"]).temperature,
+            0.0,
+        )
+        self.assertEqual(
+            run_local_agent.parse_args(["pergunta", "--temperature", "2.0"]).temperature,
+            2.0,
+        )
+
 
 class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_alias_contract_matrix(self) -> None:
+        cases = [
+            {"kwargs": {}, "alias": "local_chat", "used_rag": False},
+            {"kwargs": {"use_json": True}, "alias": "local_json", "used_rag": False},
+            {"kwargs": {"use_rag": True}, "alias": "local_rag", "used_rag": True},
+        ]
+
+        for case in cases:
+            with self.subTest(case=case):
+                seen: dict[str, object] = {}
+
+                async def chat_call(
+                    question: str,
+                    *,
+                    alias: str,
+                    max_tokens: int | None,
+                    temperature: float | None,
+                    response_format: Mapping[str, object] | None,
+                ) -> str:
+                    del question, max_tokens, temperature, response_format
+                    seen["alias"] = alias
+                    return "answer"
+
+                async def rag_call(
+                    question: str,
+                    *,
+                    max_tokens: int | None,
+                    temperature: float | None,
+                ) -> str:
+                    del question, max_tokens, temperature
+                    seen["alias"] = "local_rag"
+                    return "rag answer"
+
+                kwargs = case["kwargs"]
+                assert isinstance(kwargs, dict)
+                result = await run_local_agent.run_agent(
+                    question="pergunta",
+                    chat_call=chat_call,
+                    rag_call=rag_call,
+                    **kwargs,
+                )
+
+                self.assertEqual(result.alias, case["alias"])
+                self.assertEqual(result.used_rag, case["used_rag"])
+                self.assertEqual(seen["alias"], case["alias"])
+                _assert_safe_schema(self, result.to_json_dict())
+
     async def test_default_mode_selects_local_chat(self) -> None:
         seen: dict[str, object] = {}
 
@@ -165,8 +290,10 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             chat_call=chat_call,
         )
 
-        self.assertEqual(result.answer, "Dry run: no model call executed.")
+        self.assertEqual(result.answer, DRY_RUN_ANSWER)
         self.assertEqual(result.alias, "local_chat")
+        self.assertEqual(result.latency_ms, 0.0)
+        _assert_safe_schema(self, result.to_json_dict())
 
     async def test_output_json_returns_safe_schema(self) -> None:
         result = await run_local_agent.run_agent(
@@ -181,19 +308,7 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         )
         data = json.loads(rendered)
 
-        self.assertEqual(
-            set(data),
-            {
-                "answer",
-                "route",
-                "alias",
-                "used_rag",
-                "latency_ms",
-                "decision_id",
-                "estimated_remote_tokens_avoided",
-            },
-        )
-        self.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
+        _assert_safe_schema(self, data)
 
     async def test_routing_decision_happens_before_execution(self) -> None:
         events: list[str] = []
@@ -240,8 +355,111 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.error_category, "blocked")
         self.assertEqual(result.route, "blocked")
+        self.assertEqual(result.answer, BLOCKED_ANSWER)
+        self.assertEqual(result.latency_ms, 0.0)
+        _assert_safe_schema(self, result.to_json_dict(), expect_error="blocked")
 
-    async def test_rag_unavailable_produces_safe_error_category(self) -> None:
+    async def test_chat_unavailable_produces_safe_error_category(self) -> None:
+        attempts: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            attempts.append(alias)
+            del question, max_tokens, temperature, response_format
+            raise RuntimeError("sensitive private message")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            chat_call=chat_call,
+        )
+
+        data = result.to_json_dict()
+        self.assertEqual(result.answer, FAILURE_ANSWER)
+        self.assertEqual(data["error_category"], "chat_unavailable")
+        self.assertEqual(attempts, ["local_chat"])
+        self.assertNotIn("sensitive private message", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="chat_unavailable")
+
+    async def test_json_unavailable_does_not_fallback_to_chat(self) -> None:
+        attempts: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, max_tokens, temperature, response_format
+            attempts.append(alias)
+            raise RuntimeError("json private failure")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_json=True,
+            chat_call=chat_call,
+        )
+
+        self.assertEqual(attempts, ["local_json"])
+        self.assertEqual(result.alias, "local_json")
+        _assert_safe_schema(
+            self,
+            result.to_json_dict(),
+            expect_error="json_unavailable",
+        )
+
+    async def test_json_mode_keeps_model_answer_as_string_inside_runner_schema(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return '{"foo": "bar"}'
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_json=True,
+            chat_call=chat_call,
+        )
+        data = json.loads(
+            run_local_agent.render_result(
+                result,
+                output="json",
+                show_metadata=False,
+            )
+        )
+
+        self.assertEqual(data["answer"], '{"foo": "bar"}')
+        self.assertEqual(data["alias"], "local_json")
+        _assert_safe_schema(self, data)
+
+    async def test_rag_unavailable_produces_safe_error_category_without_chat_fallback(self) -> None:
+        chat_called = False
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            nonlocal chat_called
+            chat_called = True
+            return "should not be used"
+
         async def rag_call(
             question: str,
             *,
@@ -254,12 +472,39 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         result = await run_local_agent.run_agent(
             question="pergunta",
             use_rag=True,
+            chat_call=chat_call,
             rag_call=rag_call,
         )
 
         data = result.to_json_dict()
         self.assertEqual(data["error_category"], "rag_unavailable")
+        self.assertEqual(data["alias"], "local_rag")
+        self.assertTrue(data["used_rag"])
+        self.assertFalse(chat_called)
         self.assertNotIn("service down", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="rag_unavailable")
+
+    async def test_debug_failure_includes_exception_class_only(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError("sensitive message must not appear")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            debug=True,
+            chat_call=chat_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "chat_unavailable:RuntimeError")
+        self.assertNotIn("sensitive message", json.dumps(data))
 
     async def test_remote_provider_is_never_called(self) -> None:
         source = inspect.getsource(run_local_agent)
@@ -267,6 +512,105 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         for forbidden in ("openai", "anthropic", "gemini", "openrouter"):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, source.lower())
+
+    async def test_token_estimate_consistency(self) -> None:
+        for question in ("", " ", "a", "abcd", "abcde", "Olá, decisão local.", "x" * 100):
+            with self.subTest(question=question):
+                result = await run_local_agent.run_agent(question=question, dry_run=True)
+                self.assertIsInstance(result.estimated_remote_tokens_avoided, int)
+                self.assertGreaterEqual(result.estimated_remote_tokens_avoided, 0)
+
+    def test_prompt_token_estimate_boundaries(self) -> None:
+        self.assertEqual(run_local_agent._estimate_prompt_token_count(""), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("   "), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("a"), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("abcd"), 1)
+        self.assertEqual(run_local_agent._estimate_prompt_token_count("abcde"), 2)
+        self.assertGreaterEqual(
+            run_local_agent._estimate_prompt_token_count("Olá, ação local."),
+            1,
+        )
+
+    def test_render_result_contracts(self) -> None:
+        result = run_local_agent.AgentRunResult(
+            answer="answer",
+            route="local",
+            alias="local_chat",
+            used_rag=False,
+            latency_ms=1.0,
+            decision_id="decision-id",
+            estimated_remote_tokens_avoided=10,
+        )
+
+        self.assertEqual(
+            run_local_agent.render_result(result, output="text", show_metadata=False),
+            "answer",
+        )
+        with_metadata = run_local_agent.render_result(
+            result,
+            output="text",
+            show_metadata=True,
+        )
+        self.assertIn("metadata=", with_metadata)
+        self.assertNotIn('"answer"', with_metadata)
+        data = json.loads(
+            run_local_agent.render_result(
+                result,
+                output="json",
+                show_metadata=False,
+            )
+        )
+        _assert_safe_schema(self, data)
+
+    def test_real_routing_policy_config_remains_local_only_when_available(self) -> None:
+        policy = load_routing_policy()
+
+        self.assertFalse(policy.remote_enabled)
+        self.assertEqual(policy.allowed_remote_providers, ())
+        self.assertIn(policy.per_request_token_limit, (0, None))
+
+    async def test_fake_blocked_decision_preserves_schema(self) -> None:
+        blocked = RouterDecision(
+            decision_id="blocked-decision",
+            timestamp_utc="2026-05-02T00:00:00Z",
+            route=RouteDecisionKind.BLOCKED,
+            reason="policy_denied",
+            risk_level=TaskRiskLevel.LOW,
+            token_budget_class=TokenBudgetClass.TINY,
+            remote_allowed=False,
+            remote_candidate_provider=None,
+            requires_sanitization=False,
+            estimated_prompt_tokens=1,
+            estimated_completion_tokens=1,
+            estimated_remote_tokens=2,
+            estimated_remote_tokens_avoided=2,
+        )
+
+        def fake_decide(**_kwargs: object) -> RouterDecision:
+            return blocked
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        with patch("scripts.run_local_agent.decide_route", fake_decide):
+            result = await run_local_agent.run_agent(
+                question="pergunta",
+                chat_call=chat_call,
+            )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["decision_id"], "blocked-decision")
+        self.assertEqual(data["answer"], BLOCKED_ANSWER)
+        self.assertEqual(data["latency_ms"], 0.0)
+        _assert_safe_schema(self, data, expect_error="blocked")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -48,6 +48,8 @@ FORBIDDEN_OUTPUT_KEYS = {
     "user_prompt",
     "answer_raw",
     "raw_response",
+    "raw_exception",
+    "exception_message",
     "chunks",
     "chunk",
     "chunk_text",

--- a/tests/unit/test_run_local_agent.py
+++ b/tests/unit/test_run_local_agent.py
@@ -9,8 +9,10 @@ from typing import cast
 from unittest.mock import patch
 
 from backend.gateway.routing_policy import (
+    FallbackReason,
     RemoteEscalationPolicy,
     RouteDecisionKind,
+    RouteBlockReason,
     TaskRiskLevel,
     TokenBudgetClass,
     RouterDecision,
@@ -29,7 +31,15 @@ REQUIRED_KEYS = {
     "decision_id",
     "estimated_remote_tokens_avoided",
 }
-OPTIONAL_KEYS = {"error_category"}
+OPTIONAL_KEYS = {
+    "error_category",
+    "fallback_applied",
+    "fallback_from_alias",
+    "fallback_to_alias",
+    "fallback_reason",
+    "fallback_chain",
+    "block_reason",
+}
 FORBIDDEN_OUTPUT_KEYS = {
     "query",
     "question",
@@ -87,6 +97,19 @@ def _assert_safe_schema(
     test_case.assertIsInstance(data["decision_id"], str)
     test_case.assertTrue(data["decision_id"])
     test_case.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in data}))
+
+
+def _assert_fallback_metadata(
+    test_case: unittest.TestCase,
+    data: Mapping[str, object],
+    *,
+    reason: FallbackReason,
+) -> None:
+    test_case.assertEqual(data["fallback_applied"], True)
+    test_case.assertEqual(data["fallback_from_alias"], "local_rag")
+    test_case.assertEqual(data["fallback_to_alias"], "local_chat")
+    test_case.assertEqual(data["fallback_reason"], reason.value)
+    test_case.assertEqual(data["fallback_chain"], [reason.value])
 
 
 class RunLocalAgentCliTests(unittest.TestCase):
@@ -357,6 +380,8 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.route, "blocked")
         self.assertEqual(result.answer, BLOCKED_ANSWER)
         self.assertEqual(result.latency_ms, 0.0)
+        self.assertFalse(result.fallback_applied)
+        self.assertEqual(result.block_reason, FallbackReason.BUDGET_EXCEEDED.value)
         _assert_safe_schema(self, result.to_json_dict(), expect_error="blocked")
 
     async def test_chat_unavailable_produces_safe_error_category(self) -> None:
@@ -444,8 +469,8 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["alias"], "local_json")
         _assert_safe_schema(self, data)
 
-    async def test_rag_unavailable_produces_safe_error_category_without_chat_fallback(self) -> None:
-        chat_called = False
+    async def test_rag_unavailable_falls_back_once_to_local_chat(self) -> None:
+        calls: list[str] = []
 
         async def chat_call(
             question: str,
@@ -455,10 +480,9 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             temperature: float | None,
             response_format: Mapping[str, object] | None,
         ) -> str:
-            del question, alias, max_tokens, temperature, response_format
-            nonlocal chat_called
-            chat_called = True
-            return "should not be used"
+            del question, max_tokens, temperature, response_format
+            calls.append(alias)
+            return "fallback chat answer"
 
         async def rag_call(
             question: str,
@@ -477,12 +501,100 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         )
 
         data = result.to_json_dict()
-        self.assertEqual(data["error_category"], "rag_unavailable")
-        self.assertEqual(data["alias"], "local_rag")
-        self.assertTrue(data["used_rag"])
-        self.assertFalse(chat_called)
+        self.assertNotIn("error_category", data)
+        self.assertEqual(data["answer"], "fallback chat answer")
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertFalse(data["used_rag"])
+        self.assertEqual(calls, ["local_chat"])
         self.assertNotIn("service down", json.dumps(data))
-        _assert_safe_schema(self, data, expect_error="rag_unavailable")
+        _assert_safe_schema(self, data)
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.RAG_UNAVAILABLE,
+        )
+
+    async def test_qdrant_unavailable_fallback_reason_is_typed(self) -> None:
+        class QdrantUnavailableError(RuntimeError):
+            pass
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback chat answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise QdrantUnavailableError("private details")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.QDRANT_UNAVAILABLE,
+        )
+
+    async def test_rag_unavailable_and_fallback_chat_failure_has_no_double_fallback(self) -> None:
+        calls: list[str] = []
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, max_tokens, temperature, response_format
+            calls.append(alias)
+            raise RuntimeError("fallback private failure")
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("rag private failure")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(calls, ["local_chat"])
+        self.assertEqual(data["alias"], "local_chat")
+        self.assertFalse(data["used_rag"])
+        self.assertNotIn("rag private failure", json.dumps(data))
+        self.assertNotIn("fallback private failure", json.dumps(data))
+        _assert_safe_schema(self, data, expect_error="fallback_alias_failed")
+        _assert_fallback_metadata(
+            self,
+            data,
+            reason=FallbackReason.RAG_UNAVAILABLE,
+        )
 
     async def test_debug_failure_includes_exception_class_only(self) -> None:
         async def chat_call(
@@ -505,6 +617,40 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(data["error_category"], "chat_unavailable:RuntimeError")
         self.assertNotIn("sensitive message", json.dumps(data))
+
+    async def test_fallback_debug_failure_includes_exception_class_only(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise RuntimeError("fallback sensitive message")
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("rag sensitive message")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            use_rag=True,
+            debug=True,
+            chat_call=chat_call,
+            rag_call=rag_call,
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "fallback_alias_failed:RuntimeError")
+        self.assertNotIn("fallback sensitive message", json.dumps(data))
+        self.assertNotIn("rag sensitive message", json.dumps(data))
 
     async def test_remote_provider_is_never_called(self) -> None:
         source = inspect.getsource(run_local_agent)
@@ -574,7 +720,7 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
             decision_id="blocked-decision",
             timestamp_utc="2026-05-02T00:00:00Z",
             route=RouteDecisionKind.BLOCKED,
-            reason="policy_denied",
+            reason=RouteBlockReason.BUDGET_EXCEEDED.value,
             risk_level=TaskRiskLevel.LOW,
             token_budget_class=TokenBudgetClass.TINY,
             remote_allowed=False,
@@ -610,7 +756,149 @@ class RunLocalAgentTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["decision_id"], "blocked-decision")
         self.assertEqual(data["answer"], BLOCKED_ANSWER)
         self.assertEqual(data["latency_ms"], 0.0)
+        self.assertEqual(data["fallback_applied"], False)
+        self.assertEqual(data["block_reason"], FallbackReason.BUDGET_EXCEEDED.value)
         _assert_safe_schema(self, data, expect_error="blocked")
+
+    async def test_policy_block_unsupported_task_never_fallbacks(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            raise AssertionError("chat should not be called")
+
+        result = await run_local_agent.run_agent(
+            question="pergunta",
+            chat_call=chat_call,
+            policy_loader=lambda: RemoteEscalationPolicy(
+                blocked_task_types=("agent0_chat",),
+            ),
+        )
+        data = result.to_json_dict()
+
+        self.assertEqual(data["error_category"], "blocked")
+        self.assertEqual(data["fallback_applied"], False)
+        self.assertEqual(data["block_reason"], FallbackReason.UNSUPPORTED_TASK.value)
+        _assert_safe_schema(self, data, expect_error="blocked")
+
+    async def test_successful_fallback_exits_zero(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("private")
+
+        with (
+            patch("scripts.run_local_agent._call_chat_alias", chat_call),
+            patch("scripts.run_local_agent._call_rag", rag_call),
+            patch("sys.stdout.write") as write_mock,
+        ):
+            exit_code = await run_local_agent.main_async(["pergunta", "--rag"])
+
+        self.assertEqual(exit_code, 0)
+        rendered = write_mock.call_args.args[0]
+        self.assertIn("fallback answer", rendered)
+
+    async def test_policy_block_exits_nonzero(self) -> None:
+        with (
+            patch(
+                "scripts.run_local_agent._safe_policy",
+                lambda: RemoteEscalationPolicy(per_request_token_limit=1),
+            ),
+            patch("sys.stdout.write"),
+        ):
+            exit_code = await run_local_agent.main_async(["pergunta"])
+
+        self.assertNotEqual(exit_code, 0)
+
+    async def test_fallback_event_is_safe_and_emitted_only_on_fallback(self) -> None:
+        events: list[dict[str, object]] = []
+
+        class BoundLogger:
+            def __init__(self, event: dict[str, object]) -> None:
+                self.event = event
+
+            def info(self, message: str) -> None:
+                self.event["message"] = message
+                events.append(self.event)
+
+        def fake_bind(**kwargs: object) -> BoundLogger:
+            event = kwargs["event"]
+            assert isinstance(event, dict)
+            return BoundLogger(event)
+
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "fallback answer"
+
+        async def rag_call(
+            question: str,
+            *,
+            max_tokens: int | None,
+            temperature: float | None,
+        ) -> str:
+            del question, max_tokens, temperature
+            raise RuntimeError("private prompt should not leak")
+
+        with patch("scripts.run_local_agent.logger.bind", fake_bind):
+            await run_local_agent.run_agent(
+                question="pergunta",
+                use_rag=True,
+                chat_call=chat_call,
+                rag_call=rag_call,
+            )
+
+        self.assertEqual(len(events), 1)
+        event = events[0]
+        self.assertEqual(event["event"], "agent_fallback")
+        self.assertEqual(event["fallback_reason"], FallbackReason.RAG_UNAVAILABLE.value)
+        self.assertEqual(event["original_alias"], "local_rag")
+        self.assertEqual(event["fallback_alias"], "local_chat")
+        self.assertTrue(event["fallback_succeeded"])
+        self.assertTrue(FORBIDDEN_OUTPUT_KEYS.isdisjoint({key.lower() for key in event}))
+
+    async def test_no_fallback_event_without_fallback(self) -> None:
+        async def chat_call(
+            question: str,
+            *,
+            alias: str,
+            max_tokens: int | None,
+            temperature: float | None,
+            response_format: Mapping[str, object] | None,
+        ) -> str:
+            del question, alias, max_tokens, temperature, response_format
+            return "answer"
+
+        with patch("scripts.run_local_agent.logger.bind") as bind_mock:
+            await run_local_agent.run_agent(question="pergunta", chat_call=chat_call)
+
+        bind_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds per-segment timing (routing_ms=None, retrieval_ms, prompt_ms, generation_ms, total_ms) to RagRunTrace, hardens .env contract (B4 fix), documents uv --env-file workflow. 319/319 unit tests.