### PR TITLE
feat(g2-pr04): cold/warm latency separation + run_type_verified safety check

### DIFF
--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -82,6 +82,10 @@ Allowed `run_context` labels:
 Normal runtime may leave `run_context` unset. Baseline runs should label
 cold/warm/degraded explicitly so reports are distinguishable without rerunning.
 
+G2-04 makes the report-level label mandatory as `run_type`. New baseline
+records without `run_type` are invalid. `run_context` remains the pipeline trace
+label, while `run_type` is the benchmark report contract.
+
 ## Ollama Metrics
 
 `RagRunTrace` can store native Ollama metric fields only if they are already
@@ -102,6 +106,20 @@ metrics are not available in normal `local_rag` traces. G2-01 records
 
 Do not bypass LiteLLM, call Ollama directly, duplicate generation calls, or log
 prompt/answer text to recover these metrics.
+
+G2-04 preserves native Ollama metrics in baseline reports when they are already
+available in `RagRunTrace`, including `ollama_load_duration_ms`,
+`ollama_prompt_eval_duration_ms`, `ollama_eval_duration_ms`, and
+`ollama_eval_count`. If they are unavailable, reports use safe enum-style
+reasons only:
+
+- `not_forwarded_by_gateway`
+- `not_present_in_response`
+- `not_applicable_degraded`
+- `unknown`
+
+`model_load_observed` is derived from `ollama_load_duration_ms > 500.0`. If
+`ollama_load_duration_ms` is unavailable, `model_load_observed` is `null`.
 
 ## Safety
 
@@ -129,6 +147,53 @@ See `docs/RAG_GENERATION_BUDGET.md` for the rollback-safe configuration and
 validation contract.
 
 Serialization uses explicit allowlists and optional scalar fields only.
+
+## G2-04 Cold/Warm/Degraded Separation
+
+G2-04 is measurement-only. It does not tune `keep_alive`, preload models, unload
+models, change model config, change aliases, mutate Qdrant, alter retrieval, or
+change fallback behavior.
+
+The baseline command remains opt-in:
+
+```bash
+RUN_RAG_LATENCY_BASELINE=1 uv run python scripts/run_rag_latency_baseline.py \
+  --output-dir /tmp/openclaw_g2_cold_warm
+```
+
+Generated reports include:
+
+- one record per `run_type`;
+- `alias`;
+- safe model name;
+- hardware snapshot;
+- Ollama metric availability;
+- model residency check result from read-only Ollama `/api/ps`;
+- grouped latency aggregates by alias and `run_type`.
+
+The `/api/ps` residency check is best-effort and local-only. It uses
+`OLLAMA_API_BASE` when present, refuses non-local URLs, and records `null` if
+the check is unavailable. It does not fail the whole benchmark just because
+`/api/ps` is missing.
+
+Cold start is operational and best-effort unless the operator ensures the model
+is not already resident. Warm-model results are meaningful only when model
+residency is observed or `ollama_load_duration_ms` indicates no load cost.
+
+`cold_start`, `warm_model`, and `degraded_qdrant` numbers must never be averaged
+into one global latency number. Reports group `mean_total_ms`, `p50_total_ms`,
+and `p95_total_ms` by alias and `run_type`.
+
+Existing reports can be validated without live services:
+
+```bash
+uv run python scripts/run_rag_latency_baseline.py \
+  --verify-only /tmp/openclaw_g2_cold_warm/<report>.json
+```
+
+`degraded_qdrant` is isolated from successful `local_rag` runs. It exists to
+verify failure/degradation measurement shape, not to represent normal RAG
+quality or latency.
 
 ## Baseline Runs
 

--- a/scripts/run_rag_latency_baseline.py
+++ b/scripts/run_rag_latency_baseline.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
-"""RAG per-segment latency baseline — 3-run collector.
+"""RAG per-segment latency baseline — cold/warm/degraded collector.
 
-Produces three labelled trace JSONs:
+Produces a structured report plus three compatibility trace JSONs:
   cold_start     — first pipeline call after service startup
   warm_model     — immediate repeat call (model already loaded)
   degraded_qdrant — retrieval forced to fail via fake store
 
 Usage (opt-in only):
   RUN_RAG_LATENCY_BASELINE=1 uv run python scripts/run_rag_latency_baseline.py
+  uv run python scripts/run_rag_latency_baseline.py --verify-only report.json
 
 Output files are written to --output-dir (default: reports/g2_latency_baseline/).
 Files are gitignored. No prompt, answer, chunks, vectors or secrets are written.
@@ -19,13 +20,18 @@ import asyncio
 import hashlib
 import json
 import os
+import platform
 import sys
 import time
+from datetime import UTC, datetime
 from dataclasses import dataclass
+from uuid import uuid4
 from pathlib import Path
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Literal, cast
 
+import httpx
+import yaml
 from loguru import logger
 
 from backend.rag.pipeline import LocalRagPipeline
@@ -45,6 +51,29 @@ _QUESTION_HASH_8 = hashlib.sha256(
 ).hexdigest()[:8]
 
 DEFAULT_OUTPUT_DIR = Path("reports/g2_latency_baseline")
