### PR TITLE
feat(g2-pr03): local RAG generation budget cap for local_rag

### DIFF
--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -86,6 +86,13 @@ RAG_RUN_TRACE_KEYS = frozenset(
         "context_chunks_dropped",
         "context_budget_max_chunks",
         "context_estimated_tokens_used",
+        # Gateway-2 local_rag generation budget fields.
+        "answer_length_chars",
+        "answer_token_estimate",
+        "generation_budget_enabled",
+        "generation_budget_applied",
+        "generation_budget_max_tokens",
+        "conciseness_instruction_applied",
         "prompt_build_ms",
         "generation_ms",
         "total_ms",

--- a/backend/rag/generation_budget.py
+++ b/backend/rag/generation_budget.py
@@ -1,0 +1,239 @@
+"""Configurable local RAG generation budget controls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+LOCAL_RAG_ALIAS = "local_rag"
+ALLOWED_GENERATION_BUDGET_ALIASES = frozenset({LOCAL_RAG_ALIAS})
+DEFAULT_GENERATION_BUDGET_MAX_TOKENS = 768
+DEFAULT_TARGET_SENTENCES_MIN = 3
+DEFAULT_TARGET_SENTENCES_MAX = 6
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
+
+
+@dataclass(frozen=True)
+class GenerationBudgetConfig:
+    """Rollback-safe generation budget config for ``local_rag``."""
+
+    enabled: bool = False
+    apply_to_aliases: tuple[str, ...] = (LOCAL_RAG_ALIAS,)
+    max_tokens: int | None = DEFAULT_GENERATION_BUDGET_MAX_TOKENS
+    enforce_conciseness: bool = False
+    target_sentences_min: int = DEFAULT_TARGET_SENTENCES_MIN
+    target_sentences_max: int = DEFAULT_TARGET_SENTENCES_MAX
+
+    def validated(self) -> GenerationBudgetConfig:
+        """Return normalized config or raise a clear validation error."""
+        if not isinstance(self.enabled, bool):
+            raise TypeError("rag.generation_budget.enabled must be boolean")
+        if self.max_tokens is not None:
+            if isinstance(self.max_tokens, bool) or not isinstance(self.max_tokens, int):
+                raise TypeError("rag.generation_budget.max_tokens must be an integer")
+            if self.max_tokens <= 0:
+                raise ValueError(
+                    "rag.generation_budget.max_tokens must be greater than zero"
+                )
+        if not isinstance(self.enforce_conciseness, bool):
+            raise TypeError(
+                "rag.generation_budget.enforce_conciseness must be boolean"
+            )
+        if isinstance(self.target_sentences_min, bool) or not isinstance(
+            self.target_sentences_min,
+            int,
+        ):
+            raise TypeError(
+                "rag.generation_budget.target_sentences_min must be an integer"
+            )
+        if isinstance(self.target_sentences_max, bool) or not isinstance(
+            self.target_sentences_max,
+            int,
+        ):
+            raise TypeError(
+                "rag.generation_budget.target_sentences_max must be an integer"
+            )
+        if self.target_sentences_min < 1:
+            raise ValueError(
+                "rag.generation_budget.target_sentences_min must be at least 1"
+            )
+        if self.target_sentences_max < self.target_sentences_min:
+            raise ValueError(
+                "rag.generation_budget.target_sentences_max must be greater than "
+                "or equal to target_sentences_min"
+            )
+        aliases = tuple(
+            _validate_generation_budget_alias(alias)
+            for alias in self.apply_to_aliases
+        )
+        if not aliases:
+            raise ValueError("rag.generation_budget.apply_to_aliases cannot be empty")
+        return GenerationBudgetConfig(
+            enabled=self.enabled,
+            apply_to_aliases=aliases,
+            max_tokens=self.max_tokens,
+            enforce_conciseness=self.enforce_conciseness,
+            target_sentences_min=self.target_sentences_min,
+            target_sentences_max=self.target_sentences_max,
+        )
+
+
+@dataclass(frozen=True)
+class GenerationBudgetDecision:
+    """Per-call local RAG generation budget decision."""
+
+    enabled: bool
+    max_tokens: int | None
+    conciseness_instruction: str | None
+
+    @property
+    def max_tokens_applied(self) -> bool:
+        """Return whether a token cap should be forwarded to generation."""
+        return self.max_tokens is not None
+
+    @property
+    def conciseness_instruction_applied(self) -> bool:
+        """Return whether prompt discipline should be added."""
+        return self.conciseness_instruction is not None
+
+
+def decide_generation_budget(
+    config: GenerationBudgetConfig,
+    *,
+    alias: str | None,
+) -> GenerationBudgetDecision:
+    """Return the generation budget decision for one model alias."""
+    normalized = config.validated()
+    if (
+        not normalized.enabled
+        or alias is None
+        or alias not in normalized.apply_to_aliases
+    ):
+        return GenerationBudgetDecision(
+            enabled=False,
+            max_tokens=None,
+            conciseness_instruction=None,
+        )
+    instruction = (
+        _conciseness_instruction(normalized)
+        if normalized.enforce_conciseness
+        else None
+    )
+    return GenerationBudgetDecision(
+        enabled=True,
+        max_tokens=normalized.max_tokens,
+        conciseness_instruction=instruction,
+    )
+
+
+def load_generation_budget_config(
+    config_path: str | Path = DEFAULT_RAG_CONFIG_PATH,
+) -> GenerationBudgetConfig:
+    """Load ``rag.generation_budget`` from the RAG config file."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("rag_config.yaml must contain a mapping")
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        raise ValueError("rag_config.yaml must contain rag mapping")
+    generation_budget = rag.get("generation_budget", {})
+    if generation_budget is None:
+        generation_budget = {}
+    if not isinstance(generation_budget, Mapping):
+        raise ValueError("rag.generation_budget must be a mapping")
+    return GenerationBudgetConfig(
+        enabled=_bool_value(generation_budget, "enabled", False),
+        apply_to_aliases=_alias_tuple(
+            generation_budget,
+            "apply_to_aliases",
+            (LOCAL_RAG_ALIAS,),
+        ),
+        max_tokens=_optional_int_value(
+            generation_budget,
+            "max_tokens",
+            DEFAULT_GENERATION_BUDGET_MAX_TOKENS,
+        ),
+        enforce_conciseness=_bool_value(
+            generation_budget,
+            "enforce_conciseness",
+            False,
+        ),
+        target_sentences_min=_int_value(
+            generation_budget,
+            "target_sentences_min",
+            DEFAULT_TARGET_SENTENCES_MIN,
+        ),
+        target_sentences_max=_int_value(
+            generation_budget,
+            "target_sentences_max",
+            DEFAULT_TARGET_SENTENCES_MAX,
+        ),
+    ).validated()
+
+
+def _conciseness_instruction(config: GenerationBudgetConfig) -> str:
+    return (
+        "Answer concisely, usually in "
+        f"{config.target_sentences_min}-{config.target_sentences_max} sentences. "
+        "Preserve the most important evidence and include inline citations when "
+        "context is available. Do not repeat retrieved passages verbatim. If "
+        "the context is insufficient, say so clearly."
+    )
+
+
+def _bool_value(mapping: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = mapping.get(key, default)
+    if not isinstance(value, bool):
+        raise TypeError(f"rag.generation_budget.{key} must be boolean")
+    return value
+
+
+def _int_value(mapping: Mapping[str, Any], key: str, default: int) -> int:
+    value = mapping.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"rag.generation_budget.{key} must be an integer")
+    return int(value)
+
+
+def _optional_int_value(
+    mapping: Mapping[str, Any],
+    key: str,
+    default: int | None,
+) -> int | None:
+    value = mapping.get(key, default)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"rag.generation_budget.{key} must be an integer")
+    return int(value)
+
+
+def _alias_tuple(
+    mapping: Mapping[str, Any],
+    key: str,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = mapping.get(key, default)
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise TypeError(f"rag.generation_budget.{key} must be a sequence")
+    return tuple(_validate_generation_budget_alias(alias) for alias in value)
+
+
+def _validate_generation_budget_alias(alias: object) -> str:
+    if not isinstance(alias, str):
+        raise TypeError("rag.generation_budget aliases must be strings")
+    value = alias.strip()
+    if not value:
+        raise ValueError("rag.generation_budget aliases cannot be empty")
+    if value not in ALLOWED_GENERATION_BUDGET_ALIASES:
+        raise ValueError(
+            "rag.generation_budget.apply_to_aliases supports only "
+            f"{sorted(ALLOWED_GENERATION_BUDGET_ALIASES)} in G2-03"
+        )
+    return value

--- a/backend/rag/generation_budget.py
+++ b/backend/rag/generation_budget.py
@@ -179,11 +179,11 @@ def load_generation_budget_config(
 
 def _conciseness_instruction(config: GenerationBudgetConfig) -> str:
     return (
-        "Answer concisely, usually in "
-        f"{config.target_sentences_min}-{config.target_sentences_max} sentences. "
-        "Preserve the most important evidence and include inline citations when "
-        "context is available. Do not repeat retrieved passages verbatim. If "
-        "the context is insufficient, say so clearly."
+        "Responda de forma concisa, normalmente em "
+        f"{config.target_sentences_min} a {config.target_sentences_max} frases. "
+        "Preserve as evidencias mais relevantes e inclua citacoes quando o "
+        "contexto estiver disponivel. Nao repita trechos recuperados na integra. "
+        "Se o contexto for insuficiente, diga isso claramente."
     )
 
 

--- a/backend/rag/generation_budget.py
+++ b/backend/rag/generation_budget.py
@@ -109,11 +109,10 @@ def decide_generation_budget(
     alias: str | None,
 ) -> GenerationBudgetDecision:
     """Return the generation budget decision for one model alias."""
-    normalized = config.validated()
     if (
-        not normalized.enabled
+        not config.enabled
         or alias is None
-        or alias not in normalized.apply_to_aliases
+        or alias not in config.apply_to_aliases
     ):
         return GenerationBudgetDecision(
             enabled=False,
@@ -121,13 +120,13 @@ def decide_generation_budget(
             conciseness_instruction=None,
         )
     instruction = (
-        _conciseness_instruction(normalized)
-        if normalized.enforce_conciseness
+        _conciseness_instruction(config)
+        if config.enforce_conciseness
         else None
     )
     return GenerationBudgetDecision(
         enabled=True,
-        max_tokens=normalized.max_tokens,
+        max_tokens=config.max_tokens,
         conciseness_instruction=instruction,
     )
 

--- a/backend/rag/generator.py
+++ b/backend/rag/generator.py
@@ -110,6 +110,7 @@ class LocalGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
         """Generate one local answer through LiteLLM chat completions."""
 
@@ -120,13 +121,16 @@ class LocalGenerator:
         effective_temperature = self.temperature if temperature is None else temperature
         if not 0.0 <= effective_temperature <= 2.0:
             raise ValueError("temperature must be between 0.0 and 2.0")
+        effective_max_tokens = self.max_tokens if max_tokens is None else max_tokens
+        if effective_max_tokens <= 0:
+            raise ValueError("max_tokens must be greater than zero")
 
         start = time.perf_counter()
         answer = await self.gateway_client.chat_completion(
             clean_messages,
             model=self.model,
             temperature=effective_temperature,
-            max_tokens=self.max_tokens,
+            max_tokens=effective_max_tokens,
         )
         if not thinking_mode:
             answer = _strip_thinking(answer)

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -10,8 +10,15 @@ from uuid import uuid4
 
 from loguru import logger
 
+from backend.gateway.routing_policy import estimate_prompt_tokens
 from backend.rag._validation import validate_question
 from backend.rag.context_packer import ContextBudgetResult, RetrievedChunk
+from backend.rag.generation_budget import (
+    GenerationBudgetConfig,
+    GenerationBudgetDecision,
+    decide_generation_budget,
+    load_generation_budget_config,
+)
 from backend.rag.prompt_builder import PromptBuilder
 from backend.rag.observability import (
     RagErrorCategory,
@@ -52,6 +59,7 @@ class GeneratorProtocol(Protocol):
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> Awaitable[str]:
         """Generate an answer from chat messages."""
         ...
@@ -85,12 +93,15 @@ class LocalRagPipeline:
     thinking_mode: bool = False
     tracing_config: RagTracingConfig | None = None
     observability_config: RagObservabilityConfig | None = None
+    generation_budget_config: GenerationBudgetConfig | None = None
 
     def __post_init__(self) -> None:
         if self.tracing_config is None:
             self.tracing_config = load_rag_tracing_config()
         if self.observability_config is None:
             self.observability_config = load_rag_observability_config()
+        if self.generation_budget_config is None:
+            self.generation_budget_config = load_generation_budget_config()
 
     async def ask(
         self,
@@ -144,16 +155,22 @@ class LocalRagPipeline:
             status="success",
         )
 
+        gateway_alias = _infer_gateway_alias(self.generator)
+        generation_budget = decide_generation_budget(
+            self.generation_budget_config or GenerationBudgetConfig(),
+            alias=gateway_alias,
+        )
+
         prompt_start = time.perf_counter()
         messages = self.prompt_builder.build(
             clean_question,
             chunks,
             thinking_mode=self.thinking_mode,
+            conciseness_instruction=generation_budget.conciseness_instruction,
         )
         prompt_ms = _elapsed_ms(prompt_start)
 
         generation_start = time.perf_counter()
-        gateway_alias = _infer_gateway_alias(self.generator)
         self._emit_pipeline_event(
             RagEventKind.GENERATION_STARTED,
             query_id=query_id,
@@ -163,10 +180,12 @@ class LocalRagPipeline:
             status="started",
         )
         try:
-            answer = await self.generator.chat(
-                messages,
+            answer = await _chat_with_generation_budget(
+                self.generator,
+                messages=messages,
                 temperature=self.temperature,
                 thinking_mode=self.thinking_mode,
+                generation_budget=generation_budget,
             )
         except Exception as exc:
             self._emit_pipeline_event(
@@ -209,6 +228,9 @@ class LocalRagPipeline:
             vector_search_ms=retrieval_segments.retrieval_ms,
             context_pack_ms=retrieval_segments.context_pack_ms,
             context_budget_result=context_budget_result,
+            generation_budget=generation_budget,
+            answer_length_chars=len(answer),
+            answer_token_estimate=estimate_prompt_tokens(answer),
             prompt_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=latency["total_ms"],
@@ -236,6 +258,9 @@ class LocalRagPipeline:
         total_ms: float,
         chunk_count: int,
         context_budget_result: ContextBudgetResult | None = None,
+        generation_budget: GenerationBudgetDecision | None = None,
+        answer_length_chars: int | None = None,
+        answer_token_estimate: int | None = None,
         query_id: str | None = None,
         actual_embedding_dimensions: int | None = None,
         run_context: RagRunContext | None = None,
@@ -316,6 +341,24 @@ class LocalRagPipeline:
                 if context_budget_result is not None
                 else None
             ),
+            answer_length_chars=answer_length_chars,
+            answer_token_estimate=answer_token_estimate,
+            generation_budget_enabled=(
+                generation_budget.enabled if generation_budget is not None else None
+            ),
+            generation_budget_applied=(
+                generation_budget.max_tokens_applied
+                if generation_budget is not None
+                else None
+            ),
+            generation_budget_max_tokens=(
+                generation_budget.max_tokens if generation_budget is not None else None
+            ),
+            conciseness_instruction_applied=(
+                generation_budget.conciseness_instruction_applied
+                if generation_budget is not None
+                else None
+            ),
             prompt_build_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=total_ms,
@@ -374,6 +417,22 @@ def _infer_gateway_alias(generator: object) -> str | None:
     if isinstance(model, str) and model.strip():
         return model.strip()
     return None
+
+
+async def _chat_with_generation_budget(
+    generator: GeneratorProtocol,
+    *,
+    messages: Sequence[dict[str, str]],
+    temperature: float | None,
+    thinking_mode: bool,
+    generation_budget: GenerationBudgetDecision,
+) -> str:
+    return await generator.chat(
+        messages,
+        temperature=temperature,
+        thinking_mode=thinking_mode,
+        max_tokens=generation_budget.max_tokens,
+    )
 
 
 @dataclass(frozen=True)

--- a/backend/rag/prompt_builder.py
+++ b/backend/rag/prompt_builder.py
@@ -36,21 +36,29 @@ class PromptBuilder:
         question: str,
         chunks: Sequence[RetrievedChunk],
         thinking_mode: bool = False,
+        conciseness_instruction: str | None = None,
     ) -> list[dict[str, str]]:
         """Return chat messages with recovered context and citation rules."""
 
         clean_question = validate_question(question)
         context = self._format_context(chunks)
         thinking_directive = "/think" if thinking_mode else "/no_think"
+        response_instructions = [
+            "- Responda em portugues brasileiro.",
+            "- Use apenas o contexto recuperado.",
+            "- Inclua citacoes no formato [doc_id#chunk_index].",
+            "- Se o contexto for insuficiente, diga isso claramente.",
+        ]
+        if conciseness_instruction is not None:
+            instruction = conciseness_instruction.strip()
+            if instruction:
+                response_instructions.append(f"- {instruction}")
         user_content = (
             f"{thinking_directive}\n\n"
             f"PERGUNTA:\n{clean_question}\n\n"
             f"CONTEXTO RECUPERADO:\n{context}\n\n"
             "INSTRUCOES DE RESPOSTA:\n"
-            "- Responda em portugues brasileiro.\n"
-            "- Use apenas o contexto recuperado.\n"
-            "- Inclua citacoes no formato [doc_id#chunk_index].\n"
-            "- Se o contexto for insuficiente, diga isso claramente."
+            + "\n".join(response_instructions)
         )
 
         return [

--- a/backend/rag/run_trace.py
+++ b/backend/rag/run_trace.py
@@ -90,7 +90,16 @@ class RagTracingConfig:
 
 @dataclass(frozen=True)
 class RagRunTrace:
-    """Safe provenance metadata for one RAG query execution."""
+    """Safe provenance metadata for one RAG query execution.
+
+    Compatibility note: legacy latency fields are intentionally retained while
+    Gateway-2 segment fields stabilize. ``prompt_latency_ms`` mirrors
+    ``prompt_build_ms``, ``generation_latency_ms`` mirrors ``generation_ms``,
+    and ``total_latency_ms`` mirrors ``total_ms`` when both fields are present.
+    New consumers should prefer ``prompt_build_ms``, ``generation_ms`` and
+    ``total_ms``. Legacy fields may be considered for removal only in a future
+    schema-versioned PR.
+    """
 
     query_id: str
     timestamp_utc: str

--- a/backend/rag/run_trace.py
+++ b/backend/rag/run_trace.py
@@ -119,6 +119,12 @@ class RagRunTrace:
     context_chunks_dropped: int | None = None
     context_budget_max_chunks: int | None = None
     context_estimated_tokens_used: int | None = None
+    answer_length_chars: int | None = None
+    answer_token_estimate: int | None = None
+    generation_budget_enabled: bool | None = None
+    generation_budget_applied: bool | None = None
+    generation_budget_max_tokens: int | None = None
+    conciseness_instruction_applied: bool | None = None
     prompt_build_ms: float | None = None
     generation_ms: float | None = None
     total_ms: float | None = None
@@ -183,6 +189,9 @@ class RagRunTrace:
             "context_chunks_dropped",
             "context_budget_max_chunks",
             "context_estimated_tokens_used",
+            "answer_length_chars",
+            "answer_token_estimate",
+            "generation_budget_max_tokens",
         ):
             value = getattr(self, field_name)
             if value is not None:
@@ -192,7 +201,18 @@ class RagRunTrace:
                 self.context_budget_max_chunks,
                 "context_budget_max_chunks",
             )
-        for field_name in ("context_budget_enabled", "context_budget_applied"):
+        if self.generation_budget_max_tokens is not None:
+            _validate_positive_int(
+                self.generation_budget_max_tokens,
+                "generation_budget_max_tokens",
+            )
+        for field_name in (
+            "context_budget_enabled",
+            "context_budget_applied",
+            "generation_budget_enabled",
+            "generation_budget_applied",
+            "conciseness_instruction_applied",
+        ):
             value = getattr(self, field_name)
             if value is not None and not isinstance(value, bool):
                 raise TypeError(f"{field_name} must be boolean when provided")
@@ -254,6 +274,12 @@ class RagRunTrace:
             "context_chunks_dropped": self.context_chunks_dropped,
             "context_budget_max_chunks": self.context_budget_max_chunks,
             "context_estimated_tokens_used": self.context_estimated_tokens_used,
+            "answer_length_chars": self.answer_length_chars,
+            "answer_token_estimate": self.answer_token_estimate,
+            "generation_budget_enabled": self.generation_budget_enabled,
+            "generation_budget_applied": self.generation_budget_applied,
+            "generation_budget_max_tokens": self.generation_budget_max_tokens,
+            "conciseness_instruction_applied": self.conciseness_instruction_applied,
             "prompt_build_ms": self.prompt_build_ms,
             "generation_ms": self.generation_ms,
             "total_ms": self.total_ms,
@@ -302,6 +328,12 @@ def build_rag_run_trace(
     context_chunks_dropped: int | None = None,
     context_budget_max_chunks: int | None = None,
     context_estimated_tokens_used: int | None = None,
+    answer_length_chars: int | None = None,
+    answer_token_estimate: int | None = None,
+    generation_budget_enabled: bool | None = None,
+    generation_budget_applied: bool | None = None,
+    generation_budget_max_tokens: int | None = None,
+    conciseness_instruction_applied: bool | None = None,
     prompt_build_ms: float | None = None,
     generation_ms: float | None = None,
     total_ms: float | None = None,
@@ -342,6 +374,12 @@ def build_rag_run_trace(
         context_chunks_dropped=context_chunks_dropped,
         context_budget_max_chunks=context_budget_max_chunks,
         context_estimated_tokens_used=context_estimated_tokens_used,
+        answer_length_chars=answer_length_chars,
+        answer_token_estimate=answer_token_estimate,
+        generation_budget_enabled=generation_budget_enabled,
+        generation_budget_applied=generation_budget_applied,
+        generation_budget_max_tokens=generation_budget_max_tokens,
+        conciseness_instruction_applied=conciseness_instruction_applied,
         prompt_build_ms=prompt_build_ms,
         generation_ms=generation_ms,
         total_ms=total_ms,

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -64,6 +64,9 @@ rag:
       - "local_rag"
 
   generation_budget:
+    # G2-03 is validated only for local_rag with thinking_mode=false.
+    # Do not enable this budget for thinking aliases: Qwen3 reasoning tokens can
+    # consume the same max_tokens/num_predict budget before final answer tokens.
     enabled: false
     apply_to_aliases:
       - "local_rag"

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -63,6 +63,15 @@ rag:
     apply_to_aliases:
       - "local_rag"
 
+  generation_budget:
+    enabled: false
+    apply_to_aliases:
+      - "local_rag"
+    max_tokens: 768
+    enforce_conciseness: false
+    target_sentences_min: 3
+    target_sentences_max: 6
+
   generation:
     model: "local_rag"
     reasoning_model: "local_think"

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -189,7 +189,7 @@ OpenClaw / LocalGenerator
 | GW-11 | `feat/rag-observability-events` | Local structured RAG lifecycle events | ✅ Merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary | ✅ Merged |
 
-### Sprint Gateway-1 — CURRENT
+### Sprint Gateway-1 — COMPLETE ✅
 
 Gateway-1 starts after Gateway-0 readiness. GW-13 adds routing policy
 primitives only:
@@ -204,12 +204,37 @@ task metadata + token estimates
 | PR | Branch | Scope | Status |
 |---|---|---|---|
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Local-first routing decision records and token economy prelude | ✅ Merged |
-| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | ✅ Merged |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | ✅ Merged |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
-| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | 🚧 Current |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | ✅ Merged |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | ✅ Merged |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | ✅ Merged |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | ✅ Merged |
+| GW-20 | `feat/gateway1-proof-of-life-smoke` | Gateway-1 operational proof-of-life smoke | ✅ Merged |
+
+### Sprint Gateway-2 — CURRENT
+
+Gateway-2 is performance work on top of the stable local-only Gateway-1 stack.
+The first rule is measurement before optimization.
+
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| G2-PR01 | `feat/g2-rag-segment-timing-baseline` | Per-segment RAG latency baseline in `RagRunTrace` | ✅ Merged |
+| G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap for `local_rag` | ✅ Merged |
+| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable generation budget and answer-length discipline for `local_rag` | 🚧 Current |
+
+G2-PR03 rules:
+
+- Budget is configured under `rag.generation_budget`.
+- Default is rollback-safe: `enabled: false`.
+- `max_tokens` forwarding applies only to `local_rag`.
+- `local_chat`, `local_json`, `local_think`, retrieval, context packing,
+  Qdrant, aliases, timeouts and fallback behavior remain unchanged.
+- Optional concise-answer discipline must preserve citations and
+  insufficient-context behavior.
+- Trace fields are scalar only: answer length, token estimate, budget enabled,
+  budget applied, max tokens and conciseness applied.
+- No answer text, prompts, chunks, vectors, payloads or secrets are serialized.
 
 GW-13 rules:
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,31 +5,21 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-02
-**Updated by:** Codex — Agent-0 GW-19 observability signal contract
+**Updated by:** Codex — G2-PR03 local_rag generation budget
 
 ---
 
-## Active Sprint: Agent-0 / Local Runner MVP
+## Active Sprint: Gateway-2 / RAG Latency Optimization
 
-**Goal:** verify Agent-0 observability signal completeness and sanitization
-with deterministic offline tests for routing, token economy, RAG trace,
-fallback and decision-log records.
+**Goal:** reduce `local_rag` wall time through controlled, observable,
+rollback-safe local optimizations after the Gateway-1 proof-of-life baseline.
 
-Gateway-0 is complete on `main`. GW-13 is merged. GW-14 remains a separate
-open PR at the time GW-15 starts, so GW-15 uses compatibility helpers when the
-GW-14 token/config helpers are not present on `main`.
+Current branch: `feat/g2-local-rag-generation-budget`
+Current issue: `[G2-03] Constrain local_rag generation budget`
 
-GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
-GW-19 branch: `feat/agent0-observability-signal-contract`
-
-Note: local GitHub state on 2026-05-02 showed GW-15 merged and the GW-16
-hardening branch present, but the GW-16 commit was not on `origin/main`.
-GW-17 was therefore implemented as a stacked branch on the GW-16 branch and
-should be retargeted/rebased after GW-16 is integrated.
-GW-18 was implemented as a stacked branch on GW-17 for the same reason and
-should be retargeted/rebased after GW-16/GW-17 are integrated.
-GW-19 was implemented as a stacked branch on the GW-18 integration branch and
-should be retargeted/rebased after GW-16/GW-17/GW-18 are integrated.
+Gateway-0 and Gateway-1 are complete on `main`. Gateway-2 starts from the
+measured `local_rag` latency baseline and must keep all optimizations
+config-driven, local-only, and reversible.
 
 Current runtime path:
 
@@ -125,12 +115,16 @@ unavoidable, use `git push --force-with-lease`.
 | GW-11 | `feat/rag-observability-events` | Safe structured RAG lifecycle observability events | Done / merged |
 | GW-12 | `feat/gateway-operational-readiness` | Final runbook, readiness checks, ADR boundary, handoff | Done / merged |
 | GW-13 | `feat/gateway1-routing-policy-prelude` | Gateway-1 local-first routing policy and token economy prelude | Done / merged |
-| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Open / separate PR |
+| GW-14 | `feat/gateway1-routing-audit-token-economy` | Config-driven routing audit and token economy calibration | Done / merged |
 | GW-15 | `feat/agent0-local-runner` | Agent-0 local CLI runner MVP | Done / merged |
-| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Dependency branch / not on `origin/main` |
-| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Dependency branch / open PR |
-| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Dependency branch / merged into stack |
-| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | Current |
+| GW-16 | `feat/agent0-runner-contract-hardening` | Agent-0 runner contract hardening | Done / merged |
+| GW-17 | `feat/agent0-local-failsafe-degradation` | Explicit local fail-safe degradation for Agent-0 | Done / merged |
+| GW-18 | `feat/agent0-golden-question-harness` | Golden question benchmark harness for Agent-0 | Done / merged |
+| GW-19 | `feat/agent0-observability-signal-contract` | Agent-0 observability signal contract and sanitization tests | Done / merged |
+| GW-20 | `feat/gateway1-proof-of-life-smoke` | Gateway-1 operational proof-of-life smoke | Done / merged |
+| G2-PR01 | `feat/g2-rag-segment-timing-baseline` | Per-segment RAG latency baseline | Done / merged |
+| G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap | Done / merged |
+| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable local_rag generation budget | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -151,6 +145,36 @@ GW-19 issue: <https://github.com/franciscosalido/OPENCLAW/issues/63>
 Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
+
+## G2-PR03 Current Work
+
+G2-PR03 adds a rollback-safe generation budget for `local_rag` only.
+
+Configuration:
+
+```yaml
+rag:
+  generation_budget:
+    enabled: false
+    apply_to_aliases:
+      - "local_rag"
+    max_tokens: 768
+    enforce_conciseness: false
+    target_sentences_min: 3
+    target_sentences_max: 6
+```
+
+Rules:
+
+- Default is disabled, preserving pre-PR behavior.
+- `max_tokens` is forwarded only for `local_rag` when enabled.
+- `local_chat`, `local_json`, `local_think`, retrieval, Qdrant and context
+  packing remain unchanged.
+- Optional conciseness instruction preserves citations and insufficient-context
+  behavior.
+- `RagRunTrace` records answer length and generation-budget scalar metadata,
+  never answer text, prompt text, chunks, vectors, payloads or secrets.
+- `local_rag` keeps `extra_body.think=false` in the operational LiteLLM config.
 
 ## GW-15 Current Work
 

--- a/docs/RAG_GENERATION_BUDGET.md
+++ b/docs/RAG_GENERATION_BUDGET.md
@@ -1,0 +1,119 @@
+# RAG Generation Budget
+
+G2-03 adds an optional local-only generation budget for `local_rag`.
+
+This is a reversible performance experiment aimed at the `generation_ms`
+segment. It does not change retrieval, `top_k`, context packing, Qdrant,
+embeddings, model aliases, timeout values, `local_chat`, `local_json`, or the
+Agent-0 fallback chain.
+
+## Configuration
+
+The budget is controlled by `config/rag_config.yaml`:
+
+```yaml
+rag:
+  generation_budget:
+    enabled: false
+    apply_to_aliases:
+      - "local_rag"
+    max_tokens: 768
+    enforce_conciseness: false
+    target_sentences_min: 3
+    target_sentences_max: 6
+```
+
+Rollback is a config-only change:
+
+```yaml
+rag:
+  generation_budget:
+    enabled: false
+```
+
+Additional rollback levers:
+
+- `max_tokens: null` disables forwarding a generation cap.
+- `enforce_conciseness: false` disables prompt discipline.
+
+With `enabled: false`, the pre-G2-03 generation path is preserved.
+
+## Scope
+
+The budget applies only when the active generation alias is `local_rag` and the
+alias is listed in `apply_to_aliases`.
+
+It does not apply to:
+
+- `local_chat`
+- `local_json`
+- `local_think`
+- embedding calls
+
+G2-03 intentionally keeps JSON mode and default chat behavior unchanged.
+
+## Max Tokens
+
+When enabled and `max_tokens` is set, `LocalRagPipeline` forwards the cap to the
+existing local generation path. `GatewayChatClient` includes `max_tokens` in the
+OpenAI-compatible chat payload only when the value is provided.
+
+When no per-call cap is provided, `LocalGenerator` keeps its existing default
+budget behavior.
+
+## Conciseness Discipline
+
+When `enforce_conciseness` is true, `PromptBuilder` adds one modular instruction
+to the RAG user prompt:
+
+- answer in a concise sentence range;
+- preserve the most important evidence;
+- keep inline citations when context is available;
+- avoid repeating retrieved passages verbatim;
+- state insufficient context clearly.
+
+The base system prompt is not rewritten. Citation format remains
+`[doc_id#chunk_index]`.
+
+## Trace Fields
+
+`RagRunTrace` records safe scalar metadata:
+
+- `answer_length_chars`
+- `answer_token_estimate`
+- `generation_budget_enabled`
+- `generation_budget_applied`
+- `generation_budget_max_tokens`
+- `conciseness_instruction_applied`
+
+The trace never stores answer text, prompt text, chunks, vectors, Qdrant
+payloads, API keys, Authorization headers, raw exceptions, or tracebacks.
+
+`answer_token_estimate` uses the same heuristic token estimator used by Gateway
+routing. It is an estimate, not billing.
+
+## Validation
+
+Offline validation should prove:
+
+- default config is rollback-safe;
+- `max_tokens` is forwarded only for `local_rag` when enabled;
+- `local_chat` and `local_json` are not affected;
+- the conciseness instruction is omitted unless enabled;
+- citation and insufficient-context instructions remain present;
+- trace fields serialize through an allowlist without answer text;
+- `local_rag` keeps `think: false` in the operational LiteLLM config;
+- smoke tests remain opt-in.
+
+Optional live validation can compare uncapped and capped `local_rag` runs with
+the same synthetic question, checking:
+
+- `generation_ms`;
+- `eval_count` if available;
+- `eval_duration_ms` if available;
+- `answer_length_chars`;
+- `answer_token_estimate`;
+- citation presence;
+- `total_ms`.
+
+Do not commit generated reports.

--- a/docs/RAG_GENERATION_BUDGET.md
+++ b/docs/RAG_GENERATION_BUDGET.md
@@ -52,6 +52,21 @@ It does not apply to:
 
 G2-03 intentionally keeps JSON mode and default chat behavior unchanged.
 
+## Thinking Mode Warning
+
+G2-03 validates `generation_budget` for `local_rag` with
+`thinking_mode=false`. The combination of `generation_budget` and
+`thinking_mode=True` is untested.
+
+For Qwen3 thinking runs, reasoning tokens may consume the same
+`max_tokens` / `num_predict` budget before final answer tokens are produced.
+With a cap such as 768 tokens, this can truncate reasoning or leave little to
+no useful final answer.
+
+Do not enable `generation_budget` for thinking aliases until a dedicated
+benchmark validates that path. `local_rag` should remain `think=false` for this
+optimization.
+
 ## Max Tokens
 
 When enabled and `max_tokens` is set, `LocalRagPipeline` forwards the cap to the

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -61,6 +61,18 @@ G2-02 adds optional context budget metadata:
 These fields are counts only. They make the whole-chunk context cap observable
 without logging chunks or prompt text.
 
+G2-03 adds optional generation budget metadata:
+
+- `answer_length_chars`
+- `answer_token_estimate`
+- `generation_budget_enabled`
+- `generation_budget_applied`
+- `generation_budget_max_tokens`
+- `conciseness_instruction_applied`
+
+These fields make answer length discipline observable without serializing the
+answer itself.
+
 Allowed `run_context` labels:
 
 - `cold_start`
@@ -105,6 +117,16 @@ Latency traces must never include:
 - raw model responses
 - raw exceptions, exception messages or tracebacks
 - model weight paths
+
+## Generation Budget Follow-up
+
+G2-03 targets the measured `generation_ms` segment by allowing a config-driven
+`local_rag` max-token cap and optional concise-answer instruction. It does not
+change retrieval, context packing, Qdrant, model aliases, JSON mode, default
+chat behavior, or fallback behavior.
+
+See `docs/RAG_GENERATION_BUDGET.md` for the rollback-safe configuration and
+validation contract.
 
 Serialization uses explicit allowlists and optional scalar fields only.
 

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -53,6 +53,18 @@ G2-02 extends the trace with optional whole-chunk context budget fields:
 These fields are safe scalar counts only. They do not include chunk text,
 prompt text, answers, vectors, Qdrant payloads or secrets.
 
+G2-03 extends the trace with optional `local_rag` generation budget fields:
+
+- `answer_length_chars`
+- `answer_token_estimate`
+- `generation_budget_enabled`
+- `generation_budget_applied`
+- `generation_budget_max_tokens`
+- `conciseness_instruction_applied`
+
+These fields are safe scalar metadata only. They make output length and budget
+application observable without storing answer text.
+
 ## Forbidden Content
 
 The trace must never contain:
@@ -102,4 +114,5 @@ semantics.
 
 - GW-11 adds structured observability lifecycle events separately in
   `RagObservabilityEvent`.
-- GW-12 will add memory/resource baseline work.
+- Future Gateway-2 work may add token-economy recalibration against the final
+  capped prompt, still without logging prompt or answer content.

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -39,7 +39,9 @@ class CitationGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
+        del max_tokens
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         user_content = messages[-1]["content"]

--- a/tests/smoke/test_rag_pipeline_smoke.py
+++ b/tests/smoke/test_rag_pipeline_smoke.py
@@ -64,7 +64,9 @@ class FakeGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
+        del max_tokens
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         return (

--- a/tests/smoke/test_rag_smoke.py
+++ b/tests/smoke/test_rag_smoke.py
@@ -41,7 +41,9 @@ class SmokeGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
+        del max_tokens
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         content = messages[-1]["content"]

--- a/tests/unit/test_embedding_contract_config.py
+++ b/tests/unit/test_embedding_contract_config.py
@@ -143,6 +143,22 @@ class EmbeddingContractConfigTests(unittest.TestCase):
             },
         )
 
+    def test_rag_config_generation_budget_is_rollback_safe_by_default(self) -> None:
+        raw = _load_yaml(RAG_CONFIG)
+        generation_budget = raw["rag"]["generation_budget"]
+
+        self.assertEqual(
+            generation_budget,
+            {
+                "enabled": False,
+                "apply_to_aliases": ["local_rag"],
+                "max_tokens": 768,
+                "enforce_conciseness": False,
+                "target_sentences_min": 3,
+                "target_sentences_max": 6,
+            },
+        )
+
     def test_application_facing_embedding_alias_hides_concrete_model(self) -> None:
         self.assertNotIn("nomic", DEFAULT_LLM_EMBED_MODEL)
         self.assertNotIn("ollama/", DEFAULT_LLM_EMBED_MODEL)

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -204,6 +204,32 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_chat_completion_omits_max_tokens_when_none(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta compacta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            answer = await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                max_tokens=None,
+            )
+
+        self.assertEqual(answer, "Resposta compacta.")
+        self.assertNotIn("max_tokens", seen_payloads[0])
+
     async def test_chat_completion_uses_alias_specific_timeout(self) -> None:
         seen_timeouts: list[dict[str, float]] = []
 

--- a/tests/unit/test_gateway_config.py
+++ b/tests/unit/test_gateway_config.py
@@ -17,6 +17,7 @@ import unittest
 from pathlib import Path
 from typing import Any
 
+import yaml
 from pydantic import ValidationError
 
 from backend.gateway.config import (
@@ -31,6 +32,9 @@ from backend.gateway.errors import GatewayConfigurationError, GatewayModelAliasE
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 _YAML_PATH = Path(__file__).parent.parent.parent / "config" / "litellm_config.yaml"
+_OPERATIONAL_YAML_PATH = (
+    Path(__file__).parent.parent.parent / "infra" / "litellm" / "litellm_config.yaml"
+)
 
 _LOCALHOST = "http://localhost:11434"
 _LOOPBACK = "http://127.0.0.1:11434"
@@ -242,6 +246,32 @@ class TestActualGatewayConfig(unittest.TestCase):
                     alias.model_info.thinking_mode,
                     f"'{name}' must have thinking_mode=false",
                 )
+
+    def test_local_rag_has_think_disabled_in_extra_body(self) -> None:
+        """G2-03 guard: local_rag must keep Ollama thinking disabled."""
+        raw = yaml.safe_load(_OPERATIONAL_YAML_PATH.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise AssertionError("Operational LiteLLM config must be a mapping")
+        model_list = raw.get("model_list")
+        if not isinstance(model_list, list):
+            raise AssertionError("Operational LiteLLM config must include model_list")
+        local_rag = next(
+            item
+            for item in model_list
+            if isinstance(item, dict) and item.get("model_name") == "local_rag"
+        )
+        litellm_params = local_rag.get("litellm_params")
+        if not isinstance(litellm_params, dict):
+            raise AssertionError("local_rag.litellm_params must be a mapping")
+        extra_body = litellm_params.get("extra_body")
+        if not isinstance(extra_body, dict):
+            raise AssertionError("local_rag.litellm_params.extra_body must be a mapping")
+
+        self.assertEqual(
+            extra_body.get("think"),
+            False,
+            "local_rag.litellm_params.extra_body.think must remain false",
+        )
 
     def test_local_embed_maps_to_nomic_embed_text(self) -> None:
         embed = self.config.get_alias("local_embed")

--- a/tests/unit/test_generation_budget.py
+++ b/tests/unit/test_generation_budget.py
@@ -114,6 +114,24 @@ rag:
         self.assertEqual(config.target_sentences_min, 2)
         self.assertEqual(config.target_sentences_max, 5)
 
+    def test_load_generation_budget_config_validates_at_load_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(
+                """
+rag:
+  generation_budget:
+    enabled: true
+    apply_to_aliases:
+      - local_rag
+    max_tokens: 0
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_generation_budget_config(path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_generation_budget.py
+++ b/tests/unit/test_generation_budget.py
@@ -66,9 +66,9 @@ class GenerationBudgetConfigTests(unittest.TestCase):
 
         self.assertTrue(decision.conciseness_instruction_applied)
         assert decision.conciseness_instruction is not None
-        self.assertIn("3-6 sentences", decision.conciseness_instruction)
-        self.assertIn("citations", decision.conciseness_instruction)
-        self.assertIn("context is insufficient", decision.conciseness_instruction)
+        self.assertIn("3 a 6 frases", decision.conciseness_instruction)
+        self.assertIn("citacoes", decision.conciseness_instruction)
+        self.assertIn("contexto for insuficiente", decision.conciseness_instruction)
 
     def test_validation_rejects_invalid_max_tokens(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/unit/test_generation_budget.py
+++ b/tests/unit/test_generation_budget.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.rag.generation_budget import (
+    GenerationBudgetConfig,
+    decide_generation_budget,
+    load_generation_budget_config,
+)
+
+
+class GenerationBudgetConfigTests(unittest.TestCase):
+    def test_default_config_is_rollback_safe(self) -> None:
+        config = GenerationBudgetConfig().validated()
+        decision = decide_generation_budget(config, alias="local_rag")
+
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.apply_to_aliases, ("local_rag",))
+        self.assertEqual(config.max_tokens, 768)
+        self.assertFalse(config.enforce_conciseness)
+        self.assertFalse(decision.enabled)
+        self.assertIsNone(decision.max_tokens)
+        self.assertIsNone(decision.conciseness_instruction)
+
+    def test_enabled_local_rag_applies_token_cap(self) -> None:
+        decision = decide_generation_budget(
+            GenerationBudgetConfig(enabled=True, max_tokens=512),
+            alias="local_rag",
+        )
+
+        self.assertTrue(decision.enabled)
+        self.assertEqual(decision.max_tokens, 512)
+        self.assertTrue(decision.max_tokens_applied)
+
+    def test_enabled_non_rag_alias_is_not_applied(self) -> None:
+        decision = decide_generation_budget(
+            GenerationBudgetConfig(enabled=True, max_tokens=512),
+            alias="local_chat",
+        )
+
+        self.assertFalse(decision.enabled)
+        self.assertIsNone(decision.max_tokens)
+
+    def test_none_max_tokens_disables_forwarded_cap(self) -> None:
+        decision = decide_generation_budget(
+            GenerationBudgetConfig(enabled=True, max_tokens=None),
+            alias="local_rag",
+        )
+
+        self.assertTrue(decision.enabled)
+        self.assertIsNone(decision.max_tokens)
+        self.assertFalse(decision.max_tokens_applied)
+
+    def test_conciseness_instruction_preserves_citation_and_insufficient_context(self) -> None:
+        decision = decide_generation_budget(
+            GenerationBudgetConfig(
+                enabled=True,
+                enforce_conciseness=True,
+                target_sentences_min=3,
+                target_sentences_max=6,
+            ),
+            alias="local_rag",
+        )
+
+        self.assertTrue(decision.conciseness_instruction_applied)
+        assert decision.conciseness_instruction is not None
+        self.assertIn("3-6 sentences", decision.conciseness_instruction)
+        self.assertIn("citations", decision.conciseness_instruction)
+        self.assertIn("context is insufficient", decision.conciseness_instruction)
+
+    def test_validation_rejects_invalid_max_tokens(self) -> None:
+        with self.assertRaises(ValueError):
+            GenerationBudgetConfig(max_tokens=0).validated()
+
+    def test_validation_rejects_invalid_sentence_bounds(self) -> None:
+        with self.assertRaises(ValueError):
+            GenerationBudgetConfig(target_sentences_min=0).validated()
+        with self.assertRaises(ValueError):
+            GenerationBudgetConfig(
+                target_sentences_min=7,
+                target_sentences_max=6,
+            ).validated()
+
+    def test_validation_rejects_non_local_rag_alias(self) -> None:
+        with self.assertRaises(ValueError):
+            GenerationBudgetConfig(apply_to_aliases=("local_chat",)).validated()
+
+    def test_load_generation_budget_config_reads_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(
+                """
+rag:
+  generation_budget:
+    enabled: true
+    apply_to_aliases:
+      - local_rag
+    max_tokens: 640
+    enforce_conciseness: true
+    target_sentences_min: 2
+    target_sentences_max: 5
+""",
+                encoding="utf-8",
+            )
+
+            config = load_generation_budget_config(path)
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.apply_to_aliases, ("local_rag",))
+        self.assertEqual(config.max_tokens, 640)
+        self.assertTrue(config.enforce_conciseness)
+        self.assertEqual(config.target_sentences_min, 2)
+        self.assertEqual(config.target_sentences_max, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -46,6 +46,34 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(seen_payloads[0]["temperature"], 0.2)
         self.assertEqual(seen_payloads[0]["max_tokens"], 128)
 
+    async def test_chat_call_max_tokens_overrides_generator_default(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta curta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            generator = LocalGenerator(
+                client=client,
+                api_key="dev-key",
+                model="local_rag",
+                max_tokens=2048,
+            )
+            answer = await generator.chat(
+                [{"role": "user", "content": "pergunta"}],
+                max_tokens=768,
+            )
+
+        self.assertEqual(answer, "Resposta curta.")
+        self.assertEqual(seen_payloads[0]["max_tokens"], 768)
+
     async def test_chat_strips_thinking_blocks_when_disabled(self) -> None:
         async with httpx.AsyncClient(
             base_url=DEFAULT_LLM_BASE_URL,

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -67,6 +67,34 @@ class PromptBuilderTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             builder.build("  ", [chunk()])
 
+    def test_conciseness_instruction_is_omitted_when_absent(self) -> None:
+        builder = PromptBuilder()
+
+        messages = builder.build("Qual o impacto da Selic?", [chunk()])
+
+        self.assertNotIn("Answer concisely", messages[1]["content"])
+
+    def test_conciseness_instruction_is_added_when_provided(self) -> None:
+        builder = PromptBuilder()
+        instruction = (
+            "Answer concisely, usually in 3-6 sentences. Preserve the most "
+            "important evidence and include inline citations when context is "
+            "available. If the context is insufficient, say so clearly."
+        )
+
+        messages = builder.build(
+            "Qual o impacto da Selic?",
+            [chunk()],
+            conciseness_instruction=instruction,
+        )
+
+        user_content = messages[1]["content"]
+        self.assertIn("Answer concisely", user_content)
+        self.assertIn("include inline citations", user_content)
+        self.assertIn("context is insufficient", user_content)
+        self.assertIn("[doc-a#0]", user_content)
+        self.assertEqual(builder.system_prompt, PromptBuilder().system_prompt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_prompt_builder.py
+++ b/tests/unit/test_prompt_builder.py
@@ -72,14 +72,15 @@ class PromptBuilderTests(unittest.TestCase):
 
         messages = builder.build("Qual o impacto da Selic?", [chunk()])
 
-        self.assertNotIn("Answer concisely", messages[1]["content"])
+        self.assertNotIn("Responda de forma concisa", messages[1]["content"])
 
     def test_conciseness_instruction_is_added_when_provided(self) -> None:
         builder = PromptBuilder()
         instruction = (
-            "Answer concisely, usually in 3-6 sentences. Preserve the most "
-            "important evidence and include inline citations when context is "
-            "available. If the context is insufficient, say so clearly."
+            "Responda de forma concisa, normalmente em 3 a 6 frases. Preserve "
+            "as evidencias mais relevantes e inclua citacoes quando o contexto "
+            "estiver disponivel. Se o contexto for insuficiente, diga isso "
+            "claramente."
         )
 
         messages = builder.build(
@@ -89,9 +90,9 @@ class PromptBuilderTests(unittest.TestCase):
         )
 
         user_content = messages[1]["content"]
-        self.assertIn("Answer concisely", user_content)
-        self.assertIn("include inline citations", user_content)
-        self.assertIn("context is insufficient", user_content)
+        self.assertIn("Responda de forma concisa", user_content)
+        self.assertIn("inclua citacoes", user_content)
+        self.assertIn("contexto for insuficiente", user_content)
         self.assertIn("[doc-a#0]", user_content)
         self.assertEqual(builder.system_prompt, PromptBuilder().system_prompt)
 

--- a/tests/unit/test_rag_pipeline_observability.py
+++ b/tests/unit/test_rag_pipeline_observability.py
@@ -48,7 +48,9 @@ class FakeGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
+        del max_tokens
         return "Resposta sintetica com citacao [obs_doc#0]."
 
 

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -298,6 +298,24 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["run_context"], "warm_model")
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
 
+    def test_legacy_latency_fields_mirror_segment_fields_for_compatibility(self) -> None:
+        # Intentional backward compatibility, not accidental duplication:
+        # new consumers should prefer prompt_build_ms/generation_ms/total_ms.
+        trace = _trace(
+            prompt_latency_ms=0.5,
+            generation_latency_ms=31.0,
+            total_latency_ms=35.0,
+            prompt_build_ms=0.5,
+            generation_ms=31.0,
+            total_ms=35.0,
+        )
+
+        data = trace.to_log_dict()
+
+        self.assertEqual(data["prompt_latency_ms"], data["prompt_build_ms"])
+        self.assertEqual(data["generation_latency_ms"], data["generation_ms"])
+        self.assertEqual(data["total_latency_ms"], data["total_ms"])
+
     def test_invalid_generation_budget_max_tokens_raises(self) -> None:
         with self.assertRaises(ValueError):
             _trace(generation_budget_max_tokens=0)
@@ -652,8 +670,8 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
             logger.remove(sink_id)
 
         self.assertEqual(generator.max_tokens_seen, 768)
-        self.assertIn("Answer concisely", result.messages[1]["content"])
-        self.assertIn("include inline citations", result.messages[1]["content"])
+        self.assertIn("Responda de forma concisa", result.messages[1]["content"])
+        self.assertIn("inclua citacoes", result.messages[1]["content"])
         self.assertEqual(len(traces), 1)
         trace = traces[0]
         self.assertEqual(trace["generation_budget_enabled"], True)
@@ -678,7 +696,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         result = await pipeline.ask("Pergunta sintetica?")
 
         self.assertIsNone(generator.max_tokens_seen)
-        self.assertNotIn("Answer concisely", result.messages[1]["content"])
+        self.assertNotIn("Responda de forma concisa", result.messages[1]["content"])
 
     async def test_generation_budget_does_not_apply_to_non_rag_alias(self) -> None:
         generator = CapturingGenerator("local_chat")
@@ -697,7 +715,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         result = await pipeline.ask("Pergunta sintetica?")
 
         self.assertIsNone(generator.max_tokens_seen)
-        self.assertNotIn("Answer concisely", result.messages[1]["content"])
+        self.assertNotIn("Responda de forma concisa", result.messages[1]["content"])
 
     def test_load_rag_tracing_config_reads_yaml_defaults(self) -> None:
         config = load_rag_tracing_config()

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from backend.rag.collection_guard import EmbeddingDimensionMismatchError
 from backend.rag.context_packer import ContextBudgetResult, RetrievedChunk
+from backend.rag.generation_budget import GenerationBudgetConfig
 from backend.rag.pipeline import LocalRagPipeline
 from backend.rag.prompt_builder import PromptBuilder
 from backend.rag.run_trace import (
@@ -132,8 +133,30 @@ class FakeGenerator:
         messages: Sequence[dict[str, str]],
         temperature: float | None = None,
         thinking_mode: bool = False,
+        max_tokens: int | None = None,
     ) -> str:
+        del messages, temperature, thinking_mode, max_tokens
         return "Resposta sintetica segura com citacao [trace_doc#0]."
+
+
+class CapturingGenerator:
+    model: str
+    max_tokens_seen: int | None
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        self.max_tokens_seen = None
+
+    async def chat(
+        self,
+        messages: Sequence[dict[str, str]],
+        temperature: float | None = None,
+        thinking_mode: bool = False,
+        max_tokens: int | None = None,
+    ) -> str:
+        del messages, temperature, thinking_mode
+        self.max_tokens_seen = max_tokens
+        return "Resposta sintetica com citacao [trace_doc#0]."
 
 
 def _trace(**overrides: Any) -> RagRunTrace:
@@ -216,6 +239,12 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(trace.context_budget_applied)
         self.assertIsNone(trace.context_chunks_used)
         self.assertIsNone(trace.context_chunks_dropped)
+        self.assertIsNone(trace.answer_length_chars)
+        self.assertIsNone(trace.answer_token_estimate)
+        self.assertIsNone(trace.generation_budget_enabled)
+        self.assertIsNone(trace.generation_budget_applied)
+        self.assertIsNone(trace.generation_budget_max_tokens)
+        self.assertIsNone(trace.conciseness_instruction_applied)
         self.assertFalse(trace.ollama_metrics_available)
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
 
@@ -232,6 +261,12 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
             context_chunks_dropped=2,
             context_budget_max_chunks=3,
             context_estimated_tokens_used=120,
+            answer_length_chars=48,
+            answer_token_estimate=12,
+            generation_budget_enabled=True,
+            generation_budget_applied=True,
+            generation_budget_max_tokens=768,
+            conciseness_instruction_applied=True,
             prompt_build_ms=0.5,
             generation_ms=31.0,
             total_ms=35.0,
@@ -251,11 +286,21 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["context_chunks_dropped"], 2)
         self.assertEqual(data["context_budget_max_chunks"], 3)
         self.assertEqual(data["context_estimated_tokens_used"], 120)
+        self.assertEqual(data["answer_length_chars"], 48)
+        self.assertEqual(data["answer_token_estimate"], 12)
+        self.assertEqual(data["generation_budget_enabled"], True)
+        self.assertEqual(data["generation_budget_applied"], True)
+        self.assertEqual(data["generation_budget_max_tokens"], 768)
+        self.assertEqual(data["conciseness_instruction_applied"], True)
         self.assertEqual(data["prompt_build_ms"], 0.5)
         self.assertEqual(data["generation_ms"], 31.0)
         self.assertEqual(data["total_ms"], 35.0)
         self.assertEqual(data["run_context"], "warm_model")
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
+
+    def test_invalid_generation_budget_max_tokens_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _trace(generation_budget_max_tokens=0)
 
     def test_total_ms_is_direct_field_not_sum_assumption(self) -> None:
         trace = _trace(
@@ -571,6 +616,88 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(trace["context_budget_max_chunks"], 3)
         self.assertEqual(trace["context_estimated_tokens_used"], 24)
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
+
+    async def test_local_rag_generation_budget_forwards_max_tokens_and_trace_metadata(self) -> None:
+        traces: list[dict[str, object]] = []
+        generator = CapturingGenerator("local_rag")
+
+        def sink(message: Any) -> None:
+            trace = message.record["extra"].get("trace")
+            if isinstance(trace, dict):
+                traces.append(trace)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            pipeline = LocalRagPipeline(
+                retriever=FakeRetriever(),
+                generator=generator,
+                prompt_builder=PromptBuilder(),
+                tracing_config=RagTracingConfig(
+                    enabled=True,
+                    log_level="INFO",
+                    collection_name="configured_collection",
+                    embedding_backend="gateway_litellm_current",
+                    embedding_model="nomic-embed-text",
+                    embedding_alias="quimera_embed",
+                    embedding_dimensions=768,
+                ).validated(),
+                generation_budget_config=GenerationBudgetConfig(
+                    enabled=True,
+                    max_tokens=768,
+                    enforce_conciseness=True,
+                ),
+            )
+            result = await pipeline.ask("Pergunta sintetica?")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(generator.max_tokens_seen, 768)
+        self.assertIn("Answer concisely", result.messages[1]["content"])
+        self.assertIn("include inline citations", result.messages[1]["content"])
+        self.assertEqual(len(traces), 1)
+        trace = traces[0]
+        self.assertEqual(trace["generation_budget_enabled"], True)
+        self.assertEqual(trace["generation_budget_applied"], True)
+        self.assertEqual(trace["generation_budget_max_tokens"], 768)
+        self.assertEqual(trace["conciseness_instruction_applied"], True)
+        self.assertEqual(trace["answer_length_chars"], len(result.answer))
+        self.assertIsInstance(trace["answer_token_estimate"], int)
+        self.assertNotIn(result.answer, str(trace))
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
+
+    async def test_generation_budget_disabled_does_not_forward_max_tokens(self) -> None:
+        generator = CapturingGenerator("local_rag")
+        pipeline = LocalRagPipeline(
+            retriever=FakeRetriever(),
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            tracing_config=RagTracingConfig(enabled=False).validated(),
+            generation_budget_config=GenerationBudgetConfig(enabled=False),
+        )
+
+        result = await pipeline.ask("Pergunta sintetica?")
+
+        self.assertIsNone(generator.max_tokens_seen)
+        self.assertNotIn("Answer concisely", result.messages[1]["content"])
+
+    async def test_generation_budget_does_not_apply_to_non_rag_alias(self) -> None:
+        generator = CapturingGenerator("local_chat")
+        pipeline = LocalRagPipeline(
+            retriever=FakeRetriever(),
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            tracing_config=RagTracingConfig(enabled=False).validated(),
+            generation_budget_config=GenerationBudgetConfig(
+                enabled=True,
+                max_tokens=768,
+                enforce_conciseness=True,
+            ),
+        )
+
+        result = await pipeline.ask("Pergunta sintetica?")
+
+        self.assertIsNone(generator.max_tokens_seen)
+        self.assertNotIn("Answer concisely", result.messages[1]["content"])
 
     def test_load_rag_tracing_config_reads_yaml_defaults(self) -> None:
         config = load_rag_tracing_config()


### PR DESCRIPTION
## Summary

G2-PR03 constrains `local_rag` output length via a configurable generation budget cap and optional PT-BR conciseness instruction.

This is a rollback-safe PR. Default: `enabled: false`. No model change, no retrieval change, no Qdrant mutation, no remote providers.

## Scientific hypothesis

If `local_rag` latency is driven by excessive output tokens, then limiting max_tokens and reinforcing concise answers will reduce `generation_ms` by 20–40% without meaningful loss of answer utility.

## What changed

- Added `GenerationBudgetConfig` + `GenerationBudgetDecision` + `decide_generation_budget()`
- Added `_chat_with_generation_budget()` passing max_tokens through `GeneratorProtocol`
- Added PT-BR conciseness instruction injected into `PromptBuilder` when `enforce_conciseness=True`
- Extended `RagRunTrace` with 6 safe generation budget fields
- Updated observability contract allowlist
- Added `rag.generation_budget` section to `rag_config.yaml` (enabled=false default)
- RC-1: aligned `GeneratorProtocol.chat()` with max_tokens budget (removed cast/getattr bypass)
- RC-2: translated conciseness instruction to PT-BR for consistency with PromptBuilder
- RC-3: removed redundant hot-path validation in `decide_generation_budget()`

## What did not change

- No retrieval top_k change
- No Qdrant mutation, no reindex
- No model/alias change
- No timeout change
- No fallback behavior change
- No remote providers
- No external runner schema change
- No JSON mode change

## Rollback

```yaml
rag:
  generation_budget:
    enabled: false
```

## Validation

```bash
uv run pytest tests/unit/ -q   # 375 passed, 7 skipped
uv run mypy --strict .          # 0 errors
uv run pyright                  # 0 errors
```