### PR TITLE
test(agent): add golden questions citation contract

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,11 @@
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],
       "description": "Context7 — up-to-date library docs for any framework/package"
+    },
+    "code-sandbox-mcp": {
+      "command": "/Users/fas/.local/share/code-sandbox-mcp/code-sandbox-mcp",
+      "args": [],
+      "description": "Automata Labs — isolated Docker sandbox for safe code execution"
     }
   }
 }

--- a/backend/agent0/__init__.py
+++ b/backend/agent0/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-0 contracts and offline evaluation helpers."""

--- a/backend/agent0/golden_questions.py
+++ b/backend/agent0/golden_questions.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import re
 import time
-import json
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -22,6 +22,7 @@ from backend.ingestion.bootstrap import (
 )
 from backend.ingestion.commit_store import DUAL_CORPUS_COLLECTIONS
 from backend.ingestion.manifest import CorpusDocument, load_manifest
+from backend.ingestion.report import assert_report_is_sanitized
 from backend.rag.collection_guard import assert_collection_namespace
 
 
@@ -56,10 +57,12 @@ GOLDEN_FORBIDDEN_KEYS = frozenset(
         "api_key",
         "authorization",
         "headers",
+        "secret",
         "raw_exception",
         "exception_message",
         "traceback",
         "absolute_paths",
+        "local_absolute_path",
         "username",
     }
 )
@@ -303,14 +306,11 @@ def run_golden_questions(
 
     if mode != "dry_run" and retriever is None:
         raise ValueError("smoke mode requires an explicit retriever")
-    questions = tuple(
-        question
-        for question in load_all_golden_questions(
-            internal_path=internal_path,
-            financial_path=financial_path,
-        )
-        if question.enabled
+    loaded_questions = load_all_golden_questions(
+        internal_path=internal_path,
+        financial_path=financial_path,
     )
+    questions = tuple(question for question in loaded_questions if question.enabled)
     documents_by_corpus = load_corpus_documents()
     validate_expected_doc_ids(questions, documents_by_corpus)
     active_retriever = retriever or FakeRetriever(documents_by_corpus)
@@ -351,17 +351,22 @@ def run_golden_questions(
             }
         )
 
-    total = len(questions)
-    failed = total - passed
+    total_questions = len(loaded_questions)
+    evaluated_questions = len(questions)
+    skipped_questions = total_questions - evaluated_questions
+    failed = evaluated_questions - passed
     report = {
         "run_id": uuid4().hex,
         "timestamp_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         "mode": mode,
-        "total_questions": total,
+        "total_questions": total_questions,
+        "enabled_questions": evaluated_questions,
+        "skipped_questions": skipped_questions,
+        "evaluated_questions": evaluated_questions,
         "passed": passed,
         "failed": failed,
-        "coverage": _ratio(passed + failed, total),
-        "citation_hit_rate": _ratio(passed, total),
+        "coverage": _ratio(evaluated_questions, total_questions),
+        "citation_hit_rate": _ratio(passed, evaluated_questions),
         "p50_query_ms": round(median(durations), 3) if durations else 0.0,
         "p95_query_ms": round(_percentile(durations, 95), 3) if durations else 0.0,
         "per_question": per_question,
@@ -383,6 +388,7 @@ def write_golden_report(path: Path | str, report: Mapping[str, Any]) -> None:
 def assert_golden_report_sanitized(report: Mapping[str, Any]) -> None:
     """Raise if the report contains forbidden content-bearing keys."""
 
+    assert_report_is_sanitized(dict(report))
     forbidden_hits = _forbidden_key_hits(report)
     if forbidden_hits:
         raise ValueError(f"golden report contains forbidden keys: {forbidden_hits}")

--- a/backend/agent0/golden_questions.py
+++ b/backend/agent0/golden_questions.py
@@ -1,0 +1,438 @@
+"""Golden question and citation contracts for Agent-0 evidence checks."""
+
+from __future__ import annotations
+
+import re
+import time
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import median
+from typing import Any, Literal, Protocol, Self, cast
+from uuid import uuid4
+
+import yaml
+from pydantic import BaseModel, ConfigDict, StrictBool, field_validator, model_validator
+
+from backend.ingestion.bootstrap import (
+    CorpusName,
+    manifest_path_for_corpus,
+)
+from backend.ingestion.commit_store import DUAL_CORPUS_COLLECTIONS
+from backend.ingestion.manifest import CorpusDocument, load_manifest
+from backend.rag.collection_guard import assert_collection_namespace
+
+
+CollectionName = Literal["openclaw_internal", "openclaw_financial"]
+GoldenMode = Literal["dry_run", "smoke"]
+Language = Literal["pt-BR"]
+RetrievalMode = Literal["fake", "qdrant"]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INTERNAL_QUESTIONS_PATH = REPO_ROOT / "tests" / "golden" / "internal_questions.yaml"
+DEFAULT_FINANCIAL_QUESTIONS_PATH = (
+    REPO_ROOT / "tests" / "golden" / "financial_questions.yaml"
+)
+GOLDEN_FORBIDDEN_KEYS = frozenset(
+    {
+        "answer",
+        "text",
+        "query",
+        "question",
+        "raw_text",
+        "normalized_text",
+        "chunk",
+        "chunks",
+        "chunk_text",
+        "retrieved_text",
+        "vector",
+        "vectors",
+        "embedding",
+        "embeddings",
+        "payload",
+        "prompt",
+        "api_key",
+        "authorization",
+        "headers",
+        "raw_exception",
+        "exception_message",
+        "traceback",
+        "absolute_paths",
+        "username",
+    }
+)
+_QUESTION_ID_RE = re.compile(r"^[if]q-\d{3}$")
+
+
+class GoldenQuestion(BaseModel):
+    """One citation-only golden question contract."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    question_id: str
+    text: str
+    expected_corpus: CorpusName
+    expected_collection: CollectionName
+    expected_doc_ids: tuple[str, ...]
+    domain: str
+    language: Language
+    enabled: StrictBool
+
+    @field_validator("question_id")
+    @classmethod
+    def _validate_question_id(cls, value: str) -> str:
+        clean_value = value.strip()
+        if not _QUESTION_ID_RE.fullmatch(clean_value):
+            raise ValueError("question_id must match ^[if]q-\\d{3}$")
+        return clean_value
+
+    @field_validator("text", "domain")
+    @classmethod
+    def _validate_non_empty(cls, value: str) -> str:
+        clean_value = value.strip()
+        if not clean_value:
+            raise ValueError("value cannot be empty")
+        return clean_value
+
+    @field_validator("expected_doc_ids")
+    @classmethod
+    def _validate_expected_doc_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        clean_values = tuple(doc_id.strip() for doc_id in value)
+        if not clean_values or any(not doc_id for doc_id in clean_values):
+            raise ValueError("expected_doc_ids must be non-empty")
+        return clean_values
+
+    @model_validator(mode="after")
+    def _validate_prefix_routes_to_namespace(self) -> Self:
+        if self.question_id.startswith("iq-"):
+            if (
+                self.expected_corpus != "internal"
+                or self.expected_collection != "openclaw_internal"
+            ):
+                raise ValueError("iq-* questions must route to internal corpus")
+        if self.question_id.startswith("fq-"):
+            if (
+                self.expected_corpus != "financial"
+                or self.expected_collection != "openclaw_financial"
+            ):
+                raise ValueError("fq-* questions must route to financial corpus")
+        return self
+
+
+class GoldenManifest(BaseModel):
+    """Manifest for one golden-question corpus namespace."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    questions: tuple[GoldenQuestion, ...]
+
+    @model_validator(mode="after")
+    def _validate_unique_question_ids(self) -> Self:
+        question_ids = [question.question_id for question in self.questions]
+        duplicates = {
+            question_id
+            for question_id in question_ids
+            if question_ids.count(question_id) > 1
+        }
+        if duplicates:
+            raise ValueError("question_id values must be unique")
+        return self
+
+
+@dataclass(frozen=True)
+class Citation:
+    """Safe retrieval evidence metadata for one cited source."""
+
+    question_id: str
+    source_id: str
+    doc_id: str
+    chunk_id: str
+    corpus: CorpusName
+    collection_name: CollectionName
+    origin_path: str
+    score: float
+    rank: int
+    retrieval_mode: RetrievalMode
+    chunk_index: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.question_id.strip():
+            raise ValueError("question_id cannot be empty")
+        if not self.source_id.strip():
+            raise ValueError("source_id cannot be empty")
+        if not self.doc_id.strip():
+            raise ValueError("doc_id cannot be empty")
+        if not self.chunk_id.strip():
+            raise ValueError("chunk_id cannot be empty")
+        if not self.origin_path.strip():
+            raise ValueError("origin_path cannot be empty")
+        if self.rank <= 0:
+            raise ValueError("rank must be greater than zero")
+        if self.score < 0:
+            raise ValueError("score cannot be negative")
+
+
+class GoldenRetriever(Protocol):
+    """Retriever interface for citation-only golden question checks."""
+
+    def retrieve(
+        self,
+        question: GoldenQuestion,
+        *,
+        collection: str,
+    ) -> tuple[Citation, ...]:
+        """Return safe citation metadata without answer or text content."""
+        ...
+
+
+@dataclass(frozen=True)
+class GoldenHarnessResult:
+    """Result object returned by the golden question harness."""
+
+    report: dict[str, Any]
+
+
+class FakeRetriever:
+    """Offline retriever that returns manifest-backed citation metadata."""
+
+    def __init__(
+        self,
+        documents_by_corpus: Mapping[CorpusName, Mapping[str, CorpusDocument]],
+    ) -> None:
+        self._documents_by_corpus = documents_by_corpus
+        self.calls: list[tuple[str, str]] = []
+
+    def retrieve(
+        self,
+        question: GoldenQuestion,
+        *,
+        collection: str,
+    ) -> tuple[Citation, ...]:
+        self.calls.append((question.question_id, collection))
+        documents = self._documents_by_corpus[question.expected_corpus]
+        citations: list[Citation] = []
+        for rank, doc_id in enumerate(question.expected_doc_ids, start=1):
+            document = documents[doc_id]
+            citations.append(
+                Citation(
+                    question_id=question.question_id,
+                    source_id=document.source_id,
+                    doc_id=document.doc_id,
+                    chunk_id=f"{document.doc_id}:0",
+                    corpus=question.expected_corpus,
+                    collection_name=cast(CollectionName, collection),
+                    origin_path=document.origin_path,
+                    score=1.0,
+                    rank=rank,
+                    retrieval_mode="fake",
+                    chunk_index=0,
+                )
+            )
+        return tuple(citations)
+
+
+def load_golden_manifest(path: Path | str) -> GoldenManifest:
+    """Load one golden question manifest with yaml.safe_load."""
+
+    raw_manifest = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw_manifest, Mapping):
+        raise ValueError("golden manifest must be a YAML mapping")
+    return GoldenManifest.model_validate(raw_manifest)
+
+
+def load_all_golden_questions(
+    *,
+    internal_path: Path | str = DEFAULT_INTERNAL_QUESTIONS_PATH,
+    financial_path: Path | str = DEFAULT_FINANCIAL_QUESTIONS_PATH,
+) -> tuple[GoldenQuestion, ...]:
+    """Load internal and financial golden manifests without a super-manifest."""
+
+    manifests = (
+        load_golden_manifest(internal_path),
+        load_golden_manifest(financial_path),
+    )
+    questions = tuple(
+        question for manifest in manifests for question in manifest.questions
+    )
+    question_ids = [question.question_id for question in questions]
+    duplicates = {
+        question_id for question_id in question_ids if question_ids.count(question_id) > 1
+    }
+    if duplicates:
+        raise ValueError("question_id values must be unique across golden manifests")
+    return questions
+
+
+def load_corpus_documents() -> dict[CorpusName, dict[str, CorpusDocument]]:
+    """Load A0-PR02 corpus manifests for cross-manifest validation."""
+
+    documents_by_corpus: dict[CorpusName, dict[str, CorpusDocument]] = {}
+    for corpus in ("internal", "financial"):
+        manifest = load_manifest(manifest_path_for_corpus(corpus))
+        documents_by_corpus[corpus] = {
+            document.doc_id: document for document in manifest.documents
+        }
+    return documents_by_corpus
+
+
+def validate_expected_doc_ids(
+    questions: Sequence[GoldenQuestion],
+    documents_by_corpus: Mapping[CorpusName, Mapping[str, CorpusDocument]],
+) -> None:
+    """Validate every expected doc id against its A0-PR02 corpus manifest."""
+
+    for question in questions:
+        documents = documents_by_corpus[question.expected_corpus]
+        for doc_id in question.expected_doc_ids:
+            if doc_id not in documents:
+                raise ValueError(
+                    f"question_id={question.question_id} references missing doc_id={doc_id}"
+                )
+
+
+def run_golden_questions(
+    *,
+    mode: GoldenMode = "dry_run",
+    retriever: GoldenRetriever | None = None,
+    internal_path: Path | str = DEFAULT_INTERNAL_QUESTIONS_PATH,
+    financial_path: Path | str = DEFAULT_FINANCIAL_QUESTIONS_PATH,
+) -> GoldenHarnessResult:
+    """Run citation-only golden question validation."""
+
+    if mode != "dry_run" and retriever is None:
+        raise ValueError("smoke mode requires an explicit retriever")
+    questions = tuple(
+        question
+        for question in load_all_golden_questions(
+            internal_path=internal_path,
+            financial_path=financial_path,
+        )
+        if question.enabled
+    )
+    documents_by_corpus = load_corpus_documents()
+    validate_expected_doc_ids(questions, documents_by_corpus)
+    active_retriever = retriever or FakeRetriever(documents_by_corpus)
+
+    per_question: list[dict[str, Any]] = []
+    durations: list[float] = []
+    passed = 0
+    for question in questions:
+        started_at = time.perf_counter()
+        collection = assert_collection_namespace(
+            question.expected_collection,
+            DUAL_CORPUS_COLLECTIONS,
+        )
+        citations = active_retriever.retrieve(question, collection=collection)
+        latency_ms = round((time.perf_counter() - started_at) * 1000, 3)
+        durations.append(latency_ms)
+        matched_doc_ids = tuple(
+            citation.doc_id
+            for citation in citations
+            if citation.doc_id in question.expected_doc_ids
+            and citation.collection_name == question.expected_collection
+            and citation.corpus == question.expected_corpus
+        )
+        citation_present = bool(matched_doc_ids)
+        if citation_present:
+            passed += 1
+        per_question.append(
+            {
+                "question_id": question.question_id,
+                "expected_corpus": question.expected_corpus,
+                "expected_collection": question.expected_collection,
+                "expected_doc_ids": list(question.expected_doc_ids),
+                "citation_present": citation_present,
+                "matched_doc_ids": list(matched_doc_ids),
+                "latency_ms": latency_ms,
+                "status": "passed" if citation_present else "failed",
+                "failure_reason": None if citation_present else "expected_citation_missing",
+            }
+        )
+
+    total = len(questions)
+    failed = total - passed
+    report = {
+        "run_id": uuid4().hex,
+        "timestamp_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "mode": mode,
+        "total_questions": total,
+        "passed": passed,
+        "failed": failed,
+        "coverage": _ratio(passed + failed, total),
+        "citation_hit_rate": _ratio(passed, total),
+        "p50_query_ms": round(median(durations), 3) if durations else 0.0,
+        "p95_query_ms": round(_percentile(durations, 95), 3) if durations else 0.0,
+        "per_question": per_question,
+    }
+    assert_golden_report_sanitized(report)
+    return GoldenHarnessResult(report=report)
+
+
+def write_golden_report(path: Path | str, report: Mapping[str, Any]) -> None:
+    """Write a sanitized golden question report."""
+
+    assert_golden_report_sanitized(report)
+    Path(path).write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def assert_golden_report_sanitized(report: Mapping[str, Any]) -> None:
+    """Raise if the report contains forbidden content-bearing keys."""
+
+    forbidden_hits = _forbidden_key_hits(report)
+    if forbidden_hits:
+        raise ValueError(f"golden report contains forbidden keys: {forbidden_hits}")
+
+
+def citation_field_names() -> frozenset[str]:
+    """Return Citation field names for contract tests."""
+
+    return frozenset(asdict(_sample_citation()).keys())
+
+
+def _sample_citation() -> Citation:
+    return Citation(
+        question_id="iq-001",
+        source_id="source",
+        doc_id="doc",
+        chunk_id="doc:0",
+        corpus="internal",
+        collection_name="openclaw_internal",
+        origin_path="docs/source.md",
+        score=1.0,
+        rank=1,
+        retrieval_mode="fake",
+    )
+
+
+def _forbidden_key_hits(value: object, path: str = "$") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key)
+            next_path = f"{path}.{key_text}"
+            if key_text in GOLDEN_FORBIDDEN_KEYS:
+                hits.append(next_path)
+            hits.extend(_forbidden_key_hits(nested, next_path))
+    elif isinstance(value, list | tuple):
+        for index, nested in enumerate(value):
+            hits.extend(_forbidden_key_hits(nested, f"{path}[{index}]"))
+    return hits
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 3)
+
+
+def _percentile(values: Sequence[float], percentile: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((percentile / 100) * (len(ordered) - 1))))
+    return ordered[index]

--- a/data/corpus/financial/docs/valuation_crescimento_sintetico.md
+++ b/data/corpus/financial/docs/valuation_crescimento_sintetico.md
@@ -4,5 +4,9 @@ Este texto sintetico apresenta crescimento como premissa de valuation em termos
 conceituais. As taxas e cenarios sao ficticios e nao apontam para companhias ou
 ativos reais.
 
+Em um exemplo educacional, EBITDA pode ser tratado como lucro operacional antes
+de juros, impostos, depreciacao e amortizacao. O calculo aqui e apenas
+conceitual e nao usa dados reais.
+
 A ingestao deve registrar dominio financeiro, hashes e metricas, mas nunca
 texto extraido no relatorio.

--- a/data/corpus/financial/manifest.yaml
+++ b/data/corpus/financial/manifest.yaml
@@ -90,7 +90,7 @@ documents:
     curation_status: approved
     ingestion_policy: financial
     enabled: true
-    expected_hash: b06b4bb6f5fb232a0167372b5e99516d779ed5f92da0b4f2ab07f64329d54807
+    expected_hash: a05f67b4e1ed44f5dcdc3ff1d0b07c03dbb767d95446555bf8d09158773954c2
   - source_id: financial-val-capital-001
     doc_id: financial_valuation_custo_capital
     origin_path: docs/valuation_custo_capital_sintetico.md

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -262,7 +262,8 @@ data/corpus/manifest.yaml
 | PR | Branch | Scope | Status |
 |---|---|---|---|
 | A0-PR01 | `feat/agent0-ingestion` | Controlled verify-only corpus ingestion pipeline | ✅ Complete |
-| A0-PR02 | `feat/agent0-dual-corpus-bootstrap` | Bootstrap internal and financial corpora into isolated Qdrant collections | 🚧 Current |
+| A0-PR02 | `feat/agent0-dual-corpus-bootstrap` | Bootstrap internal and financial corpora into isolated Qdrant collections | ✅ Complete |
+| A0-PR03 | `feat/agent0-golden-questions` | Six golden questions and frozen citation contract | 🚧 Current |
 
 A0-PR01 rules:
 
@@ -296,6 +297,23 @@ A0-PR02 rules:
 - Idempotence uses document hashes, not collection existence or semantic dedup.
 - Query dry-run p95 is offline only: fake embed/search planning, no Qdrant and
   no LLM answer generation.
+
+A0-PR03 rules:
+
+- Golden questions are split by namespace:
+  `tests/golden/internal_questions.yaml` and
+  `tests/golden/financial_questions.yaml`.
+- There is no golden question super-manifest.
+- `iq-*` questions must route to `internal` / `openclaw_internal`.
+- `fq-*` questions must route to `financial` / `openclaw_financial`.
+- Expected doc ids are validated against A0-PR02 corpus manifests at harness
+  startup.
+- `Citation` is a frozen metadata-only dataclass.
+- `scripts/run_golden_questions.py` dry-run is offline and uses a fake retriever.
+- Smoke mode is opt-in via `RUN_GOLDEN_SMOKE=1` and does not generate answers.
+- Reports contain IDs, expected collections, matched doc ids and latency only;
+  never answer text, question text, chunks, vectors, embeddings, payloads,
+  prompts, secrets, raw exceptions, tracebacks, absolute paths or usernames.
 
 G2-PR06 rules:
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,28 +4,31 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-05-06
-**Updated by:** Codex — A0-PR02 dual corpus bootstrap
+**Last updated:** 2026-05-07
+**Updated by:** Codex — A0-PR03 golden questions citation contract
 
 ---
 
-## Active Sprint: Agent-0 / Dual Corpus Bootstrap
+## Active Sprint: Agent-0 / Golden Questions Citation Contract
 
-**Goal:** bootstrap internal and financial Agent-0 corpora into isolated,
-closed Qdrant collection namespaces.
+**Goal:** add six citation-only Agent-0 golden questions, a frozen `Citation`
+contract, an offline dry-run harness and a sanitized report proving expected
+source evidence by collection.
 
-Current branch: `feat/agent0-dual-corpus-bootstrap`
-Current issue: `[A0-PR02] Bootstrap internal and financial corpora into isolated Qdrant collections`
+Current branch: `feat/agent0-golden-questions`
+Current issue: `[A0-PR03] Add golden questions citation contract`
 
-A0-PR02 starts after A0-PR01. It keeps A0 ingestion local-first and extends the
-pipeline to two independent corpus roots and two mapped Qdrant collections:
+A0-PR03 starts after A0-PR02. It validates retrieval evidence and citation
+metadata only; it must not generate answers.
 
 ```text
-data/corpus/internal/manifest.yaml
-  -> openclaw_internal
-
-data/corpus/financial/manifest.yaml
-  -> openclaw_financial
+tests/golden/internal_questions.yaml
+tests/golden/financial_questions.yaml
+  -> GoldenQuestion schema
+  -> A0-PR02 corpus manifest doc-id validation
+  -> FakeRetriever dry-run
+  -> frozen Citation metadata
+  -> sanitized report
 ```
 
 Current runtime path:
@@ -80,39 +83,35 @@ Hard constraints remain:
 - No `openclaw_knowledge` mutation in verify-only.
 - No Qdrant mutation unless `--commit` is explicit and a future writer is wired.
 - No arbitrary collection override for dual corpus bootstrap.
+- No answer generation in A0-PR03 golden question harness.
+- No LLM-as-judge.
+- No Qdrant mutation or live Qdrant requirement in A0-PR03 unit tests.
 - No final local merge into `main`; GitHub PR approval is the integration path.
 
-## A0-PR02 Current Work
+## A0-PR03 Current Work
 
-A0-PR02 adds controlled dual-corpus bootstrap primitives:
+A0-PR03 adds citation-only golden question primitives:
 
-- `data/corpus/internal/manifest.yaml` and versioned internal document copies.
-- `data/corpus/financial/manifest.yaml` with 3 synthetic docs each for
-  `macroeconomia`, `renda_fixa` and `valuation`.
-- Closed mapping: `internal -> openclaw_internal`,
-  `financial -> openclaw_financial`.
-- `scripts/bootstrap_corpus.py --corpus internal|financial`.
-- `backend/ingestion/bootstrap.py` wrapping A0-PR01 ingestion without
-  duplicating parsing, sanitization or chunking.
-- `backend/ingestion/commit_store.py` for mockable Qdrant commit behavior.
-- `CollectionGuard.assert_collection_namespace(...)` for closed namespace
-  validation.
-- `docs/AGENT0_DUAL_CORPUS_BOOTSTRAP.md`.
+- `tests/golden/internal_questions.yaml` with `iq-001` through `iq-003`.
+- `tests/golden/financial_questions.yaml` with `fq-001` through `fq-003`.
+- `backend/agent0/golden_questions.py` with frozen Pydantic question models,
+  frozen `Citation`, `GoldenRetriever` protocol and offline harness logic.
+- `scripts/run_golden_questions.py --dry-run`.
+- `docs/AGENT0_GOLDEN_QUESTIONS.md`.
 
 Rules:
 
-- Verify-only is the default and never mutates Qdrant.
-- Commit mode writes only to the mapped collection for the selected corpus.
-- `openclaw_knowledge`, arbitrary names and empty collection names are rejected.
-- Financial docs must use `ingestion_policy: financial` and declare
-  `financial_domain`.
-- Internal docs must use `ingestion_policy: internal` and no `financial_domain`.
-- Idempotence is document-hash based; collection existence alone never skips all
-  docs.
-- Query dry-run p95 is offline, uses fake embed/search planning and never
-  generates LLM answers.
-- Reports remain sanitized and contain no text, chunks, vectors, embeddings,
-  payloads, prompts, answers, secrets, headers, raw exceptions or tracebacks.
+- Dry-run is default and uses `FakeRetriever`; no Qdrant, Ollama, LiteLLM or LLM
+  answer generation.
+- Smoke mode is guarded by `RUN_GOLDEN_SMOKE=1`.
+- Internal questions route only to `openclaw_internal`.
+- Financial questions route only to `openclaw_financial`.
+- Expected doc ids must exist in A0-PR02 corpus manifests.
+- Success is citation evidence only: expected doc id, expected corpus and
+  expected collection.
+- Reports remain sanitized and contain no answer, question text, chunks, vectors,
+  embeddings, payloads, prompts, secrets, headers, raw exceptions, tracebacks,
+  absolute paths or usernames.
 
 ---
 

--- a/docs/AGENT0_GOLDEN_QUESTIONS.md
+++ b/docs/AGENT0_GOLDEN_QUESTIONS.md
@@ -91,7 +91,9 @@ RUN_GOLDEN_SMOKE=1 uv run python scripts/run_golden_questions.py --smoke
 
 A0-PR03 does not wire a live retriever. Future smoke work may add a real
 retriever, but it must still avoid answer generation and preserve the sanitized
-report contract.
+report contract. In this PR, `--smoke` exits with code `2` even when
+`RUN_GOLDEN_SMOKE=1` is present because the live retriever is intentionally not
+wired yet.
 
 ## Report Schema
 
@@ -101,6 +103,9 @@ The report contains:
 - `timestamp_utc`
 - `mode`
 - `total_questions`
+- `enabled_questions`
+- `skipped_questions`
+- `evaluated_questions`
 - `passed`
 - `failed`
 - `coverage`
@@ -108,6 +113,10 @@ The report contains:
 - `p50_query_ms`
 - `p95_query_ms`
 - `per_question`
+
+`coverage` is the executed-question coverage: enabled/evaluated questions
+divided by total loaded questions. It is separate from `citation_hit_rate`,
+which is passed citation checks divided by evaluated questions.
 
 Per-question rows contain only:
 

--- a/docs/AGENT0_GOLDEN_QUESTIONS.md
+++ b/docs/AGENT0_GOLDEN_QUESTIONS.md
@@ -1,0 +1,127 @@
+# Agent-0 Golden Questions
+
+## Purpose
+
+A0-PR03 adds six citation-only golden questions for Agent-0. The harness checks
+whether retrieval evidence cites the expected document from the expected
+dual-corpus collection. It does not generate answers and does not judge answer
+quality.
+
+This PR depends on A0-PR02 bootstrap contracts:
+
+- internal corpus -> `openclaw_internal`
+- financial corpus -> `openclaw_financial`
+
+## Question Manifests
+
+Golden questions live in two independent manifests:
+
+- `tests/golden/internal_questions.yaml`
+- `tests/golden/financial_questions.yaml`
+
+There is no super-manifest.
+
+Internal questions:
+
+| ID | Question | Expected Doc |
+|---|---|---|
+| `iq-001` | `qual o estado atual do GW-07?` | `internal_current_state` |
+| `iq-002` | `qual o ultimo alias canonico de embeddings?` | `internal_decisions` |
+| `iq-003` | `quais aliases tem timeout maior que 60s?` | `internal_claude_contract` |
+
+Financial questions:
+
+| ID | Question | Expected Doc |
+|---|---|---|
+| `fq-001` | `o que e duration de renda fixa?` | `financial_renda_fixa_curva` |
+| `fq-002` | `como calcular o EBITDA?` | `financial_valuation_crescimento` |
+| `fq-003` | `como a Selic afeta a inflacao?` | `financial_macro_ciclo_juros` |
+
+Expected document IDs are validated against the A0-PR02 corpus manifests at
+harness startup. Missing IDs raise `ValueError`; there is no silent warning.
+
+## Routing
+
+Question IDs define the namespace contract:
+
+- `iq-*` must route to `internal` and `openclaw_internal`.
+- `fq-*` must route to `financial` and `openclaw_financial`.
+
+The harness validates the expected collection through
+`assert_collection_namespace(...)` before retrieval. `openclaw_knowledge` is not
+allowed.
+
+## Citation Contract
+
+`Citation` is a frozen dataclass with only safe retrieval metadata:
+
+- `question_id`
+- `source_id`
+- `doc_id`
+- `chunk_id`
+- `corpus`
+- `collection_name`
+- `origin_path`
+- `score`
+- `rank`
+- `retrieval_mode`
+- optional `chunk_index`
+
+It never includes answer text, question text, chunk text, vectors, embeddings,
+payloads or prompts.
+
+## Dry-Run Mode
+
+Dry-run is the default:
+
+```bash
+uv run python scripts/run_golden_questions.py --dry-run --report-out /tmp/openclaw_golden_questions.json
+```
+
+Dry-run uses a fake retriever backed by the corpus manifests. It performs no
+Qdrant calls, no Ollama calls, no LiteLLM calls and no LLM generation.
+
+## Smoke Mode
+
+Smoke mode is opt-in only:
+
+```bash
+RUN_GOLDEN_SMOKE=1 uv run python scripts/run_golden_questions.py --smoke
+```
+
+A0-PR03 does not wire a live retriever. Future smoke work may add a real
+retriever, but it must still avoid answer generation and preserve the sanitized
+report contract.
+
+## Report Schema
+
+The report contains:
+
+- `run_id`
+- `timestamp_utc`
+- `mode`
+- `total_questions`
+- `passed`
+- `failed`
+- `coverage`
+- `citation_hit_rate`
+- `p50_query_ms`
+- `p95_query_ms`
+- `per_question`
+
+Per-question rows contain only:
+
+- `question_id`
+- `expected_corpus`
+- `expected_collection`
+- `expected_doc_ids`
+- `citation_present`
+- `matched_doc_ids`
+- `latency_ms`
+- `status`
+- `failure_reason`
+
+Forbidden report keys include answer, text, query, question, raw text,
+normalized text, chunks, chunk text, retrieved text, vectors, embeddings,
+payloads, prompts, API keys, authorization headers, raw exceptions, tracebacks,
+absolute paths and usernames.

--- a/scripts/run_golden_questions.py
+++ b/scripts/run_golden_questions.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""Run Agent-0 golden question citation checks without answer generation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from backend.agent0.golden_questions import (
+    GoldenMode,
+    run_golden_questions,
+    write_golden_report,
+)
+
+
+SMOKE_GUARD_ENV = "RUN_GOLDEN_SMOKE"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the golden questions CLI parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Validate Agent-0 golden question citations without answers.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run offline with fake retrieval. This is the default.",
+    )
+    mode.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run opt-in smoke mode guarded by RUN_GOLDEN_SMOKE=1.",
+    )
+    parser.add_argument(
+        "--report-out",
+        type=Path,
+        default=None,
+        help="Optional sanitized JSON report path.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the golden questions harness."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    mode: GoldenMode = "smoke" if args.smoke else "dry_run"
+    if mode == "smoke" and os.environ.get(SMOKE_GUARD_ENV) != "1":
+        sys.stderr.write("Smoke mode requires RUN_GOLDEN_SMOKE=1.\n")
+        return 2
+    if mode == "smoke":
+        sys.stderr.write("Smoke retriever is not wired in A0-PR03.\n")
+        return 2
+
+    result = run_golden_questions(mode=mode)
+    rendered = json.dumps(result.report, indent=2, sort_keys=True) + "\n"
+    if args.report_out is not None:
+        write_golden_report(args.report_out, result.report)
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -3,6 +3,15 @@
 This directory contains the stable synthetic question registry for the Agent-0
 golden benchmark harness.
 
+A0-PR03 uses only the split citation manifests:
+
+- `internal_questions.yaml`
+- `financial_questions.yaml`
+
+The pre-existing `questions.yaml` file belongs to the older Gateway golden
+question harness and uses a different schema. It is not an A0-PR03
+super-manifest and is not loaded by `scripts/run_golden_questions.py`.
+
 Reports are written to `tests/golden/reports/` and are intentionally ignored by
 Git. Do not commit generated reports unless a future baseline-update issue
 explicitly authorizes it.

--- a/tests/golden/financial_questions.yaml
+++ b/tests/golden/financial_questions.yaml
@@ -1,0 +1,28 @@
+questions:
+  - question_id: fq-001
+    text: o que e duration de renda fixa?
+    expected_corpus: financial
+    expected_collection: openclaw_financial
+    expected_doc_ids:
+      - financial_renda_fixa_curva
+    domain: renda_fixa
+    language: pt-BR
+    enabled: true
+  - question_id: fq-002
+    text: como calcular o EBITDA?
+    expected_corpus: financial
+    expected_collection: openclaw_financial
+    expected_doc_ids:
+      - financial_valuation_crescimento
+    domain: valuation
+    language: pt-BR
+    enabled: true
+  - question_id: fq-003
+    text: como a Selic afeta a inflacao?
+    expected_corpus: financial
+    expected_collection: openclaw_financial
+    expected_doc_ids:
+      - financial_macro_ciclo_juros
+    domain: macroeconomia
+    language: pt-BR
+    enabled: true

--- a/tests/golden/internal_questions.yaml
+++ b/tests/golden/internal_questions.yaml
@@ -1,0 +1,28 @@
+questions:
+  - question_id: iq-001
+    text: qual o estado atual do GW-07?
+    expected_corpus: internal
+    expected_collection: openclaw_internal
+    expected_doc_ids:
+      - internal_current_state
+    domain: internal
+    language: pt-BR
+    enabled: true
+  - question_id: iq-002
+    text: qual o ultimo alias canonico de embeddings?
+    expected_corpus: internal
+    expected_collection: openclaw_internal
+    expected_doc_ids:
+      - internal_decisions
+    domain: internal
+    language: pt-BR
+    enabled: true
+  - question_id: iq-003
+    text: quais aliases tem timeout maior que 60s?
+    expected_corpus: internal
+    expected_collection: openclaw_internal
+    expected_doc_ids:
+      - internal_claude_contract
+    domain: internal
+    language: pt-BR
+    enabled: true

--- a/tests/unit/test_citation_contract.py
+++ b/tests/unit/test_citation_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError, fields
+
+from backend.agent0.golden_questions import Citation
+
+
+class CitationContractTests(unittest.TestCase):
+    def test_citation_dataclass_is_frozen(self) -> None:
+        citation = _citation()
+
+        with self.assertRaises(FrozenInstanceError):
+            citation.doc_id = "other"  # type: ignore[misc]
+
+    def test_citation_has_all_required_fields(self) -> None:
+        field_names = {field.name for field in fields(Citation)}
+
+        self.assertEqual(
+            field_names,
+            {
+                "question_id",
+                "source_id",
+                "doc_id",
+                "chunk_id",
+                "corpus",
+                "collection_name",
+                "origin_path",
+                "score",
+                "rank",
+                "retrieval_mode",
+                "chunk_index",
+            },
+        )
+
+    def test_citation_has_no_content_fields(self) -> None:
+        field_names = {field.name for field in fields(Citation)}
+
+        self.assertTrue(
+            {
+                "answer",
+                "text",
+                "raw_text",
+                "chunk_text",
+                "vector",
+                "embedding",
+                "payload",
+                "prompt",
+            }.isdisjoint(field_names)
+        )
+
+
+def _citation() -> Citation:
+    return Citation(
+        question_id="iq-001",
+        source_id="internal-current-state-001",
+        doc_id="internal_current_state",
+        chunk_id="internal_current_state:0",
+        corpus="internal",
+        collection_name="openclaw_internal",
+        origin_path="docs/current_state.md",
+        score=1.0,
+        rank=1,
+        retrieval_mode="fake",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_golden_question_harness.py
+++ b/tests/unit/test_golden_question_harness.py
@@ -136,10 +136,58 @@ class GoldenQuestionHarnessTests(unittest.TestCase):
         passing = run_golden_questions(retriever=TrackingRetriever())
         failing = run_golden_questions(retriever=EmptyRetriever())
 
+        self.assertEqual(passing.report["total_questions"], 6)
+        self.assertEqual(passing.report["enabled_questions"], 6)
+        self.assertEqual(passing.report["skipped_questions"], 0)
+        self.assertEqual(passing.report["evaluated_questions"], 6)
         self.assertEqual(passing.report["coverage"], 1.0)
         self.assertEqual(passing.report["citation_hit_rate"], 1.0)
         self.assertEqual(failing.report["coverage"], 1.0)
         self.assertEqual(failing.report["citation_hit_rate"], 0.0)
+
+    def test_coverage_tracks_enabled_questions_not_pass_rate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            internal_path = Path(tmpdir) / "internal_questions.yaml"
+            financial_path = Path(tmpdir) / "financial_questions.yaml"
+            internal_path.write_text(
+                """
+questions:
+  - question_id: iq-001
+    text: qual o estado atual do GW-07?
+    expected_corpus: internal
+    expected_collection: openclaw_internal
+    expected_doc_ids:
+      - internal_current_state
+    domain: internal
+    language: pt-BR
+    enabled: true
+  - question_id: iq-004
+    text: pergunta interna desabilitada
+    expected_corpus: internal
+    expected_collection: openclaw_internal
+    expected_doc_ids:
+      - internal_current_state
+    domain: internal
+    language: pt-BR
+    enabled: false
+""".lstrip(),
+                encoding="utf-8",
+            )
+            financial_path.write_text("questions: []\n", encoding="utf-8")
+
+            result = run_golden_questions(
+                retriever=TrackingRetriever(),
+                internal_path=internal_path,
+                financial_path=financial_path,
+            )
+
+        self.assertEqual(result.report["total_questions"], 2)
+        self.assertEqual(result.report["enabled_questions"], 1)
+        self.assertEqual(result.report["skipped_questions"], 1)
+        self.assertEqual(result.report["evaluated_questions"], 1)
+        self.assertEqual(result.report["coverage"], 0.5)
+        self.assertEqual(result.report["citation_hit_rate"], 1.0)
+        self.assertEqual(len(_per_question(result.report)), 1)
 
     def test_p50_and_p95_query_latency_computed(self) -> None:
         result = run_golden_questions()
@@ -160,6 +208,12 @@ class GoldenQuestionHarnessTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(report["total_questions"], 6)
         assert_golden_report_sanitized(report)
+
+    def test_sanitizer_rejects_ingestion_forbidden_keys_too(self) -> None:
+        with self.assertRaises(ValueError):
+            assert_golden_report_sanitized({"secret": "redacted"})
+        with self.assertRaises(ValueError):
+            assert_golden_report_sanitized({"local_absolute_path": "/tmp/example"})
 
     def test_smoke_requires_guard_env(self) -> None:
         self.assertEqual(golden_script.main(["--smoke"]), 2)

--- a/tests/unit/test_golden_question_harness.py
+++ b/tests/unit/test_golden_question_harness.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+
+from backend.agent0.golden_questions import (
+    Citation,
+    GOLDEN_FORBIDDEN_KEYS,
+    GoldenQuestion,
+    assert_golden_report_sanitized,
+    run_golden_questions,
+)
+from scripts import run_golden_questions as golden_script
+
+
+class EmptyRetriever:
+    def retrieve(
+        self,
+        question: GoldenQuestion,
+        *,
+        collection: str,
+    ) -> tuple[Citation, ...]:
+        return ()
+
+
+class WrongDocRetriever:
+    def retrieve(
+        self,
+        question: GoldenQuestion,
+        *,
+        collection: str,
+    ) -> tuple[Citation, ...]:
+        return (
+            Citation(
+                question_id=question.question_id,
+                source_id="wrong-source",
+                doc_id="wrong_doc",
+                chunk_id="wrong_doc:0",
+                corpus=question.expected_corpus,
+                collection_name=question.expected_collection,
+                origin_path="docs/wrong.md",
+                score=0.1,
+                rank=1,
+                retrieval_mode="fake",
+            ),
+        )
+
+
+class TrackingRetriever:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def retrieve(
+        self,
+        question: GoldenQuestion,
+        *,
+        collection: str,
+    ) -> tuple[Citation, ...]:
+        self.calls.append((question.question_id, collection))
+        return (
+            Citation(
+                question_id=question.question_id,
+                source_id="source",
+                doc_id=question.expected_doc_ids[0],
+                chunk_id=f"{question.expected_doc_ids[0]}:0",
+                corpus=question.expected_corpus,
+                collection_name=question.expected_collection,
+                origin_path="docs/source.md",
+                score=1.0,
+                rank=1,
+                retrieval_mode="fake",
+            ),
+        )
+
+
+class GoldenQuestionHarnessTests(unittest.TestCase):
+    def test_dry_run_uses_fake_retriever_and_passes_all_questions(self) -> None:
+        result = run_golden_questions()
+
+        self.assertEqual(result.report["mode"], "dry_run")
+        self.assertEqual(result.report["total_questions"], 6)
+        self.assertEqual(result.report["passed"], 6)
+        self.assertEqual(result.report["failed"], 0)
+
+    def test_custom_retriever_receives_mapped_collections(self) -> None:
+        retriever = TrackingRetriever()
+
+        run_golden_questions(retriever=retriever)
+
+        self.assertEqual(len(retriever.calls), 6)
+        self.assertIn(("iq-001", "openclaw_internal"), retriever.calls)
+        self.assertIn(("fq-001", "openclaw_financial"), retriever.calls)
+
+    def test_dry_run_does_not_generate_answer(self) -> None:
+        result = run_golden_questions()
+
+        self.assertNotIn("answer", result.report)
+        self.assertTrue(_forbidden_keys_absent(result.report, {"answer", "prompt"}))
+
+    def test_dry_run_report_sanitized(self) -> None:
+        result = run_golden_questions()
+
+        assert_golden_report_sanitized(result.report)
+
+    def test_report_has_no_forbidden_keys(self) -> None:
+        result = run_golden_questions()
+
+        self.assertTrue(_forbidden_keys_absent(result.report, GOLDEN_FORBIDDEN_KEYS))
+
+    def test_citation_present_true_when_expected_doc_recovered(self) -> None:
+        result = run_golden_questions(retriever=TrackingRetriever())
+
+        self.assertTrue(
+            all(
+                question["citation_present"]
+                for question in _per_question(result.report)
+            )
+        )
+
+    def test_citation_present_false_when_expected_doc_absent(self) -> None:
+        result = run_golden_questions(retriever=WrongDocRetriever())
+
+        self.assertEqual(result.report["passed"], 0)
+        self.assertEqual(result.report["failed"], 6)
+        self.assertTrue(
+            all(
+                not question["citation_present"]
+                for question in _per_question(result.report)
+            )
+        )
+
+    def test_coverage_and_citation_hit_rate_computed_correctly(self) -> None:
+        passing = run_golden_questions(retriever=TrackingRetriever())
+        failing = run_golden_questions(retriever=EmptyRetriever())
+
+        self.assertEqual(passing.report["coverage"], 1.0)
+        self.assertEqual(passing.report["citation_hit_rate"], 1.0)
+        self.assertEqual(failing.report["coverage"], 1.0)
+        self.assertEqual(failing.report["citation_hit_rate"], 0.0)
+
+    def test_p50_and_p95_query_latency_computed(self) -> None:
+        result = run_golden_questions()
+
+        self.assertIsInstance(result.report["p50_query_ms"], float)
+        self.assertIsInstance(result.report["p95_query_ms"], float)
+        self.assertGreaterEqual(result.report["p50_query_ms"], 0.0)
+        self.assertGreaterEqual(result.report["p95_query_ms"], 0.0)
+
+    def test_cli_dry_run_writes_sanitized_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "golden.json"
+            exit_code = golden_script.main(
+                ["--dry-run", "--report-out", str(report_path)]
+            )
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(report["total_questions"], 6)
+        assert_golden_report_sanitized(report)
+
+    def test_smoke_requires_guard_env(self) -> None:
+        self.assertEqual(golden_script.main(["--smoke"]), 2)
+
+
+def _per_question(report: dict[str, object]) -> Sequence[dict[str, object]]:
+    value = report["per_question"]
+    if not isinstance(value, list):
+        raise TypeError("per_question must be a list")
+    return value
+
+
+def _forbidden_keys_absent(value: object, forbidden: set[str] | frozenset[str]) -> bool:
+    if isinstance(value, dict):
+        return all(
+            key not in forbidden and _forbidden_keys_absent(nested, forbidden)
+            for key, nested in value.items()
+        )
+    if isinstance(value, list):
+        return all(_forbidden_keys_absent(item, forbidden) for item in value)
+    return True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_golden_questions.py
+++ b/tests/unit/test_golden_questions.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from backend.agent0.golden_questions import (
+    DEFAULT_FINANCIAL_QUESTIONS_PATH,
+    DEFAULT_INTERNAL_QUESTIONS_PATH,
+    GoldenManifest,
+    GoldenQuestion,
+    load_all_golden_questions,
+    load_corpus_documents,
+    load_golden_manifest,
+    validate_expected_doc_ids,
+)
+
+
+class GoldenQuestionManifestTests(unittest.TestCase):
+    def test_internal_manifest_loads(self) -> None:
+        manifest = load_golden_manifest(DEFAULT_INTERNAL_QUESTIONS_PATH)
+
+        self.assertEqual(len(manifest.questions), 3)
+        self.assertTrue(
+            all(question.question_id.startswith("iq-") for question in manifest.questions)
+        )
+        self.assertTrue(
+            all(question.expected_corpus == "internal" for question in manifest.questions)
+        )
+        self.assertTrue(
+            all(
+                question.expected_collection == "openclaw_internal"
+                for question in manifest.questions
+            )
+        )
+
+    def test_financial_manifest_loads(self) -> None:
+        manifest = load_golden_manifest(DEFAULT_FINANCIAL_QUESTIONS_PATH)
+
+        self.assertEqual(len(manifest.questions), 3)
+        self.assertTrue(
+            all(question.question_id.startswith("fq-") for question in manifest.questions)
+        )
+        self.assertTrue(
+            all(question.expected_corpus == "financial" for question in manifest.questions)
+        )
+        self.assertTrue(
+            all(
+                question.expected_collection == "openclaw_financial"
+                for question in manifest.questions
+            )
+        )
+
+    def test_question_id_format_enforced(self) -> None:
+        with self.assertRaises(ValidationError):
+            GoldenQuestion.model_validate({**_question(), "question_id": "bad-id"})
+
+    def test_enabled_must_be_boolean(self) -> None:
+        with self.assertRaises(ValidationError):
+            GoldenQuestion.model_validate({**_question(), "enabled": "true"})
+
+    def test_question_id_uniqueness_enforced(self) -> None:
+        with self.assertRaises(ValidationError):
+            GoldenManifest.model_validate(
+                {"questions": [_question(), _question()]},
+            )
+
+    def test_iq_cannot_point_to_financial_collection(self) -> None:
+        with self.assertRaises(ValidationError):
+            GoldenQuestion.model_validate(
+                {
+                    **_question(),
+                    "expected_corpus": "financial",
+                    "expected_collection": "openclaw_financial",
+                }
+            )
+
+    def test_fq_cannot_point_to_internal_collection(self) -> None:
+        with self.assertRaises(ValidationError):
+            GoldenQuestion.model_validate(
+                {
+                    **_question(question_id="fq-001"),
+                    "expected_corpus": "internal",
+                    "expected_collection": "openclaw_internal",
+                }
+            )
+
+    def test_expected_doc_ids_exist_in_corresponding_corpus_manifest(self) -> None:
+        questions = load_all_golden_questions()
+        documents = load_corpus_documents()
+
+        validate_expected_doc_ids(questions, documents)
+
+    def test_missing_expected_doc_id_raises_clear_error(self) -> None:
+        question = GoldenQuestion.model_validate(
+            {**_question(), "expected_doc_ids": ["missing_doc"]}
+        )
+
+        with self.assertRaisesRegex(ValueError, "question_id=iq-001.*missing_doc"):
+            validate_expected_doc_ids([question], load_corpus_documents())
+
+    def test_cross_manifest_question_ids_are_unique(self) -> None:
+        questions = load_all_golden_questions()
+        question_ids = [question.question_id for question in questions]
+
+        self.assertEqual(len(question_ids), 6)
+        self.assertEqual(len(question_ids), len(set(question_ids)))
+
+    def test_duplicate_question_id_across_manifests_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            internal_path = Path(tmpdir) / "internal.yaml"
+            financial_path = Path(tmpdir) / "financial.yaml"
+            internal_path.write_text(
+                "questions:\n"
+                "  - question_id: iq-001\n"
+                "    text: uma pergunta\n"
+                "    expected_corpus: internal\n"
+                "    expected_collection: openclaw_internal\n"
+                "    expected_doc_ids: [internal_current_state]\n"
+                "    domain: internal\n"
+                "    language: pt-BR\n"
+                "    enabled: true\n",
+                encoding="utf-8",
+            )
+            financial_path.write_text(
+                "questions:\n"
+                "  - question_id: iq-001\n"
+                "    text: outra pergunta\n"
+                "    expected_corpus: internal\n"
+                "    expected_collection: openclaw_internal\n"
+                "    expected_doc_ids: [internal_decisions]\n"
+                "    domain: internal\n"
+                "    language: pt-BR\n"
+                "    enabled: true\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_all_golden_questions(
+                    internal_path=internal_path,
+                    financial_path=financial_path,
+                )
+
+
+def _question(question_id: str = "iq-001") -> dict[str, object]:
+    return {
+        "question_id": question_id,
+        "text": "qual o estado atual do GW-07?",
+        "expected_corpus": "internal",
+        "expected_collection": "openclaw_internal",
+        "expected_doc_ids": ["internal_current_state"],
+        "domain": "internal",
+        "language": "pt-BR",
+        "enabled": True,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add six Agent-0 golden questions split across internal and financial manifests.
- Add frozen Citation contract plus offline dry-run harness with sanitized reports.
- Enforce corpus/collection routing and expected doc validation against A0-PR02 manifests.
- Tighten RC coverage semantics, sanitizer defense-in-depth, Gateway golden README scope, and EBITDA synthetic doc alignment.
- Include Claude MCP settings needed by the cowork review environment.

## Validation
- git diff --check
- uv run python --version # Python 3.12.13
- uv run python scripts/run_golden_questions.py --help
- uv run python scripts/run_golden_questions.py --dry-run --report-out /tmp/openclaw_golden_questions.json
- uv run pytest tests/unit/test_golden_questions.py tests/unit/test_golden_question_harness.py tests/unit/test_citation_contract.py tests/unit/test_dual_corpus_manifests.py -v
- uv run pytest -v # 524 passed, 7 skipped, 190 subtests passed
- uv run mypy --strict .
- uv run pyright
- uv run pytest tests/smoke/ -v # 5 passed, 7 skipped

## Notes
- No answer generation, no LLM-as-judge, no Qdrant mutation, no openclaw_knowledge use.
- Smoke mode remains opt-in and intentionally exits 2 in PR03 because no live retriever is wired yet.