+DEFAULT_LITELLM_CONFIG_PATH = Path("config/litellm_config.yaml")
+DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
+REPORT_SCHEMA_VERSION = "g2_pr04_rag_latency_baseline_v1"
+LOAD_DURATION_THRESHOLD_MS = 500.0
+LOCAL_URL_PREFIXES = ("http://127.0.0.1:", "http://localhost:")
+RUN_TYPES = frozenset({"cold_start", "warm_model", "degraded_qdrant"})
+OLLAMA_METRICS_UNAVAILABLE_REASONS = frozenset(
+    {
+        "not_forwarded_by_gateway",
+        "not_present_in_response",
+        "not_applicable_degraded",
+        "unknown",
+    }
+)
+RESIDENT_CHECK_UNAVAILABLE_REASONS = frozenset(
+    {
+        "non_local_url",
+        "timeout",
+        "connection",
+        "invalid_response",
+        "unknown",
+    }
+)
 
 SEGMENT_KEYS = (
     "embedding_ms",
@@ -60,35 +89,89 @@ FORBIDDEN_KEYS = frozenset(
         "vectors", "embeddings", "payload", "qdrant_payload",
         "api_key", "authorization", "headers", "secret", "password",
         "raw_response", "raw_exception", "exception_message", "traceback",
-        "raw_user_input",
+        "raw_user_input", "model_weights_path", "weights_path",
     }
 )
+
+OllamaMetricsUnavailableReason = Literal[
+    "not_forwarded_by_gateway",
+    "not_present_in_response",
+    "not_applicable_degraded",
+    "unknown",
+]
+ResidentCheckUnavailableReason = Literal[
+    "non_local_url",
+    "timeout",
+    "connection",
+    "invalid_response",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ModelResidencyCheck:
+    model_was_resident_before_run: bool | None
+    resident_check_unavailable_reason: ResidentCheckUnavailableReason | None
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "model_was_resident_before_run": self.model_was_resident_before_run,
+            "resident_check_unavailable_reason": (
+                self.resident_check_unavailable_reason
+            ),
+        }
 
 
 @dataclass(frozen=True)
 class BaselineRunResult:
-    run_context: RagRunContext
+    run_type: RagRunContext
+    alias: str
+    model: str
     question_hash_8: str
+    question_length_chars: int
     segment_ms: dict[str, float | None]
     ollama_metrics_available: bool
+    ollama_metrics_unavailable_reason: OllamaMetricsUnavailableReason | None
+    ollama_total_duration_ms: float | None
+    ollama_load_duration_ms: float | None
     ollama_eval_count: int | None
     ollama_eval_duration_ms: float | None
     ollama_prompt_eval_count: int | None
     ollama_prompt_eval_duration_ms: float | None
+    model_load_observed: bool | None
+    run_type_verified: bool | None
+    model_was_resident_before_run: bool | None
+    resident_check_unavailable_reason: ResidentCheckUnavailableReason | None
+    tokens_per_second: float | None
     wall_ms: float
     ok: bool
     error_category: str | None
 
     def to_json_dict(self) -> dict[str, object]:
         return {
-            "run_context": self.run_context,
+            "run_type": self.run_type,
+            "alias": self.alias,
+            "model": self.model,
             "question_hash_8": self.question_hash_8,
+            "question_length_chars": self.question_length_chars,
             "segments": {k: v for k, v in self.segment_ms.items() if v is not None},
             "ollama_metrics_available": self.ollama_metrics_available,
+            "ollama_metrics_unavailable_reason": (
+                self.ollama_metrics_unavailable_reason
+            ),
+            "ollama_total_duration_ms": self.ollama_total_duration_ms,
+            "ollama_load_duration_ms": self.ollama_load_duration_ms,
             "ollama_eval_count": self.ollama_eval_count,
             "ollama_eval_duration_ms": self.ollama_eval_duration_ms,
             "ollama_prompt_eval_count": self.ollama_prompt_eval_count,
             "ollama_prompt_eval_duration_ms": self.ollama_prompt_eval_duration_ms,
+            "model_load_observed": self.model_load_observed,
+            "run_type_verified": self.run_type_verified,
+            "model_was_resident_before_run": self.model_was_resident_before_run,
+            "resident_check_unavailable_reason": (
+                self.resident_check_unavailable_reason
+            ),
+            "tokens_per_second": self.tokens_per_second,
             "wall_ms": self.wall_ms,
             "ok": self.ok,
             "error_category": self.error_category,
@@ -161,7 +244,11 @@ def _capture_trace(pipeline: LocalRagPipeline) -> tuple[list[dict[str, object]],
 
 async def _run_once(
     pipeline: LocalRagPipeline,
-    run_context: RagRunContext,
+    run_type: RagRunContext,
+    *,
+    alias: str,
+    model: str,
+    residency_check: ModelResidencyCheck,
 ) -> BaselineRunResult:
     captured: list[dict[str, object]] = []
     sink_id: int | None = None
@@ -178,7 +265,7 @@ async def _run_once(
     error_category: str | None = None
     ok = False
     try:
-        await pipeline.ask(_SYNTHETIC_QUESTION, run_context=run_context)
+        await pipeline.ask(_SYNTHETIC_QUESTION, run_context=run_type)
         ok = True
     except Exception as exc:
         error_category = type(exc).__name__
@@ -192,17 +279,47 @@ async def _run_once(
     segments: dict[str, float | None] = {
         key: _float_or_none(trace.get(key)) for key in SEGMENT_KEYS
     }
+    ollama_metrics_available = bool(trace.get("ollama_metrics_available", False))
+    ollama_load_duration_ms = _float_or_none(trace.get("ollama_load_duration_ms"))
+    ollama_eval_count = _int_or_none(trace.get("ollama_eval_count"))
+    ollama_eval_duration_ms = _float_or_none(trace.get("ollama_eval_duration_ms"))
 
     return BaselineRunResult(
-        run_context=run_context,
+        run_type=run_type,
+        alias=alias,
+        model=model,
         question_hash_8=_QUESTION_HASH_8,
+        question_length_chars=len(_SYNTHETIC_QUESTION),
         segment_ms=segments,
-        ollama_metrics_available=bool(trace.get("ollama_metrics_available", False)),
-        ollama_eval_count=_int_or_none(trace.get("ollama_eval_count")),
-        ollama_eval_duration_ms=_float_or_none(trace.get("ollama_eval_duration_ms")),
+        ollama_metrics_available=ollama_metrics_available,
+        ollama_metrics_unavailable_reason=_ollama_metrics_unavailable_reason(
+            run_type=run_type,
+            trace_present=bool(trace),
+            metrics_available=ollama_metrics_available,
+        ),
+        ollama_total_duration_ms=_float_or_none(trace.get("ollama_total_duration_ms")),
+        ollama_load_duration_ms=ollama_load_duration_ms,
+        ollama_eval_count=ollama_eval_count,
+        ollama_eval_duration_ms=ollama_eval_duration_ms,
         ollama_prompt_eval_count=_int_or_none(trace.get("ollama_prompt_eval_count")),
         ollama_prompt_eval_duration_ms=_float_or_none(
             trace.get("ollama_prompt_eval_duration_ms")
+        ),
+        model_load_observed=_model_load_observed(ollama_load_duration_ms),
+        run_type_verified=_run_type_verified(
+            run_type=run_type,
+            model_load_observed=_model_load_observed(ollama_load_duration_ms),
+            error_category=error_category,
+        ),
+        model_was_resident_before_run=(
+            residency_check.model_was_resident_before_run
+        ),
+        resident_check_unavailable_reason=(
+            residency_check.resident_check_unavailable_reason
+        ),
+        tokens_per_second=_tokens_per_second(
+            eval_count=ollama_eval_count,
+            eval_duration_ms=ollama_eval_duration_ms,
         ),
         wall_ms=wall_ms,
         ok=ok,
@@ -220,6 +337,177 @@ def _int_or_none(value: object) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value
+
+
+def _validate_run_type(value: str) -> RagRunContext:
+    if value not in RUN_TYPES:
+        raise ValueError(f"run_type must be one of {sorted(RUN_TYPES)}")
+    return cast(RagRunContext, value)
+
+
+def _ollama_metrics_unavailable_reason(
+    *,
+    run_type: RagRunContext,
+    trace_present: bool,
+    metrics_available: bool,
+) -> OllamaMetricsUnavailableReason | None:
+    if metrics_available:
+        return None
+    if run_type == "degraded_qdrant":
+        return "not_applicable_degraded"
+    if trace_present:
+        return "not_forwarded_by_gateway"
+    return "not_present_in_response"
+
+
+def _model_load_observed(load_duration_ms: float | None) -> bool | None:
+    if load_duration_ms is None:
+        return None
+    return load_duration_ms > LOAD_DURATION_THRESHOLD_MS
+
+
+def _run_type_verified(
+    *,
+    run_type: RagRunContext,
+    model_load_observed: bool | None,
+    error_category: str | None,
+) -> bool | None:
+    if run_type == "degraded_qdrant":
+        return error_category is not None
+    if model_load_observed is None:
+        return None
+    if run_type == "cold_start":
+        return model_load_observed is True
+    if run_type == "warm_model":
+        return model_load_observed is False
+    return None
+
+
+def _tokens_per_second(
+    *,
+    eval_count: int | None,
+    eval_duration_ms: float | None,
+) -> float | None:
+    if eval_count is None or eval_duration_ms is None or eval_duration_ms <= 0:
+        return None
+    return float(eval_count) / (eval_duration_ms / 1000.0)
+
+
+def _is_local_url(url: str) -> bool:
+    return any(url.startswith(prefix) for prefix in LOCAL_URL_PREFIXES)
+
+
+def _ollama_model_name(litellm_model: str) -> str:
+    if "/" in litellm_model:
+        return litellm_model.rsplit("/", 1)[-1]
+    return litellm_model
+
+
+def _model_for_alias(
+    alias: str = "local_rag",
+    config_path: Path = DEFAULT_LITELLM_CONFIG_PATH,
+) -> str:
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except OSError:
+        return alias
+    if not isinstance(raw, Mapping):
+        return alias
+    model_list = raw.get("model_list")
+    if not isinstance(model_list, Sequence) or isinstance(model_list, (str, bytes)):
+        return alias
+    for item in model_list:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("model_name") != alias:
+            continue
+        params = item.get("litellm_params")
+        if not isinstance(params, Mapping):
+            return alias
+        model = params.get("model")
+        if isinstance(model, str) and model.strip():
+            return _ollama_model_name(model.strip())
+    return alias
+
+
+def _parse_ollama_ps_residency(
+    payload: object,
+    *,
+    model: str,
+) -> bool | None:
+    if not isinstance(payload, Mapping):
+        return None
+    models = payload.get("models")
+    if not isinstance(models, Sequence) or isinstance(models, (str, bytes)):
+        return None
+    candidates = {model, _ollama_model_name(model)}
+    for item in models:
+        if not isinstance(item, Mapping):
+            continue
+        for key in ("name", "model"):
+            value = item.get(key)
+            if isinstance(value, str) and value in candidates:
+                return True
+    return False
+
+
+async def check_ollama_model_residency(
+    *,
+    model: str,
+    base_url: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> ModelResidencyCheck:
+    """Check Ollama ``/api/ps`` without logging raw responses or local paths."""
+    effective_base_url = (base_url or os.environ.get(
+        "OLLAMA_API_BASE",
+        DEFAULT_OLLAMA_API_BASE,
+    )).rstrip("/")
+    if not _is_local_url(effective_base_url):
+        return ModelResidencyCheck(
+            model_was_resident_before_run=None,
+            resident_check_unavailable_reason="non_local_url",
+        )
+    owns_client = client is None
+    active_client = client or httpx.AsyncClient(
+        base_url=effective_base_url,
+        timeout=httpx.Timeout(5.0),
+    )
+    try:
+        response = await active_client.get("/api/ps")
+        response.raise_for_status()
+        resident = _parse_ollama_ps_residency(response.json(), model=model)
+        if resident is None:
+            return ModelResidencyCheck(
+                model_was_resident_before_run=None,
+                resident_check_unavailable_reason="invalid_response",
+            )
+        return ModelResidencyCheck(
+            model_was_resident_before_run=resident,
+            resident_check_unavailable_reason=None,
+        )
+    except httpx.TimeoutException:
+        return ModelResidencyCheck(
+            model_was_resident_before_run=None,
+            resident_check_unavailable_reason="timeout",
+        )
+    except httpx.ConnectError:
+        return ModelResidencyCheck(
+            model_was_resident_before_run=None,
+            resident_check_unavailable_reason="connection",
+        )
+    except httpx.HTTPError:
+        return ModelResidencyCheck(
+            model_was_resident_before_run=None,
+            resident_check_unavailable_reason="unknown",
+        )
+    except ValueError:
+        return ModelResidencyCheck(
+            model_was_resident_before_run=None,
+            resident_check_unavailable_reason="invalid_response",
+        )
+    finally:
+        if owns_client:
+            await active_client.aclose()
 
 
 def _assert_no_forbidden_keys(data: dict[str, object]) -> None:
@@ -243,12 +531,175 @@ def _flatten_keys(obj: object) -> list[str]:
 
 def _write_result(output_dir: Path, result: BaselineRunResult) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
-    fname = f"baseline_{result.run_context}_{result.question_hash_8}.json"
+    fname = f"baseline_{result.run_type}_{result.question_hash_8}.json"
     path = output_dir / fname
     data = result.to_json_dict()
     _assert_no_forbidden_keys(data)
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
     return path
+
+
+def _hardware_snapshot() -> dict[str, object]:
+    return {
+        "platform_system": platform.system(),
+        "platform_machine": platform.machine(),
+        "python_version": platform.python_version(),
+        "processor": platform.processor() or None,
+        "ram_total_bytes": _ram_total_bytes(),
+    }
+
+
+def _ram_total_bytes() -> int | None:
+    if not hasattr(os, "sysconf"):
+        return None
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        page_count = os.sysconf("SC_PHYS_PAGES")
+    except (OSError, ValueError):
+        return None
+    if not isinstance(page_size, int) or not isinstance(page_count, int):
+        return None
+    if page_size <= 0 or page_count <= 0:
+        return None
+    return page_size * page_count
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = rank - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _mean(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _safe_float_values(values: Sequence[float | None]) -> list[float]:
+    return [value for value in values if value is not None]
+
+
+def _summary_by_alias_and_run_type(
+    results: Sequence[BaselineRunResult],
+) -> dict[str, dict[str, dict[str, object]]]:
+    grouped: dict[tuple[str, str], list[BaselineRunResult]] = {}
+    for result in results:
+        grouped.setdefault((result.alias, result.run_type), []).append(result)
+
+    summary: dict[str, dict[str, dict[str, object]]] = {}
+    for (alias, run_type), items in sorted(grouped.items()):
+        total_values = _safe_float_values(
+            [item.segment_ms.get("total_ms") for item in items]
+        )
+        generation_values = _safe_float_values(
+            [item.segment_ms.get("generation_ms") for item in items]
+        )
+        tps_values = _safe_float_values([item.tokens_per_second for item in items])
+        summary.setdefault(alias, {})[run_type] = {
+            "count": len(items),
+            "ok_count": sum(1 for item in items if item.ok),
+            "mean_total_ms": _mean(total_values),
+            "p50_total_ms": _percentile(total_values, 0.50),
+            "p95_total_ms": _percentile(total_values, 0.95),
+            "mean_generation_ms": _mean(generation_values),
+            "mean_tokens_per_second": _mean(tps_values),
+            "model_load_observed_count": sum(
+                1 for item in items if item.model_load_observed is True
+            ),
+            "run_type_verified_count": sum(
+                1 for item in items if item.run_type_verified is True
+            ),
+        }
+    return summary
+
+
+def build_report(results: Sequence[BaselineRunResult]) -> dict[str, object]:
+    records = [result.to_json_dict() for result in results]
+    report: dict[str, object] = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "run_id": uuid4().hex,
+        "timestamp_utc": _utc_now_iso(),
+        "hardware_snapshot": _hardware_snapshot(),
+        "records": records,
+        "summary_by_alias_and_run_type": _summary_by_alias_and_run_type(results),
+        "record_count": len(records),
+        "run_types": sorted({result.run_type for result in results}),
+        "aliases": sorted({result.alias for result in results}),
+    }
+    validate_report(report)
+    return report
+
+
+def _write_report(output_dir: Path, results: Sequence[BaselineRunResult]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = build_report(results)
+    run_id = str(report["run_id"])
+    path = output_dir / f"rag_latency_baseline_report_{run_id}.json"
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def validate_report(data: Mapping[str, object]) -> None:
+    """Validate a G2-PR04 baseline report without requiring live services."""
+    _assert_no_forbidden_keys(dict(data))
+    if "mean_total_ms" in data:
+        raise ValueError("Report must not contain a mixed top-level mean_total_ms")
+    if data.get("report_schema_version") != REPORT_SCHEMA_VERSION:
+        raise ValueError("Unsupported baseline report schema version")
+    records = data.get("records")
+    if not isinstance(records, list) or not records:
+        raise ValueError("Baseline report must contain records")
+    for item in records:
+        if not isinstance(item, Mapping):
+            raise ValueError("Baseline report records must be mappings")
+        _validate_record(item)
+    summary = data.get("summary_by_alias_and_run_type")
+    if not isinstance(summary, Mapping) or not summary:
+        raise ValueError("Baseline report must group summary by alias and run_type")
+    hardware = data.get("hardware_snapshot")
+    if not isinstance(hardware, Mapping):
+        raise ValueError("Baseline report must include hardware_snapshot")
+
+
+def _validate_record(record: Mapping[str, object]) -> None:
+    run_type = record.get("run_type")
+    if run_type not in RUN_TYPES:
+        raise ValueError("Baseline record must include a valid run_type")
+    for key in ("alias", "model", "question_hash_8"):
+        value = record.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"Baseline record must include {key}")
+    reason = record.get("ollama_metrics_unavailable_reason")
+    if reason is not None and reason not in OLLAMA_METRICS_UNAVAILABLE_REASONS:
+        raise ValueError("Invalid ollama_metrics_unavailable_reason")
+    resident_reason = record.get("resident_check_unavailable_reason")
+    if (
+        resident_reason is not None
+        and resident_reason not in RESIDENT_CHECK_UNAVAILABLE_REASONS
+    ):
+        raise ValueError("Invalid resident_check_unavailable_reason")
+    segments = record.get("segments")
+    if not isinstance(segments, Mapping):
+        raise ValueError("Baseline record must include segments mapping")
+
+
+def verify_report_file(path: Path) -> None:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("Baseline report must be a JSON object")
+    validate_report(raw)
 
 
 def _print_summary(results: list[BaselineRunResult]) -> None:
@@ -262,7 +713,9 @@ def _print_summary(results: list[BaselineRunResult]) -> None:
         emb = segs.get("embedding_ms")
         ret = segs.get("retrieval_ms")
         pct = f"{gen / total * 100:.1f}%" if (total and gen) else "n/a"
-        print(f"\n[{r.run_context}]  ok={r.ok}  wall={r.wall_ms:.0f}ms")
+        print(f"\n[{r.run_type}]  ok={r.ok}  wall={r.wall_ms:.0f}ms")
+        print(f"  alias/model    : {r.alias} / {r.model}")
+        print(f"  resident_before: {r.model_was_resident_before_run}")
         print(f"  embedding_ms   : {emb}")
         print(f"  retrieval_ms   : {ret}")
         print(f"  context_pack_ms: {segs.get('context_pack_ms')}")
@@ -271,16 +724,21 @@ def _print_summary(results: list[BaselineRunResult]) -> None:
         print(f"  total_ms       : {total}")
         print(f"  generation %   : {pct}")
         if r.ollama_metrics_available:
+            print(f"  ollama_load_ms       : {r.ollama_load_duration_ms}")
             print(f"  ollama_eval_count     : {r.ollama_eval_count}")
             print(f"  ollama_eval_ms        : {r.ollama_eval_duration_ms}")
             print(f"  ollama_prompt_eval_ms : {r.ollama_prompt_eval_duration_ms}")
+            print(f"  tokens_per_second    : {r.tokens_per_second}")
         else:
-            print("  ollama_metrics_available: False (LiteLLM normalizes response)")
+            print(
+                "  ollama_metrics_available: False "
+                f"({r.ollama_metrics_unavailable_reason})"
+            )
 
     # Answer the 4 merge-criterion questions
-    contexts = {r.run_context for r in results}
+    contexts = {r.run_type for r in results}
     all_ok_or_degraded = all(
-        r.ok or r.run_context == "degraded_qdrant" for r in results
+        r.ok or r.run_type == "degraded_qdrant" for r in results
     )
     segments_present = all(
         r.segment_ms.get("generation_ms") is not None
@@ -310,27 +768,52 @@ async def main_async(output_dir: Path) -> int:
 
     logger.remove()  # suppress loguru noise to stdout during baseline
     results: list[BaselineRunResult] = []
+    alias = "local_rag"
+    model = _model_for_alias(alias)
 
     print("Building live pipeline (cold_start run)…")
     pipeline = _build_pipeline()
-    r1 = await _run_once(pipeline, "cold_start")
+    cold_residency = await check_ollama_model_residency(model=model)
+    r1 = await _run_once(
+        pipeline,
+        "cold_start",
+        alias=alias,
+        model=model,
+        residency_check=cold_residency,
+    )
     results.append(r1)
     path1 = _write_result(output_dir, r1)
     print(f"  cold_start  → {path1}  ({r1.wall_ms:.0f} ms)")
 
     print("Running warm_model…")
-    r2 = await _run_once(pipeline, "warm_model")
+    warm_residency = await check_ollama_model_residency(model=model)
+    r2 = await _run_once(
+        pipeline,
+        "warm_model",
+        alias=alias,
+        model=model,
+        residency_check=warm_residency,
+    )
     results.append(r2)
     path2 = _write_result(output_dir, r2)
     print(f"  warm_model  → {path2}  ({r2.wall_ms:.0f} ms)")
 
     print("Building degraded pipeline (fake Qdrant unavailable)…")
     deg_pipeline = _build_degraded_pipeline()
-    r3 = await _run_once(deg_pipeline, "degraded_qdrant")
+    degraded_residency = await check_ollama_model_residency(model=model)
+    r3 = await _run_once(
+        deg_pipeline,
+        "degraded_qdrant",
+        alias=alias,
+        model=model,
+        residency_check=degraded_residency,
+    )
     results.append(r3)
     path3 = _write_result(output_dir, r3)
     print(f"  degraded    → {path3}  ({r3.wall_ms:.0f} ms)")
 
+    report_path = _write_report(output_dir, results)
+    print(f"  report      → {report_path}")
     _print_summary(results)
     return 0
 
@@ -345,7 +828,20 @@ def main() -> int:
         default=DEFAULT_OUTPUT_DIR,
         help="Directory for baseline JSON files (default: reports/g2_latency_baseline/)",
     )
+    parser.add_argument(
+        "--verify-only",
+        type=Path,
+        help="Validate an existing baseline report without live service calls.",
+    )
     args = parser.parse_args()
+    if args.verify_only is not None:
+        try:
+            verify_report_file(args.verify_only)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(f"Invalid baseline report: {type(exc).__name__}", file=sys.stderr)
+            return 1
+        print("Baseline report OK")
+        return 0
     return asyncio.run(main_async(args.output_dir))
 
 

--- a/tests/unit/test_rag_latency_baseline.py
+++ b/tests/unit/test_rag_latency_baseline.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+
+from scripts import run_rag_latency_baseline as baseline
+
+
+def _result(
+    *,
+    run_type: str = "cold_start",
+    alias: str = "local_rag",
+    model: str = "qwen3:14b",
+    total_ms: float = 1000.0,
+    load_ms: float | None = None,
+    eval_count: int | None = None,
+    eval_duration_ms: float | None = None,
+) -> baseline.BaselineRunResult:
+    model_load_observed = baseline._model_load_observed(load_ms)
+    typed_run_type = baseline._validate_run_type(run_type)
+    return baseline.BaselineRunResult(
+        run_type=typed_run_type,
+        alias=alias,
+        model=model,
+        question_hash_8="abcdef12",
+        question_length_chars=42,
+        segment_ms={
+            "embedding_ms": 1.0,
+            "retrieval_ms": 2.0,
+            "context_pack_ms": 3.0,
+            "prompt_build_ms": 4.0,
+            "generation_ms": 900.0,
+            "total_ms": total_ms,
+        },
+        ollama_metrics_available=load_ms is not None,
+        ollama_metrics_unavailable_reason=None
+        if load_ms is not None
+        else "not_forwarded_by_gateway",
+        ollama_total_duration_ms=None,
+        ollama_load_duration_ms=load_ms,
+        ollama_eval_count=eval_count,
+        ollama_eval_duration_ms=eval_duration_ms,
+        ollama_prompt_eval_count=None,
+        ollama_prompt_eval_duration_ms=None,
+        model_load_observed=model_load_observed,
+        run_type_verified=baseline._run_type_verified(
+            run_type=typed_run_type,
+            model_load_observed=model_load_observed,
+            error_category=None,
+        ),
+        model_was_resident_before_run=False,
+        resident_check_unavailable_reason=None,
+        tokens_per_second=baseline._tokens_per_second(
+            eval_count=eval_count,
+            eval_duration_ms=eval_duration_ms,
+        ),
+        wall_ms=total_ms,
+        ok=True,
+        error_category=None,
+    )
+
+
+class RagLatencyBaselineTests(unittest.TestCase):
+    def _records(self, report: dict[str, object]) -> list[dict[str, object]]:
+        return cast(list[dict[str, object]], report["records"])
+
+    def _grouped_summary(
+        self,
+        report: dict[str, object],
+    ) -> dict[str, dict[str, dict[str, object]]]:
+        return cast(
+            dict[str, dict[str, dict[str, object]]],
+            report["summary_by_alias_and_run_type"],
+        )
+
+    def test_run_type_required_in_baseline_record(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+
+        record = self._records(report)[0]
+
+        self.assertEqual(record["run_type"], "cold_start")
+        self.assertNotIn("run_context", record)
+
+    def test_invalid_run_type_rejected_in_report_validation(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+        bad_record = dict(self._records(report)[0])
+        bad_record["run_type"] = "mixed"
+        report["records"] = [bad_record]
+
+        with self.assertRaisesRegex(ValueError, "valid run_type"):
+            baseline.validate_report(report)
+
+    def test_summary_grouped_by_alias_and_run_type(self) -> None:
+        report = baseline.build_report(
+            [
+                _result(run_type="cold_start", total_ms=1000.0),
+                _result(run_type="warm_model", total_ms=700.0),
+            ]
+        )
+
+        summary = self._grouped_summary(report)
+
+        self.assertIn("local_rag", summary)
+        self.assertEqual(summary["local_rag"]["cold_start"]["mean_total_ms"], 1000.0)
+        self.assertEqual(summary["local_rag"]["warm_model"]["mean_total_ms"], 700.0)
+
+    def test_report_has_no_top_level_mixed_mean_total_ms(self) -> None:
+        report = baseline.build_report(
+            [
+                _result(run_type="cold_start", total_ms=1000.0),
+                _result(run_type="warm_model", total_ms=700.0),
+            ]
+        )
+
+        self.assertNotIn("mean_total_ms", report)
+        bad_report = dict(report)
+        bad_report["mean_total_ms"] = 850.0
+        with self.assertRaisesRegex(ValueError, "mixed top-level mean_total_ms"):
+            baseline.validate_report(bad_report)
+
+    def test_model_load_observed_derives_from_load_duration(self) -> None:
+        self.assertIsNone(baseline._model_load_observed(None))
+        self.assertFalse(baseline._model_load_observed(500.0))
+        self.assertTrue(baseline._model_load_observed(501.0))
+
+    def test_run_type_verified_derives_from_load_and_degraded_status(self) -> None:
+        self.assertTrue(
+            baseline._run_type_verified(
+                run_type="cold_start",
+                model_load_observed=True,
+                error_category=None,
+            )
+        )
+        self.assertTrue(
+            baseline._run_type_verified(
+                run_type="warm_model",
+                model_load_observed=False,
+                error_category=None,
+            )
+        )
+        self.assertTrue(
+            baseline._run_type_verified(
+                run_type="degraded_qdrant",
+                model_load_observed=None,
+                error_category="RuntimeError",
+            )
+        )
+        self.assertIsNone(
+            baseline._run_type_verified(
+                run_type="warm_model",
+                model_load_observed=None,
+                error_category=None,
+            )
+        )
+
+    def test_tokens_per_second_computed_safely(self) -> None:
+        self.assertEqual(
+            baseline._tokens_per_second(eval_count=100, eval_duration_ms=2000.0),
+            50.0,
+        )
+        self.assertIsNone(
+            baseline._tokens_per_second(eval_count=100, eval_duration_ms=0.0)
+        )
+        self.assertIsNone(
+            baseline._tokens_per_second(eval_count=None, eval_duration_ms=100.0)
+        )
+
+    def test_missing_metrics_get_safe_reason(self) -> None:
+        self.assertEqual(
+            baseline._ollama_metrics_unavailable_reason(
+                run_type="warm_model",
+                trace_present=True,
+                metrics_available=False,
+            ),
+            "not_forwarded_by_gateway",
+        )
+        self.assertEqual(
+            baseline._ollama_metrics_unavailable_reason(
+                run_type="cold_start",
+                trace_present=False,
+                metrics_available=False,
+            ),
+            "not_present_in_response",
+        )
+        self.assertEqual(
+            baseline._ollama_metrics_unavailable_reason(
+                run_type="degraded_qdrant",
+                trace_present=False,
+                metrics_available=False,
+            ),
+            "not_applicable_degraded",
+        )
+
+    def test_ollama_ps_parser_handles_present_absent_and_invalid(self) -> None:
+        payload = {"models": [{"name": "qwen3:14b"}]}
+
+        self.assertTrue(
+            baseline._parse_ollama_ps_residency(payload, model="qwen3:14b")
+        )
+        self.assertFalse(
+            baseline._parse_ollama_ps_residency(payload, model="other:latest")
+        )
+        self.assertIsNone(
+            baseline._parse_ollama_ps_residency({"models": "bad"}, model="qwen3:14b")
+        )
+
+    def test_residency_check_rejects_remote_url_without_calling_client(self) -> None:
+        result = self.run_async(
+            baseline.check_ollama_model_residency(
+                model="qwen3:14b",
+                base_url="https://example.com",
+            )
+        )
+
+        self.assertIsNone(result.model_was_resident_before_run)
+        self.assertEqual(result.resident_check_unavailable_reason, "non_local_url")
+
+    def test_residency_check_handles_timeout(self) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.TimeoutException("timeout")
+
+        async def run_check() -> baseline.ModelResidencyCheck:
+            async with httpx.AsyncClient(
+                base_url="http://127.0.0.1:11434",
+                transport=httpx.MockTransport(handler),
+            ) as client:
+                return await baseline.check_ollama_model_residency(
+                    model="qwen3:14b",
+                    base_url="http://127.0.0.1:11434",
+                    client=client,
+                )
+
+        result = self.run_async(run_check())
+
+        self.assertIsNone(result.model_was_resident_before_run)
+        self.assertEqual(result.resident_check_unavailable_reason, "timeout")
+
+    def test_hardware_snapshot_has_no_username_path_or_hostname_keys(self) -> None:
+        snapshot = baseline._hardware_snapshot()
+
+        self.assertNotIn("username", snapshot)
+        self.assertNotIn("hostname", snapshot)
+        self.assertNotIn("path", snapshot)
+        self.assertIn("platform_system", snapshot)
+        self.assertIn("platform_machine", snapshot)
+        self.assertIn("python_version", snapshot)
+
+    def test_verify_only_accepts_valid_report(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+
+        baseline.validate_report(report)
+
+    def test_verify_only_rejects_legacy_report_missing_run_type(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+        legacy_record = dict(self._records(report)[0])
+        legacy_record.pop("run_type")
+        report["records"] = [legacy_record]
+
+        with self.assertRaisesRegex(ValueError, "valid run_type"):
+            baseline.validate_report(report)
+
+    def test_verify_report_file_reads_json(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+        path = self.tmp_path() / "report.json"
+        path.write_text(json.dumps(report), encoding="utf-8")
+
+        baseline.verify_report_file(path)
+
+    def test_sanitized_output_forbids_sensitive_keys(self) -> None:
+        report = baseline.build_report([_result(run_type="cold_start")])
+        bad_report = dict(report)
+        bad_report["prompt"] = "FAKE_PROMPT_SHOULD_NOT_APPEAR"
+
+        with self.assertRaisesRegex(ValueError, "Forbidden keys"):
+            baseline.validate_report(bad_report)
+
+    def tmp_path(self) -> Path:
+        import tempfile
+
+        return Path(tempfile.mkdtemp())
+
+    def run_async(self, awaitable: Any) -> Any:
+        import asyncio
+
+        return asyncio.run(awaitable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_latency_baseline.py
+++ b/tests/unit/test_rag_latency_baseline.py
@@ -156,6 +156,38 @@ class RagLatencyBaselineTests(unittest.TestCase):
                 error_category=None,
             )
         )
+        # Mislabelled cold start — model was already warm
+        self.assertFalse(
+            baseline._run_type_verified(
+                run_type="cold_start",
+                model_load_observed=False,
+                error_category=None,
+            )
+        )
+        # Cold start unverifiable — no Ollama metrics
+        self.assertIsNone(
+            baseline._run_type_verified(
+                run_type="cold_start",
+                model_load_observed=None,
+                error_category=None,
+            )
+        )
+        # Mislabelled warm — model loaded during claimed warm run
+        self.assertFalse(
+            baseline._run_type_verified(
+                run_type="warm_model",
+                model_load_observed=True,
+                error_category=None,
+            )
+        )
+        # Degraded run that did not actually fail
+        self.assertFalse(
+            baseline._run_type_verified(
+                run_type="degraded_qdrant",
+                model_load_observed=None,
+                error_category=None,
+            )
+        )
 
     def test_tokens_per_second_computed_safely(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## G2-PR04 — RAG Latency Baseline: cold_start / warm_model separation

### Escopo
- Novo script `scripts/run_rag_latency_baseline.py` (opt-in via `RUN_RAG_LATENCY_BASELINE=1`)
- 3 run types: `cold_start`, `warm_model`, `degraded_qdrant`
- `_run_type_verified()` detecta runs mislabelled
- `validate_report()` rejeita `mean_total_ms` raiz (anti-mixing)
- `ModelResidencyCheck` via Ollama `/api/ps` (local-only, graceful)
- `_hardware_snapshot()` sem username/hostname/path

### Testes
- 16 unit tests offline em `tests/unit/test_rag_latency_baseline.py`
- RC-1 aplicado: 4 assertions para paths False de `_run_type_verified()`

### Checklist
- [ ] pytest tests/unit/ ✅
- [ ] mypy backend/ --strict ✅
- [ ] pyright backend/ ✅
- [ ] Sem credenciais / dados sensíveis
- [ ] Sem print() — loguru only
- [ ] Docs: `docs/RAG_LATENCY_BASELINE.md`