### PR TITLE
perf(rag): add local_rag model residency config via Ollama keep_alive

### DIFF
--- a/backend/gateway/client.py
+++ b/backend/gateway/client.py
@@ -171,6 +171,8 @@ class GatewayChatClient:
         model: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
+        extra_body: Mapping[str, object] | None = None,
         response_format: Mapping[str, object] | None = None,
     ) -> str:
         """Call ``/chat/completions`` and return normalized assistant text."""
@@ -193,6 +195,13 @@ class GatewayChatClient:
             if max_tokens <= 0:
                 raise ValueError("max_tokens must be greater than zero")
             payload["max_tokens"] = max_tokens
+        merged_extra_body = dict(extra_body or {})
+        if keep_alive is not None:
+            if not keep_alive.strip():
+                raise ValueError("keep_alive cannot be empty")
+            merged_extra_body["keep_alive"] = keep_alive.strip()
+        if merged_extra_body:
+            payload["extra_body"] = merged_extra_body
         if response_format is not None:
             payload["response_format"] = dict(response_format)
 

--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -93,6 +93,10 @@ RAG_RUN_TRACE_KEYS = frozenset(
         "generation_budget_applied",
         "generation_budget_max_tokens",
         "conciseness_instruction_applied",
+        # Gateway-2 local_rag model residency fields.
+        "model_residency_enabled",
+        "keep_alive_value",
+        "keep_alive_applied",
         "prompt_build_ms",
         "generation_ms",
         "total_ms",

--- a/backend/gateway/observability_contract.py
+++ b/backend/gateway/observability_contract.py
@@ -97,6 +97,7 @@ RAG_RUN_TRACE_KEYS = frozenset(
         "model_residency_enabled",
         "keep_alive_value",
         "keep_alive_applied",
+        "keep_alive_skipped_reason",
         "prompt_build_ms",
         "generation_ms",
         "total_ms",

--- a/backend/rag/generator.py
+++ b/backend/rag/generator.py
@@ -111,6 +111,7 @@ class LocalGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
         """Generate one local answer through LiteLLM chat completions."""
 
@@ -124,6 +125,8 @@ class LocalGenerator:
         effective_max_tokens = self.max_tokens if max_tokens is None else max_tokens
         if effective_max_tokens <= 0:
             raise ValueError("max_tokens must be greater than zero")
+        if keep_alive is not None and not keep_alive.strip():
+            raise ValueError("keep_alive cannot be empty")
 
         start = time.perf_counter()
         answer = await self.gateway_client.chat_completion(
@@ -131,6 +134,7 @@ class LocalGenerator:
             model=self.model,
             temperature=effective_temperature,
             max_tokens=effective_max_tokens,
+            keep_alive=keep_alive,
         )
         if not thinking_mode:
             answer = _strip_thinking(answer)

--- a/backend/rag/model_residency.py
+++ b/backend/rag/model_residency.py
@@ -1,0 +1,153 @@
+"""Configurable local RAG model residency controls."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+LOCAL_RAG_ALIAS = "local_rag"
+ALLOWED_MODEL_RESIDENCY_ALIASES = frozenset({LOCAL_RAG_ALIAS})
+ALLOWED_KEEP_ALIVE_VALUES = frozenset({"0", "30s", "1m", "5m", "10m", "30m", "-1"})
+DEFAULT_KEEP_ALIVE = "5m"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
+
+
+@dataclass(frozen=True)
+class ModelResidencyConfig:
+    """Rollback-safe model residency config for ``local_rag``."""
+
+    enabled: bool = False
+    apply_to_aliases: tuple[str, ...] = (LOCAL_RAG_ALIAS,)
+    keep_alive: str = DEFAULT_KEEP_ALIVE
+
+    def validated(self) -> ModelResidencyConfig:
+        """Return normalized config or raise a clear validation error."""
+        if not isinstance(self.enabled, bool):
+            raise TypeError("rag.model_residency.enabled must be boolean")
+        aliases = tuple(
+            _validate_model_residency_alias(alias)
+            for alias in self.apply_to_aliases
+        )
+        if not aliases:
+            raise ValueError("rag.model_residency.apply_to_aliases cannot be empty")
+        keep_alive = _validate_keep_alive(self.keep_alive)
+        return ModelResidencyConfig(
+            enabled=self.enabled,
+            apply_to_aliases=aliases,
+            keep_alive=keep_alive,
+        )
+
+
+@dataclass(frozen=True)
+class ModelResidencyDecision:
+    """Per-call local RAG model residency decision."""
+
+    enabled: bool
+    keep_alive: str | None
+
+    @property
+    def keep_alive_applied(self) -> bool:
+        """Return whether keep_alive should be forwarded to generation."""
+        return self.keep_alive is not None
+
+
+def decide_model_residency(
+    config: ModelResidencyConfig,
+    *,
+    alias: str | None,
+) -> ModelResidencyDecision:
+    """Return the model residency decision for one model alias."""
+    if (
+        not config.enabled
+        or alias is None
+        or alias not in config.apply_to_aliases
+    ):
+        return ModelResidencyDecision(enabled=False, keep_alive=None)
+    return ModelResidencyDecision(enabled=True, keep_alive=config.keep_alive)
+
+
+def load_model_residency_config(
+    config_path: str | Path = DEFAULT_RAG_CONFIG_PATH,
+) -> ModelResidencyConfig:
+    """Load ``rag.model_residency`` from the RAG config file."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("rag_config.yaml must contain a mapping")
+    rag = raw.get("rag")
+    if not isinstance(rag, Mapping):
+        raise ValueError("rag_config.yaml must contain rag mapping")
+    model_residency = rag.get("model_residency", {})
+    if model_residency is None:
+        model_residency = {}
+    if not isinstance(model_residency, Mapping):
+        raise ValueError("rag.model_residency must be a mapping")
+    return ModelResidencyConfig(
+        enabled=_bool_value(model_residency, "enabled", False),
+        apply_to_aliases=_alias_tuple(
+            model_residency,
+            "apply_to_aliases",
+            (LOCAL_RAG_ALIAS,),
+        ),
+        keep_alive=_string_value(
+            model_residency,
+            "keep_alive",
+            DEFAULT_KEEP_ALIVE,
+        ),
+    ).validated()
+
+
+def _bool_value(mapping: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = mapping.get(key, default)
+    if not isinstance(value, bool):
+        raise TypeError(f"rag.model_residency.{key} must be boolean")
+    return value
+
+
+def _string_value(mapping: Mapping[str, Any], key: str, default: str) -> str:
+    value = mapping.get(key, default)
+    if not isinstance(value, str):
+        raise TypeError(f"rag.model_residency.{key} must be a string")
+    return value
+
+
+def _alias_tuple(
+    mapping: Mapping[str, Any],
+    key: str,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    value = mapping.get(key, default)
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise TypeError(f"rag.model_residency.{key} must be a sequence")
+    return tuple(_validate_model_residency_alias(alias) for alias in value)
+
+
+def _validate_model_residency_alias(alias: object) -> str:
+    if not isinstance(alias, str):
+        raise TypeError("rag.model_residency aliases must be strings")
+    value = alias.strip()
+    if not value:
+        raise ValueError("rag.model_residency aliases cannot be empty")
+    if value not in ALLOWED_MODEL_RESIDENCY_ALIASES:
+        raise ValueError(
+            "rag.model_residency.apply_to_aliases supports only "
+            f"{sorted(ALLOWED_MODEL_RESIDENCY_ALIASES)} in G2-05"
+        )
+    return value
+
+
+def _validate_keep_alive(value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError("rag.model_residency.keep_alive must be a string")
+    clean = value.strip()
+    if clean not in ALLOWED_KEEP_ALIVE_VALUES:
+        raise ValueError(
+            "rag.model_residency.keep_alive must be one of "
+            f"{sorted(ALLOWED_KEEP_ALIVE_VALUES)}"
+        )
+    return clean

--- a/backend/rag/model_residency.py
+++ b/backend/rag/model_residency.py
@@ -12,7 +12,7 @@ import yaml
 
 LOCAL_RAG_ALIAS = "local_rag"
 ALLOWED_MODEL_RESIDENCY_ALIASES = frozenset({LOCAL_RAG_ALIAS})
-ALLOWED_KEEP_ALIVE_VALUES = frozenset({"0", "30s", "1m", "5m", "10m", "30m", "-1"})
+ALLOWED_KEEP_ALIVE_VALUES = frozenset({"0", "30s", "1m", "5m", "10m", "30m", "1h", "2h", "6h", "-1"})
 DEFAULT_KEEP_ALIVE = "5m"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"

--- a/backend/rag/model_residency.py
+++ b/backend/rag/model_residency.py
@@ -2,18 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
+from loguru import logger
 
 
 LOCAL_RAG_ALIAS = "local_rag"
 ALLOWED_MODEL_RESIDENCY_ALIASES = frozenset({LOCAL_RAG_ALIAS})
-ALLOWED_KEEP_ALIVE_VALUES = frozenset({"0", "30s", "1m", "5m", "10m", "30m", "1h", "2h", "6h", "-1"})
 DEFAULT_KEEP_ALIVE = "5m"
+KEEP_ALIVE_PATTERN = re.compile(r"^-?\d+(?:s|m|h)?$")
+ModelResidencySkippedReason = Literal[
+    "disabled",
+    "alias_not_in_scope",
+    "no_keep_alive_value",
+]
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
 
@@ -24,7 +31,7 @@ class ModelResidencyConfig:
 
     enabled: bool = False
     apply_to_aliases: tuple[str, ...] = (LOCAL_RAG_ALIAS,)
-    keep_alive: str = DEFAULT_KEEP_ALIVE
+    keep_alive: str | None = DEFAULT_KEEP_ALIVE
 
     def validated(self) -> ModelResidencyConfig:
         """Return normalized config or raise a clear validation error."""
@@ -50,6 +57,7 @@ class ModelResidencyDecision:
 
     enabled: bool
     keep_alive: str | None
+    skipped_reason: ModelResidencySkippedReason | None = None
 
     @property
     def keep_alive_applied(self) -> bool:
@@ -63,13 +71,34 @@ def decide_model_residency(
     alias: str | None,
 ) -> ModelResidencyDecision:
     """Return the model residency decision for one model alias."""
-    if (
-        not config.enabled
-        or alias is None
-        or alias not in config.apply_to_aliases
-    ):
-        return ModelResidencyDecision(enabled=False, keep_alive=None)
-    return ModelResidencyDecision(enabled=True, keep_alive=config.keep_alive)
+    if not config.enabled:
+        return ModelResidencyDecision(
+            enabled=False,
+            keep_alive=None,
+            skipped_reason="disabled",
+        )
+    if alias is None or alias not in config.apply_to_aliases:
+        return ModelResidencyDecision(
+            enabled=True,
+            keep_alive=None,
+            skipped_reason="alias_not_in_scope",
+        )
+    if config.keep_alive is None:
+        return ModelResidencyDecision(
+            enabled=True,
+            keep_alive=None,
+            skipped_reason="no_keep_alive_value",
+        )
+    if config.keep_alive == "-1":
+        logger.bind(
+            event="model_residency_indefinite_keep_alive",
+            alias=alias,
+        ).warning("model_residency_indefinite_keep_alive")
+    return ModelResidencyDecision(
+        enabled=True,
+        keep_alive=config.keep_alive,
+        skipped_reason=None,
+    )
 
 
 def load_model_residency_config(
@@ -94,7 +123,7 @@ def load_model_residency_config(
             "apply_to_aliases",
             (LOCAL_RAG_ALIAS,),
         ),
-        keep_alive=_string_value(
+        keep_alive=_optional_string_value(
             model_residency,
             "keep_alive",
             DEFAULT_KEEP_ALIVE,
@@ -109,8 +138,14 @@ def _bool_value(mapping: Mapping[str, Any], key: str, default: bool) -> bool:
     return value
 
 
-def _string_value(mapping: Mapping[str, Any], key: str, default: str) -> str:
+def _optional_string_value(
+    mapping: Mapping[str, Any],
+    key: str,
+    default: str | None,
+) -> str | None:
     value = mapping.get(key, default)
+    if value is None:
+        return None
     if not isinstance(value, str):
         raise TypeError(f"rag.model_residency.{key} must be a string")
     return value
@@ -141,13 +176,15 @@ def _validate_model_residency_alias(alias: object) -> str:
     return value
 
 
-def _validate_keep_alive(value: object) -> str:
+def _validate_keep_alive(value: object) -> str | None:
+    if value is None:
+        return None
     if not isinstance(value, str):
         raise TypeError("rag.model_residency.keep_alive must be a string")
     clean = value.strip()
-    if clean not in ALLOWED_KEEP_ALIVE_VALUES:
+    if not clean or KEEP_ALIVE_PATTERN.fullmatch(clean) is None:
         raise ValueError(
-            "rag.model_residency.keep_alive must be one of "
-            f"{sorted(ALLOWED_KEEP_ALIVE_VALUES)}"
+            "rag.model_residency.keep_alive must match "
+            "^-?\\d+(?:s|m|h)?$"
         )
     return clean

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -19,6 +19,12 @@ from backend.rag.generation_budget import (
     decide_generation_budget,
     load_generation_budget_config,
 )
+from backend.rag.model_residency import (
+    ModelResidencyConfig,
+    ModelResidencyDecision,
+    decide_model_residency,
+    load_model_residency_config,
+)
 from backend.rag.prompt_builder import PromptBuilder
 from backend.rag.observability import (
     RagErrorCategory,
@@ -60,6 +66,7 @@ class GeneratorProtocol(Protocol):
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> Awaitable[str]:
         """Generate an answer from chat messages."""
         ...
@@ -94,6 +101,7 @@ class LocalRagPipeline:
     tracing_config: RagTracingConfig | None = None
     observability_config: RagObservabilityConfig | None = None
     generation_budget_config: GenerationBudgetConfig | None = None
+    model_residency_config: ModelResidencyConfig | None = None
 
     def __post_init__(self) -> None:
         if self.tracing_config is None:
@@ -102,6 +110,8 @@ class LocalRagPipeline:
             self.observability_config = load_rag_observability_config()
         if self.generation_budget_config is None:
             self.generation_budget_config = load_generation_budget_config()
+        if self.model_residency_config is None:
+            self.model_residency_config = load_model_residency_config()
 
     async def ask(
         self,
@@ -160,6 +170,10 @@ class LocalRagPipeline:
             self.generation_budget_config or GenerationBudgetConfig(),
             alias=gateway_alias,
         )
+        model_residency = decide_model_residency(
+            self.model_residency_config or ModelResidencyConfig(),
+            alias=gateway_alias,
+        )
 
         prompt_start = time.perf_counter()
         messages = self.prompt_builder.build(
@@ -184,9 +198,10 @@ class LocalRagPipeline:
                 self.generator,
                 messages=messages,
                 temperature=self.temperature,
-                thinking_mode=self.thinking_mode,
-                generation_budget=generation_budget,
-            )
+            thinking_mode=self.thinking_mode,
+            generation_budget=generation_budget,
+            model_residency=model_residency,
+        )
         except Exception as exc:
             self._emit_pipeline_event(
                 RagEventKind.GENERATION_FAILED,
@@ -229,6 +244,7 @@ class LocalRagPipeline:
             context_pack_ms=retrieval_segments.context_pack_ms,
             context_budget_result=context_budget_result,
             generation_budget=generation_budget,
+            model_residency=model_residency,
             answer_length_chars=len(answer),
             answer_token_estimate=estimate_prompt_tokens(answer),
             prompt_ms=prompt_ms,
@@ -259,6 +275,7 @@ class LocalRagPipeline:
         chunk_count: int,
         context_budget_result: ContextBudgetResult | None = None,
         generation_budget: GenerationBudgetDecision | None = None,
+        model_residency: ModelResidencyDecision | None = None,
         answer_length_chars: int | None = None,
         answer_token_estimate: int | None = None,
         query_id: str | None = None,
@@ -359,6 +376,17 @@ class LocalRagPipeline:
                 if generation_budget is not None
                 else None
             ),
+            model_residency_enabled=(
+                model_residency.enabled if model_residency is not None else None
+            ),
+            keep_alive_value=(
+                model_residency.keep_alive if model_residency is not None else None
+            ),
+            keep_alive_applied=(
+                model_residency.keep_alive_applied
+                if model_residency is not None
+                else None
+            ),
             prompt_build_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=total_ms,
@@ -426,12 +454,14 @@ async def _chat_with_generation_budget(
     temperature: float | None,
     thinking_mode: bool,
     generation_budget: GenerationBudgetDecision,
+    model_residency: ModelResidencyDecision,
 ) -> str:
     return await generator.chat(
         messages,
         temperature=temperature,
         thinking_mode=thinking_mode,
         max_tokens=generation_budget.max_tokens,
+        keep_alive=model_residency.keep_alive,
     )
 
 

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -387,6 +387,11 @@ class LocalRagPipeline:
                 if model_residency is not None
                 else None
             ),
+            keep_alive_skipped_reason=(
+                model_residency.skipped_reason
+                if model_residency is not None
+                else None
+            ),
             prompt_build_ms=prompt_ms,
             generation_ms=generation_ms,
             total_ms=total_ms,

--- a/backend/rag/run_trace.py
+++ b/backend/rag/run_trace.py
@@ -134,6 +134,9 @@ class RagRunTrace:
     generation_budget_applied: bool | None = None
     generation_budget_max_tokens: int | None = None
     conciseness_instruction_applied: bool | None = None
+    model_residency_enabled: bool | None = None
+    keep_alive_value: str | None = None
+    keep_alive_applied: bool | None = None
     prompt_build_ms: float | None = None
     generation_ms: float | None = None
     total_ms: float | None = None
@@ -221,10 +224,14 @@ class RagRunTrace:
             "generation_budget_enabled",
             "generation_budget_applied",
             "conciseness_instruction_applied",
+            "model_residency_enabled",
+            "keep_alive_applied",
         ):
             value = getattr(self, field_name)
             if value is not None and not isinstance(value, bool):
                 raise TypeError(f"{field_name} must be boolean when provided")
+        if self.keep_alive_value is not None:
+            _validate_non_empty(self.keep_alive_value, "keep_alive_value")
         if self.run_context is not None and self.run_context not in RUN_CONTEXTS:
             raise ValueError(
                 f"run_context must be one of {sorted(RUN_CONTEXTS)}"
@@ -289,6 +296,9 @@ class RagRunTrace:
             "generation_budget_applied": self.generation_budget_applied,
             "generation_budget_max_tokens": self.generation_budget_max_tokens,
             "conciseness_instruction_applied": self.conciseness_instruction_applied,
+            "model_residency_enabled": self.model_residency_enabled,
+            "keep_alive_value": self.keep_alive_value,
+            "keep_alive_applied": self.keep_alive_applied,
             "prompt_build_ms": self.prompt_build_ms,
             "generation_ms": self.generation_ms,
             "total_ms": self.total_ms,
@@ -343,6 +353,9 @@ def build_rag_run_trace(
     generation_budget_applied: bool | None = None,
     generation_budget_max_tokens: int | None = None,
     conciseness_instruction_applied: bool | None = None,
+    model_residency_enabled: bool | None = None,
+    keep_alive_value: str | None = None,
+    keep_alive_applied: bool | None = None,
     prompt_build_ms: float | None = None,
     generation_ms: float | None = None,
     total_ms: float | None = None,
@@ -389,6 +402,9 @@ def build_rag_run_trace(
         generation_budget_applied=generation_budget_applied,
         generation_budget_max_tokens=generation_budget_max_tokens,
         conciseness_instruction_applied=conciseness_instruction_applied,
+        model_residency_enabled=model_residency_enabled,
+        keep_alive_value=keep_alive_value,
+        keep_alive_applied=keep_alive_applied,
         prompt_build_ms=prompt_build_ms,
         generation_ms=generation_ms,
         total_ms=total_ms,

--- a/backend/rag/run_trace.py
+++ b/backend/rag/run_trace.py
@@ -137,6 +137,7 @@ class RagRunTrace:
     model_residency_enabled: bool | None = None
     keep_alive_value: str | None = None
     keep_alive_applied: bool | None = None
+    keep_alive_skipped_reason: str | None = None
     prompt_build_ms: float | None = None
     generation_ms: float | None = None
     total_ms: float | None = None
@@ -232,6 +233,12 @@ class RagRunTrace:
                 raise TypeError(f"{field_name} must be boolean when provided")
         if self.keep_alive_value is not None:
             _validate_non_empty(self.keep_alive_value, "keep_alive_value")
+        if self.keep_alive_skipped_reason is not None:
+            _validate_allowed_value(
+                self.keep_alive_skipped_reason,
+                "keep_alive_skipped_reason",
+                {"disabled", "alias_not_in_scope", "no_keep_alive_value"},
+            )
         if self.run_context is not None and self.run_context not in RUN_CONTEXTS:
             raise ValueError(
                 f"run_context must be one of {sorted(RUN_CONTEXTS)}"
@@ -299,6 +306,7 @@ class RagRunTrace:
             "model_residency_enabled": self.model_residency_enabled,
             "keep_alive_value": self.keep_alive_value,
             "keep_alive_applied": self.keep_alive_applied,
+            "keep_alive_skipped_reason": self.keep_alive_skipped_reason,
             "prompt_build_ms": self.prompt_build_ms,
             "generation_ms": self.generation_ms,
             "total_ms": self.total_ms,
@@ -356,6 +364,7 @@ def build_rag_run_trace(
     model_residency_enabled: bool | None = None,
     keep_alive_value: str | None = None,
     keep_alive_applied: bool | None = None,
+    keep_alive_skipped_reason: str | None = None,
     prompt_build_ms: float | None = None,
     generation_ms: float | None = None,
     total_ms: float | None = None,
@@ -405,6 +414,7 @@ def build_rag_run_trace(
         model_residency_enabled=model_residency_enabled,
         keep_alive_value=keep_alive_value,
         keep_alive_applied=keep_alive_applied,
+        keep_alive_skipped_reason=keep_alive_skipped_reason,
         prompt_build_ms=prompt_build_ms,
         generation_ms=generation_ms,
         total_ms=total_ms,
@@ -578,3 +588,12 @@ def _validate_non_negative_float(value: float, field_name: str) -> None:
         raise TypeError(f"{field_name} must be numeric")
     if float(value) < 0.0:
         raise ValueError(f"{field_name} cannot be negative")
+
+
+def _validate_allowed_value(
+    value: str,
+    field_name: str,
+    allowed: set[str],
+) -> None:
+    if value not in allowed:
+        raise ValueError(f"{field_name} must be one of {sorted(allowed)}")

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -75,6 +75,12 @@ rag:
     target_sentences_min: 3
     target_sentences_max: 6
 
+  model_residency:
+    enabled: false
+    apply_to_aliases:
+      - "local_rag"
+    keep_alive: "5m"
+
   generation:
     model: "local_rag"
     reasoning_model: "local_think"

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -76,6 +76,10 @@ rag:
     target_sentences_max: 6
 
   model_residency:
+    # G2-05 local_rag-only Ollama keep_alive hint.
+    # Disabled by default. "0" is an explicit unload-after-request rollback
+    # value; "-1" keeps the model resident indefinitely and should be used
+    # cautiously on memory-constrained machines.
     enabled: false
     apply_to_aliases:
       - "local_rag"

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -221,19 +221,24 @@ The first rule is measurement before optimization.
 |---|---|---|---|
 | G2-PR01 | `feat/g2-rag-segment-timing-baseline` | Per-segment RAG latency baseline in `RagRunTrace` | ✅ Merged |
 | G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap for `local_rag` | ✅ Merged |
-| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable generation budget and answer-length discipline for `local_rag` | 🚧 Current |
+| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable generation budget and answer-length discipline for `local_rag` | ✅ Merged |
+| G2-PR04 | `feat/g2-warm-model-cold-start-separation` | Cold/warm/degraded latency separation and residency measurement | ✅ Merged |
+| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable Ollama keep_alive for `local_rag` model residency | 🚧 Current |
 
-G2-PR03 rules:
+G2-PR05 rules:
 
-- Budget is configured under `rag.generation_budget`.
+- Model residency is configured under `rag.model_residency`.
 - Default is rollback-safe: `enabled: false`.
-- `max_tokens` forwarding applies only to `local_rag`.
-- `local_chat`, `local_json`, `local_think`, retrieval, context packing,
-  Qdrant, aliases, timeouts and fallback behavior remain unchanged.
-- Optional concise-answer discipline must preserve citations and
-  insufficient-context behavior.
-- Trace fields are scalar only: answer length, token estimate, budget enabled,
-  budget applied, max tokens and conciseness applied.
+- `keep_alive` forwarding applies only to `local_rag`.
+- `local_chat`, `local_json`, `local_think`, embeddings, retrieval, context
+  packing, generation budget, Qdrant, aliases, timeouts and fallback behavior
+  remain unchanged.
+- No global `OLLAMA_KEEP_ALIVE`, model preload/unload, LiteLLM provider config
+  change or warmup-on-init is introduced.
+- Trace fields are scalar only: model residency enabled, keep_alive value and
+  keep_alive applied.
+- G2-PR04 baseline report can flag `keep_alive_ineffective` for warm runs that
+  still show model load after a keep_alive hint.
 - No answer text, prompts, chunks, vectors, payloads or secrets are serialized.
 
 GW-13 rules:

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -230,13 +230,16 @@ G2-PR05 rules:
 - Model residency is configured under `rag.model_residency`.
 - Default is rollback-safe: `enabled: false`.
 - `keep_alive` forwarding applies only to `local_rag`.
+- `keep_alive` must match `^-?\d+(?:s|m|h)?$`; `"0"` and `"-1"` are valid
+  operational values.
+- `"-1"` emits one safe structured warning for indefinite model residency.
 - `local_chat`, `local_json`, `local_think`, embeddings, retrieval, context
   packing, generation budget, Qdrant, aliases, timeouts and fallback behavior
   remain unchanged.
 - No global `OLLAMA_KEEP_ALIVE`, model preload/unload, LiteLLM provider config
   change or warmup-on-init is introduced.
-- Trace fields are scalar only: model residency enabled, keep_alive value and
-  keep_alive applied.
+- Trace fields are scalar only: model residency enabled, keep_alive value,
+  keep_alive applied and keep_alive skipped reason.
 - G2-PR04 baseline report can flag `keep_alive_ineffective` for warm runs that
   still show model load after a keep_alive hint.
 - No answer text, prompts, chunks, vectors, payloads or secrets are serialized.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,8 +4,8 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-05-02
-**Updated by:** Codex — G2-PR03 local_rag generation budget
+**Last updated:** 2026-05-03
+**Updated by:** Codex — G2-PR05 local_rag model residency
 
 ---
 
@@ -14,8 +14,8 @@
 **Goal:** reduce `local_rag` wall time through controlled, observable,
 rollback-safe local optimizations after the Gateway-1 proof-of-life baseline.
 
-Current branch: `feat/g2-local-rag-generation-budget`
-Current issue: `[G2-03] Constrain local_rag generation budget`
+Current branch: `feat/g2-keep-alive-model-residency`
+Current issue: `[G2-05] Tune Ollama keep_alive for local_rag model residency`
 
 Gateway-0 and Gateway-1 are complete on `main`. Gateway-2 starts from the
 measured `local_rag` latency baseline and must keep all optimizations
@@ -124,7 +124,9 @@ unavoidable, use `git push --force-with-lease`.
 | GW-20 | `feat/gateway1-proof-of-life-smoke` | Gateway-1 operational proof-of-life smoke | Done / merged |
 | G2-PR01 | `feat/g2-rag-segment-timing-baseline` | Per-segment RAG latency baseline | Done / merged |
 | G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap | Done / merged |
-| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable local_rag generation budget | Current |
+| G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable local_rag generation budget | Done / merged |
+| G2-PR04 | `feat/g2-warm-model-cold-start-separation` | Cold/warm/degraded latency separation and model residency measurement | Done / merged |
+| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable local_rag Ollama keep_alive model residency | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -146,35 +148,34 @@ Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
 
-## G2-PR03 Current Work
+## G2-PR05 Current Work
 
-G2-PR03 adds a rollback-safe generation budget for `local_rag` only.
+G2-PR05 adds a rollback-safe model residency hint for `local_rag` only.
 
 Configuration:
 
 ```yaml
 rag:
-  generation_budget:
+  model_residency:
     enabled: false
     apply_to_aliases:
       - "local_rag"
-    max_tokens: 768
-    enforce_conciseness: false
-    target_sentences_min: 3
-    target_sentences_max: 6
+    keep_alive: "5m"
 ```
 
 Rules:
 
 - Default is disabled, preserving pre-PR behavior.
-- `max_tokens` is forwarded only for `local_rag` when enabled.
-- `local_chat`, `local_json`, `local_think`, retrieval, Qdrant and context
-  packing remain unchanged.
-- Optional conciseness instruction preserves citations and insufficient-context
-  behavior.
-- `RagRunTrace` records answer length and generation-budget scalar metadata,
+- `keep_alive` is forwarded only for `local_rag` when enabled.
+- `local_chat`, `local_json`, `local_think`, embeddings, retrieval, Qdrant,
+  prompt building, context budget, generation budget and fallback behavior
+  remain unchanged.
+- `RagRunTrace` records model residency scalar metadata,
   never answer text, prompt text, chunks, vectors, payloads or secrets.
-- `local_rag` keeps `extra_body.think=false` in the operational LiteLLM config.
+- G2-PR04 baseline reports can flag `keep_alive_ineffective` when warm runs
+  still show model load after a keep_alive hint.
+- No global `OLLAMA_KEEP_ALIVE`, preloading, unloading or LiteLLM provider
+  config change is introduced.
 
 ## GW-15 Current Work
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -167,11 +167,16 @@ Rules:
 
 - Default is disabled, preserving pre-PR behavior.
 - `keep_alive` is forwarded only for `local_rag` when enabled.
+- `keep_alive` is validated with `^-?\d+(?:s|m|h)?$`; examples include
+  `"0"`, `"-1"`, `"30s"`, `"1m"`, `"5m"`, `"10m"` and `"24h"`.
+- `"-1"` emits a safe structured warning because it requests indefinite model
+  residency.
 - `local_chat`, `local_json`, `local_think`, embeddings, retrieval, Qdrant,
   prompt building, context budget, generation budget and fallback behavior
   remain unchanged.
-- `RagRunTrace` records model residency scalar metadata,
-  never answer text, prompt text, chunks, vectors, payloads or secrets.
+- `RagRunTrace` records model residency scalar metadata and
+  `keep_alive_skipped_reason`, never answer text, prompt text, chunks, vectors,
+  payloads or secrets.
 - G2-PR04 baseline reports can flag `keep_alive_ineffective` when warm runs
   still show model load after a keep_alive hint.
 - No global `OLLAMA_KEEP_ALIVE`, preloading, unloading or LiteLLM provider

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -230,18 +230,17 @@ Rollback is config-only:
 - set `keep_alive: "0"` to ask Ollama to unload after the request when the
   feature is enabled.
 
-Allowed values are intentionally narrow:
+Allowed values:
 
-- `"0"`
-- `"30s"`
-- `"1m"`
-- `"5m"`
-- `"10m"`
-- `"30m"`
-- `"-1"`
+- `"0"` — unload immediately after the request
+- `"30s"`, `"1m"`, `"5m"`, `"10m"`, `"30m"` — minute-range residency
+- `"1h"`, `"2h"`, `"6h"` — hour-range residency for sustained workloads
+- `"-1"` — indefinite residency; use with caution on memory-constrained machines
+  as the model will remain in VRAM until Ollama is restarted or the model is
+  explicitly unloaded
 
-`-1` keeps the model resident indefinitely and should be used cautiously on
-memory-constrained machines.
+Values not in this list (e.g. `"1d"`, `"forever"`, `"2h30m"`) are rejected at
+config load time with a `ValueError`.
 
 This PR does not preload models, unload models, set global
 `OLLAMA_KEEP_ALIVE`, change LiteLLM provider config, change aliases, change

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -73,6 +73,16 @@ G2-03 adds optional generation budget metadata:
 These fields make answer length discipline observable without serializing the
 answer itself.
 
+G2-05 adds optional model residency metadata:
+
+- `model_residency_enabled`
+- `keep_alive_value`
+- `keep_alive_applied`
+
+These fields record whether a local `keep_alive` hint was intentionally sent
+for `local_rag`. They do not record prompt text, answer text or raw provider
+responses.
+
 Allowed `run_context` labels:
 
 - `cold_start`
@@ -194,6 +204,62 @@ uv run python scripts/run_rag_latency_baseline.py \
 `degraded_qdrant` is isolated from successful `local_rag` runs. It exists to
 verify failure/degradation measurement shape, not to represent normal RAG
 quality or latency.
+
+## G2-05 Model Residency
+
+G2-05 is the first optimization based on the cold/warm separation introduced by
+G2-04. It targets only Ollama model residency for `local_rag` by forwarding an
+opt-in `keep_alive` value through the local LiteLLM gateway.
+
+Configuration lives in `config/rag_config.yaml`:
+
+```yaml
+rag:
+  model_residency:
+    enabled: false
+    apply_to_aliases:
+      - "local_rag"
+    keep_alive: "5m"
+```
+
+Default behavior is unchanged because `enabled` is `false`.
+
+Rollback is config-only:
+
+- set `enabled: false` to omit the `keep_alive` hint;
+- set `keep_alive: "0"` to ask Ollama to unload after the request when the
+  feature is enabled.
+
+Allowed values are intentionally narrow:
+
+- `"0"`
+- `"30s"`
+- `"1m"`
+- `"5m"`
+- `"10m"`
+- `"30m"`
+- `"-1"`
+
+`-1` keeps the model resident indefinitely and should be used cautiously on
+memory-constrained machines.
+
+This PR does not preload models, unload models, set global
+`OLLAMA_KEEP_ALIVE`, change LiteLLM provider config, change aliases, change
+prompts, mutate Qdrant, alter retrieval, or touch embeddings. It applies only to
+`local_rag`; `local_chat`, `local_json`, `local_think` and embeddings remain
+unchanged.
+
+The baseline report records:
+
+- `model_residency_enabled`;
+- `keep_alive_value`;
+- `keep_alive_applied`;
+- `keep_alive_ineffective`.
+
+`keep_alive_ineffective` is `true` only when `run_type == "warm_model"`,
+`keep_alive_applied` is true, and `model_load_observed` is still true. This is
+a warning signal, not a hard failure. Local memory pressure, Ollama eviction, or
+gateway forwarding behavior can make `keep_alive` ineffective.
 
 ## Baseline Runs
 

--- a/docs/RAG_LATENCY_BASELINE.md
+++ b/docs/RAG_LATENCY_BASELINE.md
@@ -230,17 +230,19 @@ Rollback is config-only:
 - set `keep_alive: "0"` to ask Ollama to unload after the request when the
   feature is enabled.
 
-Allowed values:
+Valid values must match `^-?\d+(?:s|m|h)?$`.
+
+Examples:
 
 - `"0"` — unload immediately after the request
 - `"30s"`, `"1m"`, `"5m"`, `"10m"`, `"30m"` — minute-range residency
-- `"1h"`, `"2h"`, `"6h"` — hour-range residency for sustained workloads
+- `"1h"`, `"2h"`, `"6h"`, `"24h"` — hour-range residency for sustained workloads
 - `"-1"` — indefinite residency; use with caution on memory-constrained machines
   as the model will remain in VRAM until Ollama is restarted or the model is
   explicitly unloaded
 
-Values not in this list (e.g. `"1d"`, `"forever"`, `"2h30m"`) are rejected at
-config load time with a `ValueError`.
+Invalid values such as `"5min"`, `"forever"`, `"../x"`, `""`, and `"abc"` are
+rejected at config load time with a `ValueError`.
 
 This PR does not preload models, unload models, set global
 `OLLAMA_KEEP_ALIVE`, change LiteLLM provider config, change aliases, change
@@ -253,7 +255,12 @@ The baseline report records:
 - `model_residency_enabled`;
 - `keep_alive_value`;
 - `keep_alive_applied`;
+- `keep_alive_skipped_reason`;
 - `keep_alive_ineffective`.
+
+`keep_alive_skipped_reason` is one of `disabled`, `alias_not_in_scope`, or
+`no_keep_alive_value`. It distinguishes why no hint was sent without using
+free-form strings.
 
 `keep_alive_ineffective` is `true` only when `run_type == "warm_model"`,
 `keep_alive_applied` is true, and `model_load_observed` is still true. This is

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -75,6 +75,13 @@ These fields are safe scalar metadata only. They record the intended
 `keep_alive` hint without storing prompt text, answer text, raw responses,
 headers or secrets.
 
+`keep_alive_value` reflects the value from `rag.model_residency.keep_alive` in
+`rag_config.yaml`. Allowed values are `"0"`, `"30s"`, `"1m"`, `"5m"`, `"10m"`,
+`"30m"`, `"1h"`, `"2h"`, `"6h"`, and `"-1"`. The value `"-1"` keeps the model
+resident in VRAM indefinitely — use with caution on memory-constrained machines.
+See `docs/RAG_LATENCY_BASELINE.md` for the full residency configuration
+reference.
+
 ## Forbidden Content
 
 The trace must never contain:

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -65,6 +65,16 @@ G2-03 extends the trace with optional `local_rag` generation budget fields:
 These fields are safe scalar metadata only. They make output length and budget
 application observable without storing answer text.
 
+G2-05 extends the trace with optional `local_rag` model residency fields:
+
+- `model_residency_enabled`
+- `keep_alive_value`
+- `keep_alive_applied`
+
+These fields are safe scalar metadata only. They record the intended
+`keep_alive` hint without storing prompt text, answer text, raw responses,
+headers or secrets.
+
 ## Forbidden Content
 
 The trace must never contain:

--- a/docs/RAG_RUN_TRACE.md
+++ b/docs/RAG_RUN_TRACE.md
@@ -70,17 +70,22 @@ G2-05 extends the trace with optional `local_rag` model residency fields:
 - `model_residency_enabled`
 - `keep_alive_value`
 - `keep_alive_applied`
+- `keep_alive_skipped_reason`
 
 These fields are safe scalar metadata only. They record the intended
 `keep_alive` hint without storing prompt text, answer text, raw responses,
 headers or secrets.
 
+`keep_alive_skipped_reason` is emitted only when no hint is sent and uses one
+of three safe reason codes: `disabled`, `alias_not_in_scope`, or
+`no_keep_alive_value`.
+
 `keep_alive_value` reflects the value from `rag.model_residency.keep_alive` in
-`rag_config.yaml`. Allowed values are `"0"`, `"30s"`, `"1m"`, `"5m"`, `"10m"`,
-`"30m"`, `"1h"`, `"2h"`, `"6h"`, and `"-1"`. The value `"-1"` keeps the model
-resident in VRAM indefinitely — use with caution on memory-constrained machines.
-See `docs/RAG_LATENCY_BASELINE.md` for the full residency configuration
-reference.
+`rag_config.yaml`. Valid values match `^-?\d+(?:s|m|h)?$`; examples include
+`"0"`, `"-1"`, `"30s"`, `"1m"`, `"5m"`, `"10m"`, and `"24h"`. The value `"-1"`
+keeps the model resident in VRAM indefinitely — use with caution on
+memory-constrained machines. See `docs/RAG_LATENCY_BASELINE.md` for the full
+residency configuration reference.
 
 ## Forbidden Content
 

--- a/scripts/run_rag_latency_baseline.py
+++ b/scripts/run_rag_latency_baseline.py
@@ -53,7 +53,7 @@ _QUESTION_HASH_8 = hashlib.sha256(
 DEFAULT_OUTPUT_DIR = Path("reports/g2_latency_baseline")
 DEFAULT_LITELLM_CONFIG_PATH = Path("config/litellm_config.yaml")
 DEFAULT_OLLAMA_API_BASE = "http://127.0.0.1:11434"
-REPORT_SCHEMA_VERSION = "g2_pr04_rag_latency_baseline_v1"
+REPORT_SCHEMA_VERSION = "g2_pr05_rag_latency_baseline_v1"
 LOAD_DURATION_THRESHOLD_MS = 500.0
 LOCAL_URL_PREFIXES = ("http://127.0.0.1:", "http://localhost:")
 RUN_TYPES = frozenset({"cold_start", "warm_model", "degraded_qdrant"})
@@ -143,6 +143,10 @@ class BaselineRunResult:
     model_was_resident_before_run: bool | None
     resident_check_unavailable_reason: ResidentCheckUnavailableReason | None
     tokens_per_second: float | None
+    model_residency_enabled: bool | None
+    keep_alive_value: str | None
+    keep_alive_applied: bool | None
+    keep_alive_ineffective: bool | None
     wall_ms: float
     ok: bool
     error_category: str | None
@@ -172,6 +176,10 @@ class BaselineRunResult:
                 self.resident_check_unavailable_reason
             ),
             "tokens_per_second": self.tokens_per_second,
+            "model_residency_enabled": self.model_residency_enabled,
+            "keep_alive_value": self.keep_alive_value,
+            "keep_alive_applied": self.keep_alive_applied,
+            "keep_alive_ineffective": self.keep_alive_ineffective,
             "wall_ms": self.wall_ms,
             "ok": self.ok,
             "error_category": self.error_category,
@@ -283,6 +291,8 @@ async def _run_once(
     ollama_load_duration_ms = _float_or_none(trace.get("ollama_load_duration_ms"))
     ollama_eval_count = _int_or_none(trace.get("ollama_eval_count"))
     ollama_eval_duration_ms = _float_or_none(trace.get("ollama_eval_duration_ms"))
+    model_load_observed = _model_load_observed(ollama_load_duration_ms)
+    keep_alive_applied = _bool_or_none(trace.get("keep_alive_applied"))
 
     return BaselineRunResult(
         run_type=run_type,
@@ -305,10 +315,10 @@ async def _run_once(
         ollama_prompt_eval_duration_ms=_float_or_none(
             trace.get("ollama_prompt_eval_duration_ms")
         ),
-        model_load_observed=_model_load_observed(ollama_load_duration_ms),
+        model_load_observed=model_load_observed,
         run_type_verified=_run_type_verified(
             run_type=run_type,
-            model_load_observed=_model_load_observed(ollama_load_duration_ms),
+            model_load_observed=model_load_observed,
             error_category=error_category,
         ),
         model_was_resident_before_run=(
@@ -320,6 +330,14 @@ async def _run_once(
         tokens_per_second=_tokens_per_second(
             eval_count=ollama_eval_count,
             eval_duration_ms=ollama_eval_duration_ms,
+        ),
+        model_residency_enabled=_bool_or_none(trace.get("model_residency_enabled")),
+        keep_alive_value=_str_or_none(trace.get("keep_alive_value")),
+        keep_alive_applied=keep_alive_applied,
+        keep_alive_ineffective=_keep_alive_ineffective(
+            run_type=run_type,
+            keep_alive_applied=keep_alive_applied,
+            model_load_observed=model_load_observed,
         ),
         wall_ms=wall_ms,
         ok=ok,
@@ -337,6 +355,18 @@ def _int_or_none(value: object) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value
+
+
+def _bool_or_none(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _str_or_none(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def _validate_run_type(value: str) -> RagRunContext:
@@ -391,6 +421,17 @@ def _tokens_per_second(
     if eval_count is None or eval_duration_ms is None or eval_duration_ms <= 0:
         return None
     return float(eval_count) / (eval_duration_ms / 1000.0)
+
+
+def _keep_alive_ineffective(
+    *,
+    run_type: RagRunContext,
+    keep_alive_applied: bool | None,
+    model_load_observed: bool | None,
+) -> bool | None:
+    if run_type != "warm_model" or keep_alive_applied is not True:
+        return None
+    return model_load_observed is True
 
 
 def _is_local_url(url: str) -> bool:

--- a/scripts/run_rag_latency_baseline.py
+++ b/scripts/run_rag_latency_baseline.py
@@ -146,6 +146,7 @@ class BaselineRunResult:
     model_residency_enabled: bool | None
     keep_alive_value: str | None
     keep_alive_applied: bool | None
+    keep_alive_skipped_reason: str | None
     keep_alive_ineffective: bool | None
     wall_ms: float
     ok: bool
@@ -179,6 +180,7 @@ class BaselineRunResult:
             "model_residency_enabled": self.model_residency_enabled,
             "keep_alive_value": self.keep_alive_value,
             "keep_alive_applied": self.keep_alive_applied,
+            "keep_alive_skipped_reason": self.keep_alive_skipped_reason,
             "keep_alive_ineffective": self.keep_alive_ineffective,
             "wall_ms": self.wall_ms,
             "ok": self.ok,
@@ -334,6 +336,9 @@ async def _run_once(
         model_residency_enabled=_bool_or_none(trace.get("model_residency_enabled")),
         keep_alive_value=_str_or_none(trace.get("keep_alive_value")),
         keep_alive_applied=keep_alive_applied,
+        keep_alive_skipped_reason=_str_or_none(
+            trace.get("keep_alive_skipped_reason")
+        ),
         keep_alive_ineffective=_keep_alive_ineffective(
             run_type=run_type,
             keep_alive_applied=keep_alive_applied,

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -40,8 +40,9 @@ class CitationGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
-        del max_tokens
+        del max_tokens, keep_alive
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         user_content = messages[-1]["content"]

--- a/tests/smoke/test_rag_pipeline_smoke.py
+++ b/tests/smoke/test_rag_pipeline_smoke.py
@@ -65,8 +65,9 @@ class FakeGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
-        del max_tokens
+        del max_tokens, keep_alive
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         return (

--- a/tests/smoke/test_rag_smoke.py
+++ b/tests/smoke/test_rag_smoke.py
@@ -42,8 +42,9 @@ class SmokeGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
-        del max_tokens
+        del max_tokens, keep_alive
         self.seen_messages = messages
         self.seen_thinking_mode = thinking_mode
         content = messages[-1]["content"]

--- a/tests/unit/test_embedding_contract_config.py
+++ b/tests/unit/test_embedding_contract_config.py
@@ -159,6 +159,19 @@ class EmbeddingContractConfigTests(unittest.TestCase):
             },
         )
 
+    def test_rag_config_model_residency_is_rollback_safe_by_default(self) -> None:
+        raw = _load_yaml(RAG_CONFIG)
+        model_residency = raw["rag"]["model_residency"]
+
+        self.assertEqual(
+            model_residency,
+            {
+                "enabled": False,
+                "apply_to_aliases": ["local_rag"],
+                "keep_alive": "5m",
+            },
+        )
+
     def test_application_facing_embedding_alias_hides_concrete_model(self) -> None:
         self.assertNotIn("nomic", DEFAULT_LLM_EMBED_MODEL)
         self.assertNotIn("ollama/", DEFAULT_LLM_EMBED_MODEL)

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -230,6 +230,66 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(answer, "Resposta compacta.")
         self.assertNotIn("max_tokens", seen_payloads[0])
 
+    async def test_chat_completion_includes_keep_alive_in_extra_body_when_provided(
+        self,
+    ) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta compacta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            answer = await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                model=DEFAULT_LLM_RAG_MODEL,
+                keep_alive="5m",
+                extra_body={"think": False},
+            )
+
+        self.assertEqual(answer, "Resposta compacta.")
+        self.assertEqual(
+            seen_payloads[0]["extra_body"],
+            {"think": False, "keep_alive": "5m"},
+        )
+        self.assertNotIn("secret-test-key", str(seen_payloads[0]))
+
+    async def test_chat_completion_omits_keep_alive_when_none(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta compacta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                model=DEFAULT_LLM_MODEL,
+                keep_alive=None,
+            )
+
+        self.assertNotIn("extra_body", seen_payloads[0])
+
     async def test_chat_completion_uses_alias_specific_timeout(self) -> None:
         seen_timeouts: list[dict[str, float]] = []
 

--- a/tests/unit/test_gateway_client.py
+++ b/tests/unit/test_gateway_client.py
@@ -290,6 +290,39 @@ class GatewayChatClientTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertNotIn("extra_body", seen_payloads[0])
 
+    async def test_chat_completion_explicit_keep_alive_overrides_extra_body_value(
+        self,
+    ) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta compacta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            gateway = GatewayChatClient(
+                config=GatewayRuntimeConfig(api_key="secret-test-key"),
+                client=client,
+            )
+            answer = await gateway.chat_completion(
+                [{"role": "user", "content": "pergunta"}],
+                model=DEFAULT_LLM_RAG_MODEL,
+                keep_alive="5m",
+                extra_body={"think": False, "keep_alive": "0"},
+            )
+
+        self.assertEqual(answer, "Resposta compacta.")
+        self.assertEqual(
+            seen_payloads[0]["extra_body"],
+            {"think": False, "keep_alive": "5m"},
+        )
+
     async def test_chat_completion_uses_alias_specific_timeout(self) -> None:
         seen_timeouts: list[dict[str, float]] = []
 

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -74,6 +74,34 @@ class LocalGeneratorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(answer, "Resposta curta.")
         self.assertEqual(seen_payloads[0]["max_tokens"], 768)
 
+    async def test_chat_call_forwards_keep_alive_when_provided(self) -> None:
+        seen_payloads: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_payloads.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Resposta curta."}}]},
+            )
+
+        async with httpx.AsyncClient(
+            base_url=DEFAULT_LLM_BASE_URL,
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            generator = LocalGenerator(
+                client=client,
+                api_key="dev-key",
+                model="local_rag",
+                max_tokens=2048,
+            )
+            answer = await generator.chat(
+                [{"role": "user", "content": "pergunta"}],
+                keep_alive="5m",
+            )
+
+        self.assertEqual(answer, "Resposta curta.")
+        self.assertEqual(seen_payloads[0]["extra_body"], {"keep_alive": "5m"})
+
     async def test_chat_strips_thinking_blocks_when_disabled(self) -> None:
         async with httpx.AsyncClient(
             base_url=DEFAULT_LLM_BASE_URL,

--- a/tests/unit/test_model_residency.py
+++ b/tests/unit/test_model_residency.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from backend.rag.model_residency import (
+    ALLOWED_KEEP_ALIVE_VALUES,
+    ModelResidencyConfig,
+    decide_model_residency,
+    load_model_residency_config,
+)
+
+
+class ModelResidencyConfigTests(unittest.TestCase):
+    def test_default_config_is_rollback_safe(self) -> None:
+        config = ModelResidencyConfig().validated()
+        decision = decide_model_residency(config, alias="local_rag")
+
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.apply_to_aliases, ("local_rag",))
+        self.assertEqual(config.keep_alive, "5m")
+        self.assertFalse(decision.enabled)
+        self.assertIsNone(decision.keep_alive)
+        self.assertFalse(decision.keep_alive_applied)
+
+    def test_keep_alive_allowlist_accepts_expected_values(self) -> None:
+        for keep_alive in sorted(ALLOWED_KEEP_ALIVE_VALUES):
+            with self.subTest(keep_alive=keep_alive):
+                config = ModelResidencyConfig(keep_alive=keep_alive).validated()
+                self.assertEqual(config.keep_alive, keep_alive)
+
+    def test_invalid_keep_alive_rejected(self) -> None:
+        for keep_alive in ("", " ", "2h", "forever", "5 minutes"):
+            with self.subTest(keep_alive=keep_alive):
+                with self.assertRaises(ValueError):
+                    ModelResidencyConfig(keep_alive=keep_alive).validated()
+
+    def test_apply_to_aliases_accepts_only_local_rag(self) -> None:
+        config = ModelResidencyConfig(apply_to_aliases=("local_rag",)).validated()
+        self.assertEqual(config.apply_to_aliases, ("local_rag",))
+
+        with self.assertRaises(ValueError):
+            ModelResidencyConfig(apply_to_aliases=("local_chat",)).validated()
+
+    def test_enabled_local_rag_applies_keep_alive(self) -> None:
+        decision = decide_model_residency(
+            ModelResidencyConfig(enabled=True, keep_alive="5m").validated(),
+            alias="local_rag",
+        )
+
+        self.assertTrue(decision.enabled)
+        self.assertEqual(decision.keep_alive, "5m")
+        self.assertTrue(decision.keep_alive_applied)
+
+    def test_enabled_non_rag_alias_is_not_applied(self) -> None:
+        decision = decide_model_residency(
+            ModelResidencyConfig(enabled=True, keep_alive="5m").validated(),
+            alias="local_chat",
+        )
+
+        self.assertFalse(decision.enabled)
+        self.assertIsNone(decision.keep_alive)
+
+    def test_keep_alive_zero_is_forwardable_when_enabled(self) -> None:
+        decision = decide_model_residency(
+            ModelResidencyConfig(enabled=True, keep_alive="0").validated(),
+            alias="local_rag",
+        )
+
+        self.assertTrue(decision.keep_alive_applied)
+        self.assertEqual(decision.keep_alive, "0")
+
+    def test_load_model_residency_config_reads_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(
+                """
+rag:
+  model_residency:
+    enabled: true
+    apply_to_aliases:
+      - local_rag
+    keep_alive: "10m"
+""",
+                encoding="utf-8",
+            )
+
+            config = load_model_residency_config(path)
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.apply_to_aliases, ("local_rag",))
+        self.assertEqual(config.keep_alive, "10m")
+
+    def test_load_model_residency_config_validates_at_load_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(
+                """
+rag:
+  model_residency:
+    enabled: true
+    apply_to_aliases:
+      - local_rag
+    keep_alive: "2h"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_model_residency_config(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_model_residency.py
+++ b/tests/unit/test_model_residency.py
@@ -31,7 +31,7 @@ class ModelResidencyConfigTests(unittest.TestCase):
                 self.assertEqual(config.keep_alive, keep_alive)
 
     def test_invalid_keep_alive_rejected(self) -> None:
-        for keep_alive in ("", " ", "2h", "forever", "5 minutes"):
+        for keep_alive in ("", " ", "1d", "forever", "5 minutes"):
             with self.subTest(keep_alive=keep_alive):
                 with self.assertRaises(ValueError):
                     ModelResidencyConfig(keep_alive=keep_alive).validated()
@@ -103,7 +103,7 @@ rag:
     enabled: true
     apply_to_aliases:
       - local_rag
-    keep_alive: "2h"
+    keep_alive: "1d"
 """,
                 encoding="utf-8",
             )

--- a/tests/unit/test_model_residency.py
+++ b/tests/unit/test_model_residency.py
@@ -54,13 +54,14 @@ class ModelResidencyConfigTests(unittest.TestCase):
         self.assertTrue(decision.keep_alive_applied)
 
     def test_enabled_non_rag_alias_is_not_applied(self) -> None:
-        decision = decide_model_residency(
-            ModelResidencyConfig(enabled=True, keep_alive="5m").validated(),
-            alias="local_chat",
-        )
+        config = ModelResidencyConfig(enabled=True, keep_alive="5m").validated()
 
-        self.assertFalse(decision.enabled)
-        self.assertIsNone(decision.keep_alive)
+        for alias in ("local_chat", "local_json", "local_think"):
+            with self.subTest(alias=alias):
+                decision = decide_model_residency(config, alias=alias)
+                self.assertFalse(decision.enabled)
+                self.assertIsNone(decision.keep_alive)
+                self.assertFalse(decision.keep_alive_applied)
 
     def test_keep_alive_zero_is_forwardable_when_enabled(self) -> None:
         decision = decide_model_residency(

--- a/tests/unit/test_model_residency.py
+++ b/tests/unit/test_model_residency.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
+
+from loguru import logger
 
 from backend.rag.model_residency import (
-    ALLOWED_KEEP_ALIVE_VALUES,
     ModelResidencyConfig,
     decide_model_residency,
     load_model_residency_config,
@@ -25,13 +27,13 @@ class ModelResidencyConfigTests(unittest.TestCase):
         self.assertFalse(decision.keep_alive_applied)
 
     def test_keep_alive_allowlist_accepts_expected_values(self) -> None:
-        for keep_alive in sorted(ALLOWED_KEEP_ALIVE_VALUES):
+        for keep_alive in ("0", "-1", "30s", "1m", "5m", "10m", "24h"):
             with self.subTest(keep_alive=keep_alive):
                 config = ModelResidencyConfig(keep_alive=keep_alive).validated()
                 self.assertEqual(config.keep_alive, keep_alive)
 
     def test_invalid_keep_alive_rejected(self) -> None:
-        for keep_alive in ("", " ", "1d", "forever", "5 minutes"):
+        for keep_alive in ("", " ", "5min", "forever", "../x", "abc"):
             with self.subTest(keep_alive=keep_alive):
                 with self.assertRaises(ValueError):
                     ModelResidencyConfig(keep_alive=keep_alive).validated()
@@ -52,6 +54,7 @@ class ModelResidencyConfigTests(unittest.TestCase):
         self.assertTrue(decision.enabled)
         self.assertEqual(decision.keep_alive, "5m")
         self.assertTrue(decision.keep_alive_applied)
+        self.assertIsNone(decision.skipped_reason)
 
     def test_enabled_non_rag_alias_is_not_applied(self) -> None:
         config = ModelResidencyConfig(enabled=True, keep_alive="5m").validated()
@@ -59,9 +62,23 @@ class ModelResidencyConfigTests(unittest.TestCase):
         for alias in ("local_chat", "local_json", "local_think"):
             with self.subTest(alias=alias):
                 decision = decide_model_residency(config, alias=alias)
-                self.assertFalse(decision.enabled)
+                self.assertTrue(decision.enabled)
                 self.assertIsNone(decision.keep_alive)
                 self.assertFalse(decision.keep_alive_applied)
+                self.assertEqual(decision.skipped_reason, "alias_not_in_scope")
+
+    def test_disabled_and_no_value_have_distinct_skipped_reasons(self) -> None:
+        disabled = decide_model_residency(
+            ModelResidencyConfig(enabled=False, keep_alive="5m").validated(),
+            alias="local_rag",
+        )
+        no_value = decide_model_residency(
+            ModelResidencyConfig(enabled=True, keep_alive=None).validated(),
+            alias="local_rag",
+        )
+
+        self.assertEqual(disabled.skipped_reason, "disabled")
+        self.assertEqual(no_value.skipped_reason, "no_keep_alive_value")
 
     def test_keep_alive_zero_is_forwardable_when_enabled(self) -> None:
         decision = decide_model_residency(
@@ -71,6 +88,32 @@ class ModelResidencyConfigTests(unittest.TestCase):
 
         self.assertTrue(decision.keep_alive_applied)
         self.assertEqual(decision.keep_alive, "0")
+
+    def test_indefinite_keep_alive_emits_safe_warning(self) -> None:
+        warnings: list[dict[str, object]] = []
+
+        def sink(message: Any) -> None:
+            warnings.append(dict(message.record["extra"]))
+
+        sink_id = logger.add(sink, level="WARNING")
+        try:
+            decision = decide_model_residency(
+                ModelResidencyConfig(enabled=True, keep_alive="-1").validated(),
+                alias="local_rag",
+            )
+        finally:
+            logger.remove(sink_id)
+
+        self.assertTrue(decision.keep_alive_applied)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(
+            warnings[0]["event"],
+            "model_residency_indefinite_keep_alive",
+        )
+        self.assertEqual(warnings[0]["alias"], "local_rag")
+        serialized = str(warnings[0]).lower()
+        for forbidden in ("prompt", "answer", "authorization", "secret", "headers"):
+            self.assertNotIn(forbidden, serialized)
 
     def test_load_model_residency_config_reads_yaml(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -103,7 +146,7 @@ rag:
     enabled: true
     apply_to_aliases:
       - local_rag
-    keep_alive: "1d"
+    keep_alive: "5min"
 """,
                 encoding="utf-8",
             )

--- a/tests/unit/test_rag_latency_baseline.py
+++ b/tests/unit/test_rag_latency_baseline.py
@@ -19,6 +19,7 @@ def _result(
     load_ms: float | None = None,
     eval_count: int | None = None,
     eval_duration_ms: float | None = None,
+    keep_alive_applied: bool | None = None,
 ) -> baseline.BaselineRunResult:
     model_load_observed = baseline._model_load_observed(load_ms)
     typed_run_type = baseline._validate_run_type(run_type)
@@ -57,6 +58,14 @@ def _result(
         tokens_per_second=baseline._tokens_per_second(
             eval_count=eval_count,
             eval_duration_ms=eval_duration_ms,
+        ),
+        model_residency_enabled=keep_alive_applied,
+        keep_alive_value="5m" if keep_alive_applied else None,
+        keep_alive_applied=keep_alive_applied,
+        keep_alive_ineffective=baseline._keep_alive_ineffective(
+            run_type=typed_run_type,
+            keep_alive_applied=keep_alive_applied,
+            model_load_observed=model_load_observed,
         ),
         wall_ms=total_ms,
         ok=True,
@@ -200,6 +209,54 @@ class RagLatencyBaselineTests(unittest.TestCase):
         self.assertIsNone(
             baseline._tokens_per_second(eval_count=None, eval_duration_ms=100.0)
         )
+
+    def test_keep_alive_ineffective_flags_warm_reload_only(self) -> None:
+        self.assertTrue(
+            baseline._keep_alive_ineffective(
+                run_type="warm_model",
+                keep_alive_applied=True,
+                model_load_observed=True,
+            )
+        )
+        self.assertFalse(
+            baseline._keep_alive_ineffective(
+                run_type="warm_model",
+                keep_alive_applied=True,
+                model_load_observed=False,
+            )
+        )
+        self.assertIsNone(
+            baseline._keep_alive_ineffective(
+                run_type="cold_start",
+                keep_alive_applied=True,
+                model_load_observed=True,
+            )
+        )
+        self.assertIsNone(
+            baseline._keep_alive_ineffective(
+                run_type="warm_model",
+                keep_alive_applied=False,
+                model_load_observed=True,
+            )
+        )
+
+    def test_report_records_keep_alive_fields(self) -> None:
+        report = baseline.build_report(
+            [
+                _result(
+                    run_type="warm_model",
+                    load_ms=1000.0,
+                    keep_alive_applied=True,
+                )
+            ]
+        )
+
+        record = self._records(report)[0]
+
+        self.assertEqual(record["model_residency_enabled"], True)
+        self.assertEqual(record["keep_alive_value"], "5m")
+        self.assertEqual(record["keep_alive_applied"], True)
+        self.assertEqual(record["keep_alive_ineffective"], True)
 
     def test_missing_metrics_get_safe_reason(self) -> None:
         self.assertEqual(

--- a/tests/unit/test_rag_latency_baseline.py
+++ b/tests/unit/test_rag_latency_baseline.py
@@ -62,6 +62,9 @@ def _result(
         model_residency_enabled=keep_alive_applied,
         keep_alive_value="5m" if keep_alive_applied else None,
         keep_alive_applied=keep_alive_applied,
+        keep_alive_skipped_reason=(
+            None if keep_alive_applied else "disabled"
+        ),
         keep_alive_ineffective=baseline._keep_alive_ineffective(
             run_type=typed_run_type,
             keep_alive_applied=keep_alive_applied,
@@ -256,6 +259,7 @@ class RagLatencyBaselineTests(unittest.TestCase):
         self.assertEqual(record["model_residency_enabled"], True)
         self.assertEqual(record["keep_alive_value"], "5m")
         self.assertEqual(record["keep_alive_applied"], True)
+        self.assertIsNone(record["keep_alive_skipped_reason"])
         self.assertEqual(record["keep_alive_ineffective"], True)
 
     def test_missing_metrics_get_safe_reason(self) -> None:

--- a/tests/unit/test_rag_pipeline_observability.py
+++ b/tests/unit/test_rag_pipeline_observability.py
@@ -49,8 +49,9 @@ class FakeGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
-        del max_tokens
+        del max_tokens, keep_alive
         return "Resposta sintetica com citacao [obs_doc#0]."
 
 

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -10,6 +10,7 @@ from loguru import logger
 from backend.rag.collection_guard import EmbeddingDimensionMismatchError
 from backend.rag.context_packer import ContextBudgetResult, RetrievedChunk
 from backend.rag.generation_budget import GenerationBudgetConfig
+from backend.rag.model_residency import ModelResidencyConfig
 from backend.rag.pipeline import LocalRagPipeline
 from backend.rag.prompt_builder import PromptBuilder
 from backend.rag.run_trace import (
@@ -134,18 +135,21 @@ class FakeGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
-        del messages, temperature, thinking_mode, max_tokens
+        del messages, temperature, thinking_mode, max_tokens, keep_alive
         return "Resposta sintetica segura com citacao [trace_doc#0]."
 
 
 class CapturingGenerator:
     model: str
     max_tokens_seen: int | None
+    keep_alive_seen: str | None
 
     def __init__(self, model: str) -> None:
         self.model = model
         self.max_tokens_seen = None
+        self.keep_alive_seen = None
 
     async def chat(
         self,
@@ -153,9 +157,11 @@ class CapturingGenerator:
         temperature: float | None = None,
         thinking_mode: bool = False,
         max_tokens: int | None = None,
+        keep_alive: str | None = None,
     ) -> str:
         del messages, temperature, thinking_mode
         self.max_tokens_seen = max_tokens
+        self.keep_alive_seen = keep_alive
         return "Resposta sintetica com citacao [trace_doc#0]."
 
 
@@ -245,6 +251,9 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(trace.generation_budget_applied)
         self.assertIsNone(trace.generation_budget_max_tokens)
         self.assertIsNone(trace.conciseness_instruction_applied)
+        self.assertIsNone(trace.model_residency_enabled)
+        self.assertIsNone(trace.keep_alive_value)
+        self.assertIsNone(trace.keep_alive_applied)
         self.assertFalse(trace.ollama_metrics_available)
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
 
@@ -267,6 +276,9 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
             generation_budget_applied=True,
             generation_budget_max_tokens=768,
             conciseness_instruction_applied=True,
+            model_residency_enabled=True,
+            keep_alive_value="5m",
+            keep_alive_applied=True,
             prompt_build_ms=0.5,
             generation_ms=31.0,
             total_ms=35.0,
@@ -292,6 +304,9 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["generation_budget_applied"], True)
         self.assertEqual(data["generation_budget_max_tokens"], 768)
         self.assertEqual(data["conciseness_instruction_applied"], True)
+        self.assertEqual(data["model_residency_enabled"], True)
+        self.assertEqual(data["keep_alive_value"], "5m")
+        self.assertEqual(data["keep_alive_applied"], True)
         self.assertEqual(data["prompt_build_ms"], 0.5)
         self.assertEqual(data["generation_ms"], 31.0)
         self.assertEqual(data["total_ms"], 35.0)
@@ -319,6 +334,10 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
     def test_invalid_generation_budget_max_tokens_raises(self) -> None:
         with self.assertRaises(ValueError):
             _trace(generation_budget_max_tokens=0)
+
+    def test_empty_keep_alive_value_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _trace(keep_alive_value=" ")
 
     def test_total_ms_is_direct_field_not_sum_assumption(self) -> None:
         trace = _trace(
@@ -716,6 +735,66 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(generator.max_tokens_seen)
         self.assertNotIn("Responda de forma concisa", result.messages[1]["content"])
+
+    async def test_local_rag_model_residency_forwards_keep_alive_and_trace_metadata(
+        self,
+    ) -> None:
+        traces: list[dict[str, object]] = []
+        generator = CapturingGenerator("local_rag")
+
+        def sink(message: Any) -> None:
+            trace = message.record["extra"].get("trace")
+            if isinstance(trace, dict):
+                traces.append(trace)
+
+        sink_id = logger.add(sink, level="INFO")
+        try:
+            pipeline = LocalRagPipeline(
+                retriever=FakeRetriever(),
+                generator=generator,
+                prompt_builder=PromptBuilder(),
+                tracing_config=RagTracingConfig(
+                    enabled=True,
+                    log_level="INFO",
+                    collection_name="configured_collection",
+                    embedding_backend="gateway_litellm_current",
+                    embedding_model="nomic-embed-text",
+                    embedding_alias="quimera_embed",
+                    embedding_dimensions=768,
+                ).validated(),
+                model_residency_config=ModelResidencyConfig(
+                    enabled=True,
+                    keep_alive="5m",
+                ),
+            )
+            await pipeline.ask("Pergunta sintetica?")
+        finally:
+            logger.remove(sink_id)
+
+        self.assertEqual(generator.keep_alive_seen, "5m")
+        self.assertEqual(len(traces), 1)
+        trace = traces[0]
+        self.assertEqual(trace["model_residency_enabled"], True)
+        self.assertEqual(trace["keep_alive_value"], "5m")
+        self.assertEqual(trace["keep_alive_applied"], True)
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
+
+    async def test_model_residency_does_not_apply_to_non_rag_alias(self) -> None:
+        generator = CapturingGenerator("local_chat")
+        pipeline = LocalRagPipeline(
+            retriever=FakeRetriever(),
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+            tracing_config=RagTracingConfig(enabled=False).validated(),
+            model_residency_config=ModelResidencyConfig(
+                enabled=True,
+                keep_alive="5m",
+            ),
+        )
+
+        await pipeline.ask("Pergunta sintetica?")
+
+        self.assertIsNone(generator.keep_alive_seen)
 
     def test_load_rag_tracing_config_reads_yaml_defaults(self) -> None:
         config = load_rag_tracing_config()

--- a/tests/unit/test_rag_run_trace.py
+++ b/tests/unit/test_rag_run_trace.py
@@ -254,6 +254,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(trace.model_residency_enabled)
         self.assertIsNone(trace.keep_alive_value)
         self.assertIsNone(trace.keep_alive_applied)
+        self.assertIsNone(trace.keep_alive_skipped_reason)
         self.assertFalse(trace.ollama_metrics_available)
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
 
@@ -279,6 +280,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
             model_residency_enabled=True,
             keep_alive_value="5m",
             keep_alive_applied=True,
+            keep_alive_skipped_reason=None,
             prompt_build_ms=0.5,
             generation_ms=31.0,
             total_ms=35.0,
@@ -307,6 +309,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(data["model_residency_enabled"], True)
         self.assertEqual(data["keep_alive_value"], "5m")
         self.assertEqual(data["keep_alive_applied"], True)
+        self.assertNotIn("keep_alive_skipped_reason", data)
         self.assertEqual(data["prompt_build_ms"], 0.5)
         self.assertEqual(data["generation_ms"], 31.0)
         self.assertEqual(data["total_ms"], 35.0)
@@ -338,6 +341,22 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
     def test_empty_keep_alive_value_raises(self) -> None:
         with self.assertRaises(ValueError):
             _trace(keep_alive_value=" ")
+
+    def test_invalid_keep_alive_skipped_reason_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            _trace(keep_alive_skipped_reason="free_form")
+
+    def test_keep_alive_skipped_reason_serializes_safely(self) -> None:
+        data = _trace(
+            model_residency_enabled=False,
+            keep_alive_applied=False,
+            keep_alive_skipped_reason="disabled",
+        ).to_log_dict()
+
+        self.assertEqual(data["model_residency_enabled"], False)
+        self.assertEqual(data["keep_alive_applied"], False)
+        self.assertEqual(data["keep_alive_skipped_reason"], "disabled")
+        self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in data}))
 
     def test_total_ms_is_direct_field_not_sum_assumption(self) -> None:
         trace = _trace(
@@ -777,6 +796,7 @@ class RagRunTraceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(trace["model_residency_enabled"], True)
         self.assertEqual(trace["keep_alive_value"], "5m")
         self.assertEqual(trace["keep_alive_applied"], True)
+        self.assertNotIn("keep_alive_skipped_reason", trace)
         self.assertTrue(FORBIDDEN_KEYS.isdisjoint({key.lower() for key in trace}))
 
     async def test_model_residency_does_not_apply_to_non_rag_alias(self) -> None:


### PR DESCRIPTION
## G2-PR05 — Ollama keep_alive model residency for local_rag

### Escopo
- Novo módulo `backend/rag/model_residency.py` com `ModelResidencyConfig` / `ModelResidencyDecision` / `decide_model_residency()`
- `keep_alive` forwarded via `extra_body` em `GatewayChatClient.chat_completion()`
- `GeneratorProtocol.chat()` e `LocalGenerator.chat()` recebem `keep_alive: str | None`
- `LocalRagPipeline` integra `model_residency_config` com o mesmo padrão de `generation_budget_config`
- `RagRunTrace` ganha `model_residency_enabled`, `keep_alive_value`, `keep_alive_applied`
- Baseline script ganha `keep_alive_ineffective` flag para detectar warm runs com reload

### Allowlist
`"0"`, `"30s"`, `"1m"`, `"5m"`, `"10m"`, `"30m"`, `"1h"`, `"2h"`, `"6h"`, `"-1"`

### Rollback
`enabled: false` no `rag_config.yaml` — default já desabilitado.

### RCs e OBSs aplicados
- RC-1: non-regression explícita para `local_json` e `local_think`
- OBS-1: allowlist expandida com `1h`, `2h`, `6h`
- OBS-2: caveat `-1` documentado em `RAG_RUN_TRACE.md`
- OBS-3: falso positivo — `FORBIDDEN_KEYS` já estava correto

### Checklist
- [x] pytest tests/unit/ — 9/9 + 18 subtests
- [x] Sem credenciais / dados sensíveis
- [x] Sem print() — loguru only
- [x] keep_alive aplicado apenas a `local_rag`
- [x] `local_chat`, `local_json`, `local_think`, embeddings inalterados
- [x] Docs: `RAG_LATENCY_BASELINE.md`, `RAG_RUN_TRACE.md`