### PR TITLE
test(gateway): compare local_rag candidate aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs/*.jsonl
 tests/golden/reports/
 reports/gateway1_smoke/
 reports/g2_latency_baseline/
+reports/g2_alias_comparison/
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)
 *.claude_session

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -223,26 +223,26 @@ The first rule is measurement before optimization.
 | G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap for `local_rag` | ✅ Merged |
 | G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable generation budget and answer-length discipline for `local_rag` | ✅ Merged |
 | G2-PR04 | `feat/g2-warm-model-cold-start-separation` | Cold/warm/degraded latency separation and residency measurement | ✅ Merged |
-| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable Ollama keep_alive for `local_rag` model residency | 🚧 Current |
+| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable Ollama keep_alive for `local_rag` model residency | ✅ Merged |
+| G2-PR06 | `feat/g2-local-rag-alias-comparison` | Local-only local_rag candidate alias comparison harness | 🚧 Current |
 
-G2-PR05 rules:
+G2-PR06 rules:
 
-- Model residency is configured under `rag.model_residency`.
-- Default is rollback-safe: `enabled: false`.
-- `keep_alive` forwarding applies only to `local_rag`.
-- `keep_alive` must match `^-?\d+(?:s|m|h)?$`; `"0"` and `"-1"` are valid
-  operational values.
-- `"-1"` emits one safe structured warning for indefinite model residency.
-- `local_chat`, `local_json`, `local_think`, embeddings, retrieval, context
-  packing, generation budget, Qdrant, aliases, timeouts and fallback behavior
-  remain unchanged.
-- No global `OLLAMA_KEEP_ALIVE`, model preload/unload, LiteLLM provider config
-  change or warmup-on-init is introduced.
-- Trace fields are scalar only: model residency enabled, keep_alive value,
-  keep_alive applied and keep_alive skipped reason.
-- G2-PR04 baseline report can flag `keep_alive_ineffective` for warm runs that
-  still show model load after a keep_alive hint.
-- No answer text, prompts, chunks, vectors, payloads or secrets are serialized.
+- Alias comparison is opt-in via `RUN_RAG_ALIAS_COMPARISON=1`.
+- `local_rag` remains the baseline and default.
+- Candidate aliases must be semantic local LiteLLM aliases and must not be
+  concrete model names.
+- Candidate aliases must resolve to local Ollama config only; remote provider
+  prefixes are rejected.
+- The same synthetic golden question fixture is used for every alias.
+- Warmup calls are discarded from measured results.
+- Reports contain safe metadata only: alias, run type, latency, eval metrics,
+  answer length, citation flag, fallback flag and token estimate.
+- No prompt, answer, question text, chunks, vectors, payloads, headers, API
+  keys, raw exceptions or tracebacks are serialized.
+- No prompt, retrieval, Qdrant, context budget, generation budget, keep_alive,
+  default alias or provider config is changed.
+- Candidate promotion requires a separate future PR.
 
 GW-13 rules:
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,7 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-03
-**Updated by:** Codex — G2-PR05 local_rag model residency
+**Updated by:** Codex — G2-PR06 local_rag alias comparison
 
 ---
 
@@ -14,8 +14,8 @@
 **Goal:** reduce `local_rag` wall time through controlled, observable,
 rollback-safe local optimizations after the Gateway-1 proof-of-life baseline.
 
-Current branch: `feat/g2-keep-alive-model-residency`
-Current issue: `[G2-05] Tune Ollama keep_alive for local_rag model residency`
+Current branch: `feat/g2-local-rag-alias-comparison`
+Current issue: `[G2-06] Compare local_rag candidate aliases without changing defaults`
 
 Gateway-0 and Gateway-1 are complete on `main`. Gateway-2 starts from the
 measured `local_rag` latency baseline and must keep all optimizations
@@ -126,7 +126,8 @@ unavoidable, use `git push --force-with-lease`.
 | G2-PR02 | `feat/g2-local-rag-context-budget-cap` | Configurable whole-chunk context budget cap | Done / merged |
 | G2-PR03 | `feat/g2-local-rag-generation-budget` | Configurable local_rag generation budget | Done / merged |
 | G2-PR04 | `feat/g2-warm-model-cold-start-separation` | Cold/warm/degraded latency separation and model residency measurement | Done / merged |
-| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable local_rag Ollama keep_alive model residency | Current |
+| G2-PR05 | `feat/g2-keep-alive-model-residency` | Configurable local_rag Ollama keep_alive model residency | Done / merged |
+| G2-PR06 | `feat/g2-local-rag-alias-comparison` | Local-only local_rag candidate alias comparison harness | Current |
 
 GW-05a issue: <https://github.com/franciscosalido/OPENCLAW/issues/25>
 GW-05b issue: <https://github.com/franciscosalido/OPENCLAW/issues/28>
@@ -148,39 +149,32 @@ Gateway-0 sprint complete. GW-01 through GW-12 merged on `main`.
 The next sprint must start from a new explicit issue, ADR if architecture
 changes, and `git pull --ff-only origin main`.
 
-## G2-PR05 Current Work
+## G2-PR06 Current Work
 
-G2-PR05 adds a rollback-safe model residency hint for `local_rag` only.
+G2-PR06 adds an opt-in alias comparison harness for `local_rag` candidates.
 
-Configuration:
+Deliverables:
 
-```yaml
-rag:
-  model_residency:
-    enabled: false
-    apply_to_aliases:
-      - "local_rag"
-    keep_alive: "5m"
-```
+- `scripts/run_rag_alias_comparison.py`.
+- `tests/unit/test_rag_alias_comparison.py`.
+- `docs/RAG_ALIAS_COMPARISON.md`.
 
 Rules:
 
-- Default is disabled, preserving pre-PR behavior.
-- `keep_alive` is forwarded only for `local_rag` when enabled.
-- `keep_alive` is validated with `^-?\d+(?:s|m|h)?$`; examples include
-  `"0"`, `"-1"`, `"30s"`, `"1m"`, `"5m"`, `"10m"` and `"24h"`.
-- `"-1"` emits a safe structured warning because it requests indefinite model
-  residency.
-- `local_chat`, `local_json`, `local_think`, embeddings, retrieval, Qdrant,
-  prompt building, context budget, generation budget and fallback behavior
-  remain unchanged.
-- `RagRunTrace` records model residency scalar metadata and
-  `keep_alive_skipped_reason`, never answer text, prompt text, chunks, vectors,
-  payloads or secrets.
-- G2-PR04 baseline reports can flag `keep_alive_ineffective` when warm runs
-  still show model load after a keep_alive hint.
-- No global `OLLAMA_KEEP_ALIVE`, preloading, unloading or LiteLLM provider
-  config change is introduced.
+- `local_rag` remains the default and comparison baseline.
+- Candidate aliases must be semantic local LiteLLM aliases, never concrete
+  model names.
+- Candidate aliases must resolve to local Ollama config only.
+- Remote provider prefixes are rejected.
+- The same synthetic golden question fixture is used for baseline and
+  candidates.
+- Reports store `question_id`, fixture hash, alias metrics and citation flags,
+  never question text, answer text, prompt text, chunks, vectors, payloads,
+  headers, API keys or tracebacks.
+- Warmup runs are discarded and marked only in summary metadata.
+- No prompt, retrieval, Qdrant, context budget, generation budget, keep_alive,
+  alias default or provider config is changed.
+- Candidate promotion requires a separate future PR.
 
 ## GW-15 Current Work
 

--- a/docs/RAG_ALIAS_COMPARISON.md
+++ b/docs/RAG_ALIAS_COMPARISON.md
@@ -29,6 +29,11 @@ exits before running any comparison.
 - Candidate aliases must exist in the local LiteLLM config passed by
   `--litellm-config`.
 - Candidate aliases must use local Ollama config only.
+- Candidate alias `api_base` values must be literal local URLs using
+  `http://localhost:` or `http://127.0.0.1:`.
+- Environment references such as `os.environ/OLLAMA_API_BASE` are rejected by
+  this comparison script because they cannot be proven local at config-read
+  time.
 - Candidate aliases must not equal `local_rag`.
 - Concrete model names such as values containing `/` or `:` are rejected.
 - Remote provider prefixes such as `openai/`, `anthropic/`, `gemini/`,

--- a/docs/RAG_ALIAS_COMPARISON.md
+++ b/docs/RAG_ALIAS_COMPARISON.md
@@ -1,0 +1,112 @@
+# RAG Alias Comparison
+
+G2-PR06 adds an opt-in benchmark for comparing local-only RAG generation
+aliases against the current `local_rag` baseline.
+
+This is comparison infrastructure only. It does not promote a candidate alias,
+change defaults, change prompts, change retrieval, mutate Qdrant, alter context
+budget, alter generation budget, alter keep_alive behavior, or enable remote
+providers.
+
+## Command
+
+```bash
+RUN_RAG_ALIAS_COMPARISON=1 uv run python scripts/run_rag_alias_comparison.py \
+  --baseline-alias local_rag \
+  --candidate-alias local_rag_fast \
+  --output-dir /tmp/openclaw_g2_alias_comparison
+```
+
+Multiple candidates can be passed by repeating `--candidate-alias`.
+
+The script is guarded by `RUN_RAG_ALIAS_COMPARISON=1`. Without the guard it
+exits before running any comparison.
+
+## Alias Rules
+
+- `local_rag` remains the baseline and default.
+- Candidate aliases must be semantic LiteLLM aliases.
+- Candidate aliases must exist in the local LiteLLM config passed by
+  `--litellm-config`.
+- Candidate aliases must use local Ollama config only.
+- Candidate aliases must not equal `local_rag`.
+- Concrete model names such as values containing `/` or `:` are rejected.
+- Remote provider prefixes such as `openai/`, `anthropic/`, `gemini/`,
+  `azure/`, `openrouter/`, and `xai/` are rejected.
+- If a candidate alias defines `model_info.experimental`, it must be `true`.
+
+The report marks candidates as experimental. A successful result never promotes
+an alias automatically.
+
+## Question Set
+
+The comparison uses the existing synthetic golden question registry:
+
+```text
+tests/golden/questions.yaml
+```
+
+The same fixture is run for baseline and every candidate. Reports store a
+fixture hash and `question_id` only; they do not store question text.
+
+Measured runs are ordered round-robin by question:
+
+```text
+question 1 -> local_rag
+question 1 -> candidate A
+question 1 -> candidate B
+question 2 -> local_rag
+...
+```
+
+Each alias receives one warmup call before measured runs. The warmup result is
+discarded and recorded only as `warmup_discarded: true` in the summary.
+
+## Report Schema
+
+The JSONL report writes one safe row per question/alias:
+
+- `question_id`
+- `alias`
+- `alias_role`
+- `experimental`
+- `run_type`
+- `total_ms`
+- `generation_ms`
+- `prompt_eval_duration_ms`
+- `eval_duration_ms`
+- `eval_count`
+- `tokens_per_second`
+- `answer_length_chars`
+- `citation_present`
+- `fallback_applied`
+- `estimated_remote_tokens_avoided`
+
+The summary JSON includes:
+
+- `baseline_alias`
+- `candidate_aliases`
+- `question_fixture_hash`
+- `warmup_discarded`
+- `default_unchanged`
+- `results_by_alias`
+- `delta_by_candidate`
+- `citation_regression`
+- `quality_regression`
+- `hypothesis_supported`
+
+Reports never include answer text, prompt text, chunks, vectors, Qdrant
+payloads, headers, API keys, raw exceptions, tracebacks, or local paths.
+
+## Interpretation
+
+A candidate supports the G2-PR06 hypothesis only when:
+
+- `total_ms` or `generation_ms` improves materially versus `local_rag`;
+- `citation_regression` is `false`;
+- no safety violation is present;
+- the same question fixture and run type were used;
+- `local_rag` remains unchanged as the default.
+
+Promotion of a candidate alias requires a separate future PR and explicit human
+approval.

--- a/scripts/run_rag_alias_comparison.py
+++ b/scripts/run_rag_alias_comparison.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python
+"""Compare local RAG candidate aliases without changing defaults.
+
+The comparison is opt-in, local-only and report-oriented. It does not promote
+aliases, mutate Qdrant, or store prompt/question/answer/chunk/vector content in
+reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import mean
+from typing import Any
+from uuid import uuid4
+
+import yaml
+from loguru import logger
+
+from backend.gateway.routing_policy import estimate_prompt_tokens
+from scripts import run_golden_harness, run_local_agent
+from scripts.rag_ask_local import ask_local
+
+
+GUARD_ENV = "RUN_RAG_ALIAS_COMPARISON"
+DEFAULT_BASELINE_ALIAS = run_local_agent.LOCAL_RAG_ALIAS
+DEFAULT_LITELLM_CONFIG_PATH = Path("config/litellm_config.yaml")
+DEFAULT_QUESTIONS_PATH = run_golden_harness.DEFAULT_QUESTIONS_PATH
+DEFAULT_OUTPUT_DIR = Path("reports/g2_alias_comparison")
+REMOTE_PROVIDER_PREFIXES = (
+    "openai/",
+    "anthropic/",
+    "gemini/",
+    "azure/",
+    "openrouter/",
+    "xai/",
+)
+SAFE_RUN_TYPE = "warm_model"
+
+
+@dataclass(frozen=True)
+class AliasMetadata:
+    """Safe LiteLLM alias metadata for comparison validation."""
+
+    alias: str
+    provider: str
+    api_base: str
+    experimental: bool | None
+
+
+@dataclass(frozen=True)
+class AliasComparisonResult:
+    """Safe per-question/per-alias comparison result."""
+
+    question_id: str
+    alias: str
+    alias_role: str
+    experimental: bool
+    run_type: str
+    total_ms: float | None
+    generation_ms: float | None
+    prompt_eval_duration_ms: float | None
+    eval_duration_ms: float | None
+    eval_count: int | None
+    tokens_per_second: float | None
+    answer_length_chars: int
+    citation_present: bool
+    fallback_applied: bool
+    estimated_remote_tokens_avoided: int
+    error_category: str | None = None
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return an allowlisted report row without answer/question text."""
+        data: dict[str, object] = {
+            "question_id": self.question_id,
+            "alias": self.alias,
+            "alias_role": self.alias_role,
+            "experimental": self.experimental,
+            "run_type": self.run_type,
+            "answer_length_chars": self.answer_length_chars,
+            "citation_present": self.citation_present,
+            "fallback_applied": self.fallback_applied,
+            "estimated_remote_tokens_avoided": self.estimated_remote_tokens_avoided,
+        }
+        optional: dict[str, object | None] = {
+            "total_ms": self.total_ms,
+            "generation_ms": self.generation_ms,
+            "prompt_eval_duration_ms": self.prompt_eval_duration_ms,
+            "eval_duration_ms": self.eval_duration_ms,
+            "eval_count": self.eval_count,
+            "tokens_per_second": self.tokens_per_second,
+            "error_category": self.error_category,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+AliasRunner = Callable[
+    [run_golden_harness.GoldenQuestion, str, str],
+    Awaitable[AliasComparisonResult],
+]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compare local_rag against local-only candidate aliases.",
+    )
+    parser.add_argument("--baseline-alias", default=DEFAULT_BASELINE_ALIAS)
+    parser.add_argument(
+        "--candidate-alias",
+        action="append",
+        required=True,
+        help="Local semantic candidate alias. Repeat for multiple candidates.",
+    )
+    parser.add_argument(
+        "--questions",
+        default=str(DEFAULT_QUESTIONS_PATH),
+        help="Path to the golden question registry.",
+    )
+    parser.add_argument(
+        "--litellm-config",
+        default=str(DEFAULT_LITELLM_CONFIG_PATH),
+        help="Path to a local LiteLLM config containing candidate aliases.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for JSONL and summary reports.",
+    )
+    parser.add_argument(
+        "--run-type",
+        choices=("warm_model",),
+        default=SAFE_RUN_TYPE,
+        help="Comparison run type. G2-PR06 compares warm_model only.",
+    )
+    return parser.parse_args(argv)
+
+
+async def run_comparison(
+    *,
+    baseline_alias: str,
+    candidate_aliases: Sequence[str],
+    questions_path: Path | str = DEFAULT_QUESTIONS_PATH,
+    litellm_config_path: Path | str = DEFAULT_LITELLM_CONFIG_PATH,
+    output_dir: Path | str = DEFAULT_OUTPUT_DIR,
+    run_type: str = SAFE_RUN_TYPE,
+    runner: AliasRunner | None = None,
+) -> tuple[Path, Path]:
+    """Run alias comparison and write JSONL plus summary reports."""
+    if run_type != SAFE_RUN_TYPE:
+        raise ValueError("G2-PR06 alias comparison supports warm_model only")
+    alias_metadata = load_alias_metadata(litellm_config_path)
+    validated_candidates = validate_aliases(
+        baseline_alias=baseline_alias,
+        candidate_aliases=candidate_aliases,
+        alias_metadata=alias_metadata,
+    )
+    questions = run_golden_harness.load_questions(questions_path)
+    fixture_hash = question_fixture_hash(questions_path)
+    active_runner = _live_alias_result if runner is None else runner
+    aliases = [baseline_alias, *validated_candidates]
+
+    for alias in aliases:
+        await active_runner(questions[0], alias, run_type)
+
+    results: list[AliasComparisonResult] = []
+    for question in questions:
+        for alias in aliases:
+            results.append(await active_runner(question, alias, run_type))
+
+    run_id = uuid4().hex[:12]
+    timestamp = _utc_now()
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = out_dir / f"rag_alias_comparison_{run_id}.jsonl"
+    summary_path = out_dir / f"rag_alias_comparison_summary_{run_id}.json"
+    write_jsonl(jsonl_path, results)
+    write_summary(
+        summary_path,
+        baseline_alias=baseline_alias,
+        candidate_aliases=validated_candidates,
+        fixture_hash=fixture_hash,
+        run_id=run_id,
+        timestamp_utc=timestamp,
+        results=results,
+    )
+    return jsonl_path, summary_path
+
+
+async def main_async(argv: Sequence[str] | None = None) -> int:
+    """Async CLI entrypoint."""
+    args = parse_args(argv)
+    if os.environ.get(GUARD_ENV) != "1":
+        sys.stdout.write(
+            "RAG alias comparison is opt-in. "
+            "Set RUN_RAG_ALIAS_COMPARISON=1 to run.\n",
+        )
+        return 2
+    jsonl_path, summary_path = await run_comparison(
+        baseline_alias=args.baseline_alias,
+        candidate_aliases=tuple(args.candidate_alias),
+        questions_path=args.questions,
+        litellm_config_path=args.litellm_config,
+        output_dir=args.output_dir,
+        run_type=args.run_type,
+    )
+    sys.stdout.write(
+        f"OK alias_comparison_jsonl={jsonl_path} summary_json={summary_path}\n",
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(main_async(argv))
+
+
+def load_alias_metadata(config_path: Path | str) -> dict[str, AliasMetadata]:
+    """Load safe alias metadata from a LiteLLM YAML config."""
+    raw = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("LiteLLM config must be a mapping")
+    model_list = raw.get("model_list")
+    if not isinstance(model_list, list):
+        raise ValueError("LiteLLM config must contain model_list")
+    aliases: dict[str, AliasMetadata] = {}
+    for item in model_list:
+        if not isinstance(item, Mapping):
+            raise ValueError("LiteLLM model_list entries must be mappings")
+        alias = _read_required_str(item, "model_name")
+        params = item.get("litellm_params")
+        info = item.get("model_info")
+        if not isinstance(params, Mapping):
+            raise ValueError(f"Alias {alias} missing litellm_params")
+        if not isinstance(info, Mapping):
+            raise ValueError(f"Alias {alias} missing model_info")
+        aliases[alias] = AliasMetadata(
+            alias=alias,
+            provider=_read_required_str(info, "provider"),
+            api_base=_read_required_str(params, "api_base"),
+            experimental=_optional_bool(info.get("experimental")),
+        )
+    return aliases
+
+
+def validate_aliases(
+    *,
+    baseline_alias: str,
+    candidate_aliases: Sequence[str],
+    alias_metadata: Mapping[str, AliasMetadata],
+) -> tuple[str, ...]:
+    """Validate baseline and candidate aliases for local-only comparison."""
+    baseline = _validate_semantic_alias(baseline_alias)
+    if baseline != DEFAULT_BASELINE_ALIAS:
+        raise ValueError("baseline_alias must remain local_rag in G2-PR06")
+    if baseline not in alias_metadata:
+        raise ValueError("baseline alias is not defined in LiteLLM config")
+    _validate_local_alias(alias_metadata[baseline], require_experimental=False)
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for candidate_alias in candidate_aliases:
+        candidate = _validate_semantic_alias(candidate_alias)
+        if candidate == baseline:
+            raise ValueError("candidate alias cannot equal baseline alias")
+        if candidate in seen:
+            raise ValueError(f"duplicate candidate alias: {candidate}")
+        if candidate not in alias_metadata:
+            raise ValueError(f"candidate alias is not defined: {candidate}")
+        _validate_local_alias(alias_metadata[candidate], require_experimental=True)
+        candidates.append(candidate)
+        seen.add(candidate)
+    if not candidates:
+        raise ValueError("at least one candidate alias is required")
+    return tuple(candidates)
+
+
+def question_fixture_hash(path: Path | str) -> str:
+    """Return a stable hash for the golden fixture without storing text."""
+    digest = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+    return digest[:16]
+
+
+def write_jsonl(path: Path, results: Sequence[AliasComparisonResult]) -> None:
+    """Write one sanitized JSON object per result line."""
+    with path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(result.to_json_dict(), sort_keys=True) + "\n")
+
+
+def write_summary(
+    path: Path,
+    *,
+    baseline_alias: str,
+    candidate_aliases: Sequence[str],
+    fixture_hash: str,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[AliasComparisonResult],
+) -> None:
+    """Write a safe aggregate comparison summary."""
+    summary = build_summary(
+        baseline_alias=baseline_alias,
+        candidate_aliases=candidate_aliases,
+        fixture_hash=fixture_hash,
+        run_id=run_id,
+        timestamp_utc=timestamp_utc,
+        results=results,
+    )
+    path.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_summary(
+    *,
+    baseline_alias: str,
+    candidate_aliases: Sequence[str],
+    fixture_hash: str,
+    run_id: str,
+    timestamp_utc: str,
+    results: Sequence[AliasComparisonResult],
+) -> dict[str, object]:
+    """Build a safe alias comparison summary."""
+    results_by_alias = _results_by_alias(results)
+    delta_by_candidate = _delta_by_candidate(
+        baseline_alias=baseline_alias,
+        candidate_aliases=candidate_aliases,
+        results=results,
+    )
+    citation_regression = {
+        alias: _citation_regression(
+            baseline_alias=baseline_alias,
+            candidate_alias=alias,
+            results=results,
+        )
+        for alias in candidate_aliases
+    }
+    hypothesis_supported = {
+        alias: (
+            _material_latency_improvement(delta_by_candidate.get(alias, {}))
+            and citation_regression.get(alias) is False
+        )
+        for alias in candidate_aliases
+    }
+    return {
+        "run_id": run_id,
+        "timestamp_utc": timestamp_utc,
+        "question_fixture_hash": fixture_hash,
+        "baseline_alias": baseline_alias,
+        "candidate_aliases": list(candidate_aliases),
+        "warmup_discarded": True,
+        "default_unchanged": baseline_alias == DEFAULT_BASELINE_ALIAS,
+        "results_by_alias": results_by_alias,
+        "delta_by_candidate": delta_by_candidate,
+        "citation_regression": citation_regression,
+        "quality_regression": None,
+        "hypothesis_supported": hypothesis_supported,
+    }
+
+
+async def _live_alias_result(
+    question: run_golden_harness.GoldenQuestion,
+    alias: str,
+    run_type: str,
+) -> AliasComparisonResult:
+    """Run one live local RAG question for an alias and return safe metrics."""
+    traces: list[dict[str, object]] = []
+
+    def sink(message: Any) -> None:
+        trace = message.record["extra"].get("trace")
+        if isinstance(trace, dict):
+            traces.append(trace)
+
+    sink_id = logger.add(sink, level="INFO")
+    start = time.perf_counter()
+    try:
+        result = await ask_local(question=question.question, model=alias)
+    except Exception as exc:
+        return AliasComparisonResult(
+            question_id=question.question_id,
+            alias=alias,
+            alias_role=_alias_role(alias),
+            experimental=alias != DEFAULT_BASELINE_ALIAS,
+            run_type=run_type,
+            total_ms=(time.perf_counter() - start) * 1000.0,
+            generation_ms=None,
+            prompt_eval_duration_ms=None,
+            eval_duration_ms=None,
+            eval_count=None,
+            tokens_per_second=None,
+            answer_length_chars=0,
+            citation_present=False,
+            fallback_applied=False,
+            estimated_remote_tokens_avoided=estimate_prompt_tokens(question.question),
+            error_category=exc.__class__.__name__,
+        )
+    finally:
+        logger.remove(sink_id)
+    trace = traces[0] if traces else {}
+    return AliasComparisonResult(
+        question_id=question.question_id,
+        alias=alias,
+        alias_role=_alias_role(alias),
+        experimental=alias != DEFAULT_BASELINE_ALIAS,
+        run_type=run_type,
+        total_ms=_float_or_none(trace.get("total_ms")) or result.latency_ms["total_ms"],
+        generation_ms=(
+            _float_or_none(trace.get("generation_ms"))
+            or result.latency_ms["generation_ms"]
+        ),
+        prompt_eval_duration_ms=_float_or_none(
+            trace.get("ollama_prompt_eval_duration_ms")
+        ),
+        eval_duration_ms=_float_or_none(trace.get("ollama_eval_duration_ms")),
+        eval_count=_int_or_none(trace.get("ollama_eval_count")),
+        tokens_per_second=_tokens_per_second(
+            eval_count=_int_or_none(trace.get("ollama_eval_count")),
+            eval_duration_ms=_float_or_none(trace.get("ollama_eval_duration_ms")),
+        ),
+        answer_length_chars=len(result.answer),
+        citation_present=_citation_present(result.answer, result.citations),
+        fallback_applied=False,
+        estimated_remote_tokens_avoided=estimate_prompt_tokens(question.question),
+        error_category=None,
+    )
+
+
+def _results_by_alias(
+    results: Sequence[AliasComparisonResult],
+) -> dict[str, dict[str, dict[str, object]]]:
+    grouped: dict[str, dict[str, list[AliasComparisonResult]]] = {}
+    for result in results:
+        grouped.setdefault(result.alias, {}).setdefault(result.run_type, []).append(result)
+    output: dict[str, dict[str, dict[str, object]]] = {}
+    for alias, by_run_type in grouped.items():
+        output[alias] = {}
+        for run_type, items in by_run_type.items():
+            output[alias][run_type] = {
+                "count": len(items),
+                "mean_total_ms": _mean_metric(items, "total_ms"),
+                "mean_generation_ms": _mean_metric(items, "generation_ms"),
+                "mean_eval_duration_ms": _mean_metric(items, "eval_duration_ms"),
+                "mean_eval_count": _mean_metric(items, "eval_count"),
+                "mean_tokens_per_second": _mean_metric(items, "tokens_per_second"),
+                "mean_answer_length_chars": mean(
+                    item.answer_length_chars for item in items
+                ),
+                "citation_present_count": sum(
+                    1 for item in items if item.citation_present
+                ),
+                "fallback_count": sum(1 for item in items if item.fallback_applied),
+            }
+    return output
+
+
+def _delta_by_candidate(
+    *,
+    baseline_alias: str,
+    candidate_aliases: Sequence[str],
+    results: Sequence[AliasComparisonResult],
+) -> dict[str, dict[str, float | None]]:
+    baseline_total = _mean_for_alias(results, baseline_alias, "total_ms")
+    baseline_generation = _mean_for_alias(results, baseline_alias, "generation_ms")
+    deltas: dict[str, dict[str, float | None]] = {}
+    for alias in candidate_aliases:
+        candidate_total = _mean_for_alias(results, alias, "total_ms")
+        candidate_generation = _mean_for_alias(results, alias, "generation_ms")
+        deltas[alias] = {
+            "total_ms_delta_pct": _improvement_pct(baseline_total, candidate_total),
+            "generation_ms_delta_pct": _improvement_pct(
+                baseline_generation,
+                candidate_generation,
+            ),
+        }
+    return deltas
+
+
+def _citation_regression(
+    *,
+    baseline_alias: str,
+    candidate_alias: str,
+    results: Sequence[AliasComparisonResult],
+) -> bool:
+    baseline_by_question = {
+        result.question_id: result.citation_present
+        for result in results
+        if result.alias == baseline_alias
+    }
+    for result in results:
+        if result.alias != candidate_alias:
+            continue
+        if baseline_by_question.get(result.question_id) and not result.citation_present:
+            return True
+    return False
+
+
+def _material_latency_improvement(delta: Mapping[str, object]) -> bool:
+    total = delta.get("total_ms_delta_pct")
+    generation = delta.get("generation_ms_delta_pct")
+    return (
+        isinstance(total, (int, float))
+        and total >= 30.0
+        or isinstance(generation, (int, float))
+        and generation >= 30.0
+    )
+
+
+def _mean_for_alias(
+    results: Sequence[AliasComparisonResult],
+    alias: str,
+    field_name: str,
+) -> float | None:
+    return _mean_metric([result for result in results if result.alias == alias], field_name)
+
+
+def _mean_metric(
+    results: Sequence[AliasComparisonResult],
+    field_name: str,
+) -> float | None:
+    values: list[float] = []
+    for result in results:
+        raw = getattr(result, field_name)
+        if isinstance(raw, bool) or raw is None:
+            continue
+        if isinstance(raw, (int, float)):
+            values.append(float(raw))
+    if not values:
+        return None
+    return mean(values)
+
+
+def _improvement_pct(
+    baseline_value: float | None,
+    candidate_value: float | None,
+) -> float | None:
+    if baseline_value is None or candidate_value is None or baseline_value <= 0:
+        return None
+    return ((baseline_value - candidate_value) / baseline_value) * 100.0
+
+
+def _validate_local_alias(
+    metadata: AliasMetadata,
+    *,
+    require_experimental: bool,
+) -> None:
+    provider = metadata.provider.strip().lower()
+    if provider != "ollama":
+        raise ValueError(f"Alias {metadata.alias} is not a local Ollama alias")
+    if not _is_local_api_base(metadata.api_base):
+        raise ValueError(f"Alias {metadata.alias} does not use a local api_base")
+    if require_experimental and metadata.experimental is False:
+        raise ValueError(f"Candidate alias {metadata.alias} is not experimental")
+
+
+def _validate_semantic_alias(alias: str) -> str:
+    value = alias.strip()
+    if not value:
+        raise ValueError("alias cannot be empty")
+    lower = value.lower()
+    if any(lower.startswith(prefix) for prefix in REMOTE_PROVIDER_PREFIXES):
+        raise ValueError("remote provider aliases are not allowed")
+    if "/" in value or ":" in value:
+        raise ValueError("concrete model names are not allowed")
+    if not value.replace("_", "").isalnum() or not value[0].isalpha():
+        raise ValueError("alias must be a semantic local identifier")
+    return value
+
+
+def _is_local_api_base(api_base: str) -> bool:
+    return (
+        api_base.startswith("http://localhost:")
+        or api_base.startswith("http://127.0.0.1:")
+        or api_base == "os.environ/OLLAMA_API_BASE"
+    )
+
+
+def _alias_role(alias: str) -> str:
+    return "baseline" if alias == DEFAULT_BASELINE_ALIAS else "candidate"
+
+
+def _citation_present(answer: str, citations: Sequence[str]) -> bool:
+    return any(citation in answer for citation in citations)
+
+
+def _tokens_per_second(
+    *,
+    eval_count: int | None,
+    eval_duration_ms: float | None,
+) -> float | None:
+    if eval_count is None or eval_duration_ms is None or eval_duration_ms <= 0:
+        return None
+    return float(eval_count) / (eval_duration_ms / 1000.0)
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _read_required_str(data: Mapping[object, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_bool(value: object) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError("experimental must be boolean when present")
+    return value
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_rag_alias_comparison.py
+++ b/scripts/run_rag_alias_comparison.py
@@ -584,7 +584,6 @@ def _is_local_api_base(api_base: str) -> bool:
     return (
         api_base.startswith("http://localhost:")
         or api_base.startswith("http://127.0.0.1:")
-        or api_base == "os.environ/OLLAMA_API_BASE"
     )
 
 

--- a/tests/unit/test_rag_alias_comparison.py
+++ b/tests/unit/test_rag_alias_comparison.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+from scripts import run_golden_harness, run_rag_alias_comparison
+
+
+FORBIDDEN_REPORT_KEYS = {
+    "answer",
+    "question",
+    "prompt",
+    "chunks",
+    "chunk",
+    "vectors",
+    "vector",
+    "payload",
+    "qdrant_payload",
+    "api_key",
+    "authorization",
+    "secret",
+    "password",
+    "headers",
+    "raw_response",
+    "raw_exception",
+    "exception_message",
+    "traceback",
+}
+
+
+def _config_file(
+    tmp_path: Path,
+    *,
+    candidate_alias: str = "local_rag_fast",
+    candidate_provider: str = "ollama",
+    candidate_api_base: str = "http://localhost:11434",
+    experimental_line: str = "      experimental: true\n",
+) -> Path:
+    path = tmp_path / "litellm_config.yaml"
+    path.write_text(
+        f"""
+model_list:
+  - model_name: local_rag
+    litellm_params:
+      model: ollama_chat/safe-baseline
+      api_base: http://localhost:11434
+      timeout: 60
+    model_info:
+      provider: ollama
+      purpose: baseline
+      thinking_mode: false
+  - model_name: {candidate_alias}
+    litellm_params:
+      model: ollama_chat/safe-candidate
+      api_base: {candidate_api_base}
+      timeout: 60
+    model_info:
+      provider: {candidate_provider}
+      purpose: candidate
+{experimental_line}      thinking_mode: false
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+async def _fake_runner(
+    question: run_golden_harness.GoldenQuestion,
+    alias: str,
+    run_type: str,
+) -> run_rag_alias_comparison.AliasComparisonResult:
+    is_candidate = alias != "local_rag"
+    return run_rag_alias_comparison.AliasComparisonResult(
+        question_id=question.question_id,
+        alias=alias,
+        alias_role="candidate" if is_candidate else "baseline",
+        experimental=is_candidate,
+        run_type=run_type,
+        total_ms=600.0 if is_candidate else 1000.0,
+        generation_ms=300.0 if is_candidate else 600.0,
+        prompt_eval_duration_ms=100.0,
+        eval_duration_ms=250.0 if is_candidate else 500.0,
+        eval_count=50,
+        tokens_per_second=200.0,
+        answer_length_chars=120,
+        citation_present=True,
+        fallback_applied=False,
+        estimated_remote_tokens_avoided=42,
+    )
+
+
+class RagAliasComparisonTests(unittest.IsolatedAsyncioTestCase):
+    async def test_guard_env_required(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            exit_code = await run_rag_alias_comparison.main_async(
+                ["--candidate-alias", "local_rag_fast"],
+            )
+
+        self.assertEqual(exit_code, 2)
+
+    def test_alias_validation_accepts_local_semantic_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(Path(tmpdir))
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        candidates = run_rag_alias_comparison.validate_aliases(
+            baseline_alias="local_rag",
+            candidate_aliases=("local_rag_fast",),
+            alias_metadata=aliases,
+        )
+
+        self.assertEqual(candidates, ("local_rag_fast",))
+
+    def test_alias_validation_rejects_remote_provider_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(
+                Path(tmpdir),
+                candidate_provider="openai",
+                candidate_api_base="https://api.openai.com/v1",
+            )
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        with self.assertRaises(ValueError):
+            run_rag_alias_comparison.validate_aliases(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag_fast",),
+                alias_metadata=aliases,
+            )
+
+    def test_alias_validation_rejects_concrete_model_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(Path(tmpdir))
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        for candidate in ("ollama_chat/qwen3:14b", "qwen3:14b"):
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(ValueError):
+                    run_rag_alias_comparison.validate_aliases(
+                        baseline_alias="local_rag",
+                        candidate_aliases=(candidate,),
+                        alias_metadata=aliases,
+                    )
+
+    def test_candidate_cannot_equal_baseline_and_baseline_remains_local_rag(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(Path(tmpdir))
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        with self.assertRaises(ValueError):
+            run_rag_alias_comparison.validate_aliases(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag",),
+                alias_metadata=aliases,
+            )
+        with self.assertRaises(ValueError):
+            run_rag_alias_comparison.validate_aliases(
+                baseline_alias="local_rag_fast",
+                candidate_aliases=("local_rag",),
+                alias_metadata=aliases,
+            )
+
+    def test_candidate_experimental_false_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(
+                Path(tmpdir),
+                experimental_line="      experimental: false\n",
+            )
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        with self.assertRaises(ValueError):
+            run_rag_alias_comparison.validate_aliases(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag_fast",),
+                alias_metadata=aliases,
+            )
+
+    async def test_run_comparison_records_fixture_hash_and_writes_safe_reports(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = Path(tmpdir)
+            config_path = _config_file(temp_path)
+            jsonl_path, summary_path = await run_rag_alias_comparison.run_comparison(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag_fast",),
+                litellm_config_path=config_path,
+                output_dir=temp_path,
+                runner=_fake_runner,
+            )
+
+            lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+        questions = run_golden_harness.load_questions()
+        self.assertEqual(len(lines), len(questions) * 2)
+        self.assertEqual(
+            summary["question_fixture_hash"],
+            run_rag_alias_comparison.question_fixture_hash(
+                run_rag_alias_comparison.DEFAULT_QUESTIONS_PATH,
+            ),
+        )
+        for line in lines:
+            row = json.loads(line)
+            self.assertTrue(FORBIDDEN_REPORT_KEYS.isdisjoint({key.lower() for key in row}))
+            self.assertIn(row["alias_role"], {"baseline", "candidate"})
+            self.assertEqual(row["run_type"], "warm_model")
+
+    async def test_summary_separates_aliases_run_type_and_deltas(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = Path(tmpdir)
+            config_path = _config_file(temp_path)
+            _jsonl_path, summary_path = await run_rag_alias_comparison.run_comparison(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag_fast",),
+                litellm_config_path=config_path,
+                output_dir=temp_path,
+                runner=_fake_runner,
+            )
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(summary["baseline_alias"], "local_rag")
+        self.assertEqual(summary["candidate_aliases"], ["local_rag_fast"])
+        self.assertIn("warm_model", summary["results_by_alias"]["local_rag"])
+        self.assertIn("warm_model", summary["results_by_alias"]["local_rag_fast"])
+        self.assertEqual(
+            summary["delta_by_candidate"]["local_rag_fast"]["total_ms_delta_pct"],
+            40.0,
+        )
+        self.assertEqual(summary["citation_regression"]["local_rag_fast"], False)
+        self.assertEqual(summary["hypothesis_supported"]["local_rag_fast"], True)
+
+    def test_citation_regression_marks_hypothesis_unsupported(self) -> None:
+        baseline = run_rag_alias_comparison.AliasComparisonResult(
+            question_id="q1",
+            alias="local_rag",
+            alias_role="baseline",
+            experimental=False,
+            run_type="warm_model",
+            total_ms=1000.0,
+            generation_ms=600.0,
+            prompt_eval_duration_ms=None,
+            eval_duration_ms=None,
+            eval_count=None,
+            tokens_per_second=None,
+            answer_length_chars=100,
+            citation_present=True,
+            fallback_applied=False,
+            estimated_remote_tokens_avoided=10,
+        )
+        candidate = run_rag_alias_comparison.AliasComparisonResult(
+            question_id="q1",
+            alias="local_rag_fast",
+            alias_role="candidate",
+            experimental=True,
+            run_type="warm_model",
+            total_ms=500.0,
+            generation_ms=300.0,
+            prompt_eval_duration_ms=None,
+            eval_duration_ms=None,
+            eval_count=None,
+            tokens_per_second=None,
+            answer_length_chars=90,
+            citation_present=False,
+            fallback_applied=False,
+            estimated_remote_tokens_avoided=10,
+        )
+
+        summary = run_rag_alias_comparison.build_summary(
+            baseline_alias="local_rag",
+            candidate_aliases=("local_rag_fast",),
+            fixture_hash="hash",
+            run_id="run",
+            timestamp_utc="2026-05-04T00:00:00Z",
+            results=(baseline, candidate),
+        )
+
+        citation_regression = cast(
+            "dict[str, bool]",
+            summary["citation_regression"],
+        )
+        hypothesis_supported = cast(
+            "dict[str, bool]",
+            summary["hypothesis_supported"],
+        )
+
+        self.assertEqual(citation_regression["local_rag_fast"], True)
+        self.assertEqual(hypothesis_supported["local_rag_fast"], False)
+
+    def test_warmup_is_discarded_from_measured_results(self) -> None:
+        questions = run_golden_harness.load_questions()
+        self.assertEqual(
+            len(questions) * 2,
+            len([1 for question in questions for _alias in ("local_rag", "fast")]),
+        )
+        summary = run_rag_alias_comparison.build_summary(
+            baseline_alias="local_rag",
+            candidate_aliases=("local_rag_fast",),
+            fixture_hash="hash",
+            run_id="run",
+            timestamp_utc="2026-05-04T00:00:00Z",
+            results=(),
+        )
+        self.assertEqual(summary["warmup_discarded"], True)
+
+    def test_default_alias_constant_is_not_changed(self) -> None:
+        self.assertEqual(run_rag_alias_comparison.DEFAULT_BASELINE_ALIAS, "local_rag")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_alias_comparison.py
+++ b/tests/unit/test_rag_alias_comparison.py
@@ -132,6 +132,21 @@ class RagAliasComparisonTests(unittest.IsolatedAsyncioTestCase):
                 alias_metadata=aliases,
             )
 
+    def test_alias_validation_rejects_env_api_base_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _config_file(
+                Path(tmpdir),
+                candidate_api_base="os.environ/OLLAMA_API_BASE",
+            )
+            aliases = run_rag_alias_comparison.load_alias_metadata(path)
+
+        with self.assertRaises(ValueError):
+            run_rag_alias_comparison.validate_aliases(
+                baseline_alias="local_rag",
+                candidate_aliases=("local_rag_fast",),
+                alias_metadata=aliases,
+            )
+
     def test_alias_validation_rejects_concrete_model_name(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = _config_file(Path(tmpdir))


### PR DESCRIPTION
## Summary
- Add opt-in local RAG alias comparison harness
- Validate candidate aliases as local semantic LiteLLM aliases
- Reject remote provider prefixes, concrete model names, and env api_base references
- Emit sanitized JSONL and summary reports with latency/citation deltas

## Safety
- local_rag default unchanged
- No remote providers or concrete model names
- No Qdrant mutation
- No answer/question/prompt/chunk/vector/secret serialization

## Validation
- uv run python scripts/run_rag_alias_comparison.py --help
- uv run pytest tests/unit/test_rag_alias_comparison.py -v
- uv run pytest -v
- uv run mypy --strict .
- uv run pyright
- uv run pytest tests/smoke/ -v

## RC-1
- Reject os.environ/OLLAMA_API_BASE in alias comparison api_base validation because env refs cannot be proven local at config-read time.