### PR TITLE
feat(agent): add deterministic domain routing

### DIFF
--- a/backend/agent0/domain_classifier.py
+++ b/backend/agent0/domain_classifier.py
@@ -1,0 +1,186 @@
+"""Deterministic Agent-0 domain classifier.
+
+This module intentionally uses only local string and regex rules. It must not
+import model clients, embedders, retrievers or vector stores.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Literal
+
+
+DomainName = Literal["internal", "macroeconomia", "renda_fixa", "valuation", "unknown"]
+CorpusName = Literal["internal", "financial", "none"]
+CollectionName = Literal["openclaw_internal", "openclaw_financial", "none"]
+
+
+@dataclass(frozen=True)
+class DomainClassification:
+    """Safe metadata returned by the deterministic classifier."""
+
+    domain: DomainName
+    corpus: CorpusName
+    collection_name: CollectionName
+    reason_code: str
+    matched_rule: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.reason_code.strip():
+            raise ValueError("reason_code cannot be empty")
+        if self.matched_rule is not None and not self.matched_rule.strip():
+            raise ValueError("matched_rule cannot be empty")
+
+
+_DOMAIN_COLLECTIONS: dict[DomainName, tuple[CorpusName, CollectionName]] = {
+    "internal": ("internal", "openclaw_internal"),
+    "macroeconomia": ("financial", "openclaw_financial"),
+    "renda_fixa": ("financial", "openclaw_financial"),
+    "valuation": ("financial", "openclaw_financial"),
+    "unknown": ("none", "none"),
+}
+
+_KEYWORD_RULES: tuple[tuple[DomainName, str, tuple[str, ...]], ...] = (
+    (
+        "internal",
+        "keyword_internal",
+        (
+            "gw-07",
+            "gw07",
+            "gateway",
+            "alias",
+            "aliases",
+            "claude",
+            "current_state",
+            "decisions",
+            "timeout",
+        ),
+    ),
+    (
+        "macroeconomia",
+        "keyword_selic",
+        (
+            "selic",
+            "inflacao",
+            "cambio",
+            "juros",
+            "ipca",
+            "macroeconomia",
+        ),
+    ),
+    (
+        "renda_fixa",
+        "keyword_duration",
+        (
+            "duration",
+            "renda fixa",
+            "prefixado",
+            "pos-fixado",
+            "credito privado",
+            "curva de juros",
+        ),
+    ),
+    (
+        "valuation",
+        "keyword_ebitda",
+        (
+            "valuation",
+            "ebitda",
+            "fluxo de caixa",
+            "multiplo",
+            "margem de seguranca",
+        ),
+    ),
+)
+
+_REGEX_RULES: tuple[tuple[DomainName, str, re.Pattern[str]], ...] = (
+    ("internal", "regex_gateway_id", re.compile(r"\bgw-?\d+\b")),
+    ("macroeconomia", "regex_macro_index", re.compile(r"\b(ipca|selic)\b")),
+    ("renda_fixa", "regex_duration", re.compile(r"\bduration\b")),
+    ("valuation", "regex_ebitda", re.compile(r"\bebitda\b")),
+)
+
+
+def classify_domain(query: str, question_id: str | None = None) -> DomainClassification:
+    """Classify a query into an Agent-0 corpus domain with no model calls."""
+
+    clean_query = _normalize_query(query)
+    clean_question_id = question_id.strip().lower() if question_id else None
+
+    if clean_question_id:
+        prefix_classification = _classify_by_question_prefix(clean_question_id)
+        if prefix_classification is not None:
+            domain_hint = _classify_by_rules(clean_query)
+            if domain_hint.domain != "unknown":
+                return domain_hint
+            return prefix_classification
+
+    return _classify_by_rules(clean_query)
+
+
+def _classify_by_question_prefix(question_id: str) -> DomainClassification | None:
+    if question_id.startswith("iq-"):
+        return _classification(
+            "internal",
+            reason_code="question_id_internal",
+            matched_rule="iq-*",
+        )
+    if question_id.startswith("fq-"):
+        return DomainClassification(
+            domain="unknown",
+            corpus="financial",
+            collection_name="openclaw_financial",
+            reason_code="question_id_financial",
+            matched_rule="fq-*",
+        )
+    return None
+
+
+def _classify_by_rules(clean_query: str) -> DomainClassification:
+    for domain, reason_code, keywords in _KEYWORD_RULES:
+        for keyword in keywords:
+            if keyword in clean_query:
+                return _classification(
+                    domain,
+                    reason_code=reason_code,
+                    matched_rule=keyword,
+                )
+
+    for domain, reason_code, pattern in _REGEX_RULES:
+        match = pattern.search(clean_query)
+        if match is not None:
+            return _classification(
+                domain,
+                reason_code=reason_code,
+                matched_rule=pattern.pattern,
+            )
+
+    return _classification("unknown", reason_code="no_domain_match")
+
+
+def _classification(
+    domain: DomainName,
+    *,
+    reason_code: str,
+    matched_rule: str | None = None,
+) -> DomainClassification:
+    corpus, collection_name = _DOMAIN_COLLECTIONS[domain]
+    return DomainClassification(
+        domain=domain,
+        corpus=corpus,
+        collection_name=collection_name,
+        reason_code=reason_code,
+        matched_rule=matched_rule,
+    )
+
+
+def _normalize_query(query: str) -> str:
+    if not isinstance(query, str):
+        raise TypeError("query must be a string")
+    clean_query = query.strip()
+    if not clean_query:
+        raise ValueError("query cannot be empty")
+    normalized = unicodedata.normalize("NFKD", clean_query.lower())
+    return "".join(character for character in normalized if not unicodedata.combining(character))

--- a/backend/agent0/domain_routing.py
+++ b/backend/agent0/domain_routing.py
@@ -1,0 +1,522 @@
+"""Deterministic Agent-0 domain routing policy."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+from typing import Any, Literal, Protocol, cast
+
+import yaml
+
+from backend.agent0.domain_classifier import (
+    CollectionName,
+    CorpusName,
+    DomainClassification,
+    DomainName,
+    classify_domain,
+)
+from backend.agent0.golden_questions import load_all_golden_questions
+from backend.ingestion.commit_store import DUAL_CORPUS_COLLECTIONS
+from backend.rag.collection_guard import assert_collection_namespace
+
+
+RouteName = Literal["local_rag", "local_think", "local_chat"]
+RoutingMode = Literal["deterministic"]
+DEFAULT_RAG_CONFIG_PATH = Path("config/rag_config.yaml")
+ALLOWED_DOMAIN_NAMES = frozenset(
+    {"internal", "macroeconomia", "renda_fixa", "valuation", "unknown"}
+)
+ALLOWED_CORPORA = frozenset({"internal", "financial", "none"})
+ALLOWED_COLLECTIONS = frozenset({"openclaw_internal", "openclaw_financial", "none"})
+
+
+@dataclass(frozen=True)
+class DomainRuleConfig:
+    """Config-backed domain rule metadata."""
+
+    domain: DomainName
+    corpus: CorpusName
+    collection_name: CollectionName
+    keywords: tuple[str, ...]
+    regex: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.domain not in ALLOWED_DOMAIN_NAMES:
+            raise ValueError("domain is not allowed")
+        if self.corpus not in ALLOWED_CORPORA:
+            raise ValueError("corpus is not allowed")
+        if self.collection_name not in ALLOWED_COLLECTIONS:
+            raise ValueError("collection_name is not allowed")
+        for keyword in self.keywords:
+            _validate_non_empty(keyword, "keyword")
+        for pattern in self.regex:
+            _validate_non_empty(pattern, "regex")
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError("regex pattern must compile") from exc
+
+
+@dataclass(frozen=True)
+class DomainRoutingConfig:
+    """Agent-0 routing thresholds loaded from ``config/rag_config.yaml``."""
+
+    retrieval_score_min: float
+    escalate_to_think_below: float
+    p95_routing_budget_ms: float
+    citation_weight: float
+    domain_rules: Mapping[DomainName, DomainRuleConfig]
+
+    def __post_init__(self) -> None:
+        if not 0 < self.escalate_to_think_below < self.retrieval_score_min <= 1.0:
+            raise ValueError(
+                "domain routing thresholds must satisfy "
+                "0 < escalate_to_think_below < retrieval_score_min <= 1.0"
+            )
+        if self.p95_routing_budget_ms <= 0:
+            raise ValueError("p95_routing_budget_ms must be greater than zero")
+        if not 0 <= self.citation_weight <= 1.0:
+            raise ValueError("citation_weight must be between zero and one")
+        for domain, rule in self.domain_rules.items():
+            if domain != rule.domain:
+                raise ValueError("domain_rules keys must match rule domain")
+
+
+@dataclass(frozen=True)
+class RetrievalConfidence:
+    """Safe retrieval confidence signals supplied by a scorer."""
+
+    score: float
+    top_score: float
+    citation_present: bool
+    citation_count: int
+
+    def __post_init__(self) -> None:
+        _validate_score(self.score, "score")
+        _validate_score(self.top_score, "top_score")
+        if self.citation_count < 0:
+            raise ValueError("citation_count cannot be negative")
+
+
+class ConfidenceScorer(Protocol):
+    """Protocol for deterministic retrieval confidence scoring."""
+
+    def score(
+        self,
+        *,
+        query: str,
+        classification: DomainClassification,
+        state: "SystemState",
+        config: DomainRoutingConfig,
+    ) -> RetrievalConfidence:
+        """Return retrieval confidence without mutating stores or calling LLMs."""
+        ...
+
+
+@dataclass(frozen=True)
+class FakeConfidenceScorer:
+    """Offline confidence scorer for unit tests and dry-run benchmarks."""
+
+    default_score: float
+    scores_by_domain: Mapping[DomainName, float] | None = None
+    citation_present: bool = True
+    citation_count: int = 1
+
+    def __post_init__(self) -> None:
+        _validate_score(self.default_score, "default_score")
+        if self.scores_by_domain is not None:
+            for domain, score in self.scores_by_domain.items():
+                if domain not in ALLOWED_DOMAIN_NAMES:
+                    raise ValueError("scores_by_domain contains invalid domain")
+                _validate_score(score, "domain score")
+        if self.citation_count < 0:
+            raise ValueError("citation_count cannot be negative")
+
+    def score(
+        self,
+        *,
+        query: str,
+        classification: DomainClassification,
+        state: "SystemState",
+        config: DomainRoutingConfig,
+    ) -> RetrievalConfidence:
+        del query, state, config
+        score = self.default_score
+        if self.scores_by_domain is not None:
+            score = self.scores_by_domain.get(classification.domain, self.default_score)
+        return RetrievalConfidence(
+            score=score,
+            top_score=score,
+            citation_present=self.citation_present,
+            citation_count=self.citation_count,
+        )
+
+
+@dataclass(frozen=True)
+class SystemState:
+    """Minimal local system state needed by the deterministic router."""
+
+    qdrant_available: bool
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    """Safe allowlisted Agent-0 routing decision."""
+
+    route: RouteName
+    corpus: CorpusName
+    domain: DomainName
+    collection_name: CollectionName
+    confidence_score: float
+    threshold_used: str
+    reason_code: str
+    latency_ms: float
+    fallback_reason: str | None
+    routing_mode: RoutingMode
+
+    def __post_init__(self) -> None:
+        _validate_score(self.confidence_score, "confidence_score")
+        if self.latency_ms < 0:
+            raise ValueError("latency_ms cannot be negative")
+        _validate_non_empty(self.threshold_used, "threshold_used")
+        _validate_non_empty(self.reason_code, "reason_code")
+        if self.fallback_reason is not None:
+            _validate_non_empty(self.fallback_reason, "fallback_reason")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return safe allowlisted metadata only."""
+
+        data: dict[str, object] = {
+            "route": self.route,
+            "corpus": self.corpus,
+            "domain": self.domain,
+            "collection_name": self.collection_name,
+            "confidence_score": round(self.confidence_score, 6),
+            "threshold_used": self.threshold_used,
+            "reason_code": self.reason_code,
+            "latency_ms": round(self.latency_ms, 3),
+            "routing_mode": self.routing_mode,
+        }
+        if self.fallback_reason is not None:
+            data["fallback_reason"] = self.fallback_reason
+        return data
+
+
+@dataclass(frozen=True)
+class GoldenRoutingGateResult:
+    """Aggregate result for routing A0-PR03 golden questions."""
+
+    total_questions: int
+    passed: int
+    failed: int
+    accuracy: float
+    p95_routing_ms: float
+    decisions: tuple[RouteDecision, ...]
+
+
+def load_domain_routing_config(
+    config_path: Path | str = DEFAULT_RAG_CONFIG_PATH,
+) -> DomainRoutingConfig:
+    """Load Agent-0 domain routing thresholds from ``rag_config.yaml``."""
+
+    raw_config = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    if not isinstance(raw_config, Mapping):
+        raise ValueError("rag_config.yaml must contain a mapping")
+    agent0 = raw_config.get("agent0")
+    if not isinstance(agent0, Mapping):
+        raise ValueError("rag_config.yaml must contain agent0 mapping")
+    routing = agent0.get("domain_routing")
+    if not isinstance(routing, Mapping):
+        raise ValueError("rag_config.yaml must contain agent0.domain_routing mapping")
+
+    raw_rules = routing.get("domain_rules")
+    if not isinstance(raw_rules, Mapping):
+        raise ValueError("agent0.domain_routing.domain_rules must be a mapping")
+    domain_rules: dict[DomainName, DomainRuleConfig] = {}
+    for domain_text, raw_rule in raw_rules.items():
+        if not isinstance(domain_text, str):
+            raise ValueError("domain rule names must be strings")
+        domain = _cast_domain(domain_text)
+        if not isinstance(raw_rule, Mapping):
+            raise ValueError("domain rule config must be a mapping")
+        domain_rules[domain] = DomainRuleConfig(
+            domain=domain,
+            corpus=_cast_corpus(_required_string(raw_rule, "corpus")),
+            collection_name=_cast_collection(
+                _required_string(raw_rule, "collection_name")
+            ),
+            keywords=_read_string_tuple(raw_rule, "keywords"),
+            regex=_read_string_tuple(raw_rule, "regex"),
+        )
+
+    return DomainRoutingConfig(
+        retrieval_score_min=_required_float(routing, "retrieval_score_min"),
+        escalate_to_think_below=_required_float(routing, "escalate_to_think_below"),
+        p95_routing_budget_ms=_required_float(routing, "p95_routing_budget_ms"),
+        citation_weight=_required_float(routing, "citation_weight"),
+        domain_rules=domain_rules,
+    )
+
+
+def route(
+    query: str,
+    state: SystemState,
+    config: DomainRoutingConfig,
+    scorer: ConfidenceScorer,
+    question_id: str | None = None,
+) -> RouteDecision:
+    """Route an Agent-0 query using deterministic local policy only."""
+
+    started_at = time.perf_counter()
+    classification = classify_domain(query, question_id=question_id)
+    if not state.qdrant_available:
+        return _decision(
+            started_at=started_at,
+            route_name="local_chat",
+            classification=classification,
+            confidence_score=0.0,
+            threshold_used="qdrant_available",
+            reason_code="qdrant_unavailable",
+            corpus="none",
+            collection_name="none",
+            fallback_reason="qdrant_unavailable",
+        )
+    if classification.domain == "unknown":
+        return _decision(
+            started_at=started_at,
+            route_name="local_chat",
+            classification=classification,
+            confidence_score=0.0,
+            threshold_used="domain_classifier",
+            reason_code="no_domain_match",
+            corpus="none",
+            collection_name="none",
+            fallback_reason="no_domain_match",
+        )
+
+    if classification.collection_name != "none":
+        assert_collection_namespace(
+            classification.collection_name,
+            DUAL_CORPUS_COLLECTIONS,
+        )
+    confidence = scorer.score(
+        query=query,
+        classification=classification,
+        state=state,
+        config=config,
+    )
+    if confidence.score >= config.retrieval_score_min:
+        return _decision(
+            started_at=started_at,
+            route_name="local_rag",
+            classification=classification,
+            confidence_score=confidence.score,
+            threshold_used="retrieval_score_min",
+            reason_code="retrieval_confident",
+        )
+    if confidence.score >= config.escalate_to_think_below:
+        return _decision(
+            started_at=started_at,
+            route_name="local_think",
+            classification=classification,
+            confidence_score=confidence.score,
+            threshold_used="escalate_to_think_below",
+            reason_code="retrieval_uncertain",
+        )
+    return _decision(
+        started_at=started_at,
+        route_name="local_chat",
+        classification=classification,
+        confidence_score=confidence.score,
+        threshold_used="escalate_to_think_below",
+        reason_code="retrieval_low_confidence",
+        corpus="none",
+        collection_name="none",
+        fallback_reason="retrieval_low_confidence",
+    )
+
+
+def validate_routing_against_golden_questions(
+    *,
+    config: DomainRoutingConfig | None = None,
+    state: SystemState | None = None,
+    scorer: ConfidenceScorer | None = None,
+) -> GoldenRoutingGateResult:
+    """Route A0-PR03 golden questions and measure corpus/collection accuracy."""
+
+    active_config = config or load_domain_routing_config()
+    active_state = state or SystemState(qdrant_available=True)
+    active_scorer = scorer or FakeConfidenceScorer(
+        default_score=active_config.retrieval_score_min
+    )
+    questions = tuple(question for question in load_all_golden_questions() if question.enabled)
+    decisions: list[RouteDecision] = []
+    passed = 0
+    for question in questions:
+        decision = route(
+            question.text,
+            active_state,
+            active_config,
+            active_scorer,
+            question_id=question.question_id,
+        )
+        decisions.append(decision)
+        if (
+            decision.corpus == question.expected_corpus
+            and decision.collection_name == question.expected_collection
+            and decision.route == "local_rag"
+        ):
+            passed += 1
+
+    total = len(questions)
+    latencies = [decision.latency_ms for decision in decisions]
+    return GoldenRoutingGateResult(
+        total_questions=total,
+        passed=passed,
+        failed=total - passed,
+        accuracy=_ratio(passed, total),
+        p95_routing_ms=_percentile(latencies, 95),
+        decisions=tuple(decisions),
+    )
+
+
+def route_dry_run_p95(
+    *,
+    config: DomainRoutingConfig | None = None,
+    iterations: int = 100,
+) -> float:
+    """Return p95 routing latency for synthetic offline decisions."""
+
+    if iterations <= 0:
+        raise ValueError("iterations must be greater than zero")
+    active_config = config or load_domain_routing_config()
+    state = SystemState(qdrant_available=True)
+    scorer = FakeConfidenceScorer(default_score=active_config.retrieval_score_min)
+    queries = (
+        "qual o estado atual do GW-07?",
+        "como a Selic afeta a inflacao?",
+        "o que e duration de renda fixa?",
+        "como calcular o EBITDA?",
+        "pergunta sem dominio conhecido",
+    )
+    latencies: list[float] = []
+    for index in range(iterations):
+        decision = route(
+            queries[index % len(queries)],
+            state,
+            active_config,
+            scorer,
+        )
+        latencies.append(decision.latency_ms)
+    return _percentile(latencies, 95)
+
+
+def route_counts(decisions: Sequence[RouteDecision]) -> dict[str, int]:
+    """Return deterministic route-count metadata."""
+
+    return dict(Counter(decision.route for decision in decisions))
+
+
+def reason_code_counts(decisions: Sequence[RouteDecision]) -> dict[str, int]:
+    """Return deterministic reason-code count metadata."""
+
+    return dict(Counter(decision.reason_code for decision in decisions))
+
+
+def _decision(
+    *,
+    started_at: float,
+    route_name: RouteName,
+    classification: DomainClassification,
+    confidence_score: float,
+    threshold_used: str,
+    reason_code: str,
+    corpus: CorpusName | None = None,
+    collection_name: CollectionName | None = None,
+    fallback_reason: str | None = None,
+) -> RouteDecision:
+    return RouteDecision(
+        route=route_name,
+        corpus=corpus or classification.corpus,
+        domain=classification.domain,
+        collection_name=collection_name or classification.collection_name,
+        confidence_score=confidence_score,
+        threshold_used=threshold_used,
+        reason_code=reason_code,
+        latency_ms=(time.perf_counter() - started_at) * 1000,
+        fallback_reason=fallback_reason,
+        routing_mode="deterministic",
+    )
+
+
+def _required_string(mapping: Mapping[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"agent0.domain_routing.{key} must be a non-empty string")
+    return value.strip()
+
+
+def _required_float(mapping: Mapping[str, Any], key: str) -> float:
+    value = mapping.get(key)
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise ValueError(f"agent0.domain_routing.{key} must be a number")
+    return float(value)
+
+
+def _read_string_tuple(mapping: Mapping[str, Any], key: str) -> tuple[str, ...]:
+    value = mapping.get(key, ())
+    if not isinstance(value, list | tuple):
+        raise ValueError(f"agent0.domain_routing.{key} must be a list")
+    values: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"agent0.domain_routing.{key} must contain strings")
+        values.append(item.strip())
+    return tuple(values)
+
+
+def _validate_non_empty(value: str, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+
+
+def _validate_score(value: float, field_name: str) -> None:
+    if not 0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between zero and one")
+
+
+def _cast_domain(value: str) -> DomainName:
+    if value not in ALLOWED_DOMAIN_NAMES:
+        raise ValueError("domain is not allowed")
+    return cast(DomainName, value)
+
+
+def _cast_corpus(value: str) -> CorpusName:
+    if value not in ALLOWED_CORPORA:
+        raise ValueError("corpus is not allowed")
+    return cast(CorpusName, value)
+
+
+def _cast_collection(value: str) -> CollectionName:
+    if value not in ALLOWED_COLLECTIONS:
+        raise ValueError("collection_name is not allowed")
+    return cast(CollectionName, value)
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 3)
+
+
+def _percentile(values: Sequence[float], percentile: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((percentile / 100) * (len(ordered) - 1))))
+    return round(ordered[index], 3)

--- a/backend/agent0/domain_routing.py
+++ b/backend/agent0/domain_routing.py
@@ -214,6 +214,7 @@ class GoldenRoutingGateResult:
     total_questions: int
     passed: int
     failed: int
+    failed_question_ids: tuple[str, ...]
     accuracy: float
     p95_routing_ms: float
     decisions: tuple[RouteDecision, ...]
@@ -356,6 +357,7 @@ def validate_routing_against_golden_questions(
     )
     questions = tuple(question for question in load_all_golden_questions() if question.enabled)
     decisions: list[RouteDecision] = []
+    failed_question_ids: list[str] = []
     passed = 0
     for question in questions:
         decision = route(
@@ -372,6 +374,8 @@ def validate_routing_against_golden_questions(
             and decision.route == "local_rag"
         ):
             passed += 1
+        else:
+            failed_question_ids.append(question.question_id)
 
     total = len(questions)
     latencies = [decision.latency_ms for decision in decisions]
@@ -379,6 +383,7 @@ def validate_routing_against_golden_questions(
         total_questions=total,
         passed=passed,
         failed=total - passed,
+        failed_question_ids=tuple(failed_question_ids),
         accuracy=_ratio(passed, total),
         p95_routing_ms=_percentile(latencies, 95),
         decisions=tuple(decisions),

--- a/backend/agent0/routing_report.py
+++ b/backend/agent0/routing_report.py
@@ -1,0 +1,115 @@
+"""Sanitized Agent-0 domain routing report contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from statistics import median
+from typing import Any
+from uuid import uuid4
+
+from backend.agent0.domain_routing import (
+    RouteDecision,
+    reason_code_counts,
+    route_counts,
+)
+from backend.agent0.golden_questions import assert_golden_report_sanitized
+
+
+ROUTING_FORBIDDEN_KEYS = frozenset(
+    {
+        "query",
+        "text",
+        "raw_text",
+        "answer",
+        "prompt",
+        "chunk",
+        "chunks",
+        "chunk_text",
+        "vector",
+        "vectors",
+        "embedding",
+        "embeddings",
+        "payload",
+        "headers",
+        "api_key",
+        "authorization",
+        "secret",
+        "raw_exception",
+        "exception_message",
+        "traceback",
+        "absolute_path",
+        "absolute_paths",
+        "local_absolute_path",
+        "username",
+    }
+)
+
+
+def build_routing_report(
+    *,
+    decisions: Sequence[RouteDecision],
+    passed: int,
+    failed: int,
+    golden_accuracy: float,
+) -> dict[str, Any]:
+    """Build a sanitized routing report with allowlisted metadata."""
+
+    if passed < 0 or failed < 0:
+        raise ValueError("passed and failed cannot be negative")
+    total_decisions = len(decisions)
+    latencies = [decision.latency_ms for decision in decisions]
+    report: dict[str, Any] = {
+        "run_id": uuid4().hex,
+        "timestamp_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "total_decisions": total_decisions,
+        "passed": passed,
+        "failed": failed,
+        "coverage": _ratio(passed + failed, total_decisions),
+        "p50_routing_ms": round(median(latencies), 3) if latencies else 0.0,
+        "p95_routing_ms": _percentile(latencies, 95),
+        "route_counts": route_counts(decisions),
+        "reason_code_counts": reason_code_counts(decisions),
+        "golden_accuracy": round(golden_accuracy, 3),
+        "per_decision": [decision.to_dict() for decision in decisions],
+    }
+    assert_routing_report_sanitized(report)
+    return report
+
+
+def assert_routing_report_sanitized(report: Mapping[str, Any]) -> None:
+    """Reject forbidden content-bearing keys anywhere in the report."""
+
+    assert_golden_report_sanitized(report)
+    hits = _forbidden_key_hits(report)
+    if hits:
+        raise ValueError(f"routing report contains forbidden keys: {hits}")
+
+
+def _forbidden_key_hits(value: object, path: str = "$") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key)
+            next_path = f"{path}.{key_text}"
+            if key_text in ROUTING_FORBIDDEN_KEYS:
+                hits.append(next_path)
+            hits.extend(_forbidden_key_hits(nested, next_path))
+    elif isinstance(value, list | tuple):
+        for index, nested in enumerate(value):
+            hits.extend(_forbidden_key_hits(nested, f"{path}[{index}]"))
+    return hits
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 3)
+
+
+def _percentile(values: Sequence[float], percentile: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((percentile / 100) * (len(ordered) - 1))))
+    return round(ordered[index], 3)

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -125,3 +125,66 @@ gateway:
     token_estimation:
       chars_per_token: 4
       min_tokens: 1
+
+agent0:
+  domain_routing:
+    retrieval_score_min: 0.75
+    escalate_to_think_below: 0.45
+    p95_routing_budget_ms: 100.0
+    citation_weight: 0.2
+    domain_rules:
+      internal:
+        corpus: "internal"
+        collection_name: "openclaw_internal"
+        keywords:
+          - "gw-07"
+          - "gateway"
+          - "alias"
+          - "aliases"
+          - "claude"
+          - "current_state"
+          - "decisions"
+          - "timeout"
+        regex:
+          - "\\bgw-?\\d+\\b"
+      macroeconomia:
+        corpus: "financial"
+        collection_name: "openclaw_financial"
+        keywords:
+          - "selic"
+          - "inflacao"
+          - "inflação"
+          - "cambio"
+          - "câmbio"
+          - "juros"
+          - "ipca"
+          - "macroeconomia"
+        regex:
+          - "\\b(ipca|selic)\\b"
+      renda_fixa:
+        corpus: "financial"
+        collection_name: "openclaw_financial"
+        keywords:
+          - "duration"
+          - "renda fixa"
+          - "prefixado"
+          - "pos-fixado"
+          - "pós-fixado"
+          - "credito privado"
+          - "crédito privado"
+          - "curva de juros"
+        regex:
+          - "\\bduration\\b"
+      valuation:
+        corpus: "financial"
+        collection_name: "openclaw_financial"
+        keywords:
+          - "valuation"
+          - "ebitda"
+          - "fluxo de caixa"
+          - "multiplo"
+          - "múltiplo"
+          - "margem de seguranca"
+          - "margem de segurança"
+        regex:
+          - "\\bebitda\\b"

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -263,7 +263,8 @@ data/corpus/manifest.yaml
 |---|---|---|---|
 | A0-PR01 | `feat/agent0-ingestion` | Controlled verify-only corpus ingestion pipeline | ✅ Complete |
 | A0-PR02 | `feat/agent0-dual-corpus-bootstrap` | Bootstrap internal and financial corpora into isolated Qdrant collections | ✅ Complete |
-| A0-PR03 | `feat/agent0-golden-questions` | Six golden questions and frozen citation contract | 🚧 Current |
+| A0-PR03 | `feat/agent0-golden-questions` | Six golden questions and frozen citation contract | ✅ Complete |
+| A0-PR04 | `feat/agent0-domain-routing` | Deterministic domain routing by rules, confidence and state | 🚧 Current |
 
 A0-PR01 rules:
 
@@ -314,6 +315,28 @@ A0-PR03 rules:
 - Reports contain IDs, expected collections, matched doc ids and latency only;
   never answer text, question text, chunks, vectors, embeddings, payloads,
   prompts, secrets, raw exceptions, tracebacks, absolute paths or usernames.
+
+A0-PR04 rules:
+
+- `backend/agent0/domain_classifier.py` is pure keyword/regex logic and must not
+  import gateway clients, Ollama, LiteLLM, Qdrant, embedders, retrievers or
+  remote providers.
+- Route thresholds live under `agent0.domain_routing` in
+  `config/rag_config.yaml`; do not hardcode threshold constants in Python.
+- `RouteDecision` is frozen and serializes through an explicit allowlist.
+- `route(...)` classifies first, then combines `SystemState` and injected
+  `ConfidenceScorer` results; it never calls Qdrant directly and never mutates
+  collections.
+- `openclaw_knowledge` remains forbidden for Agent-0 routing; only
+  `openclaw_internal`, `openclaw_financial` and `none` are valid routing
+  collection values.
+- Golden routing gate reuses A0-PR03 questions and currently routes 6/6 to the
+  expected corpus/collection with fake high confidence.
+- Offline routing dry-run p95 is currently ~0.003 ms against the configured
+  100 ms budget.
+- Routing reports contain safe metadata only; never query, text, answer, prompt,
+  chunks, vectors, embeddings, payloads, headers, secrets, raw exceptions,
+  tracebacks, absolute paths or usernames.
 
 G2-PR06 rules:
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -4,31 +4,32 @@
 > review. Read after `docs/04_MEM/AGENT_CONTEXT.md`. Update at the end of
 > meaningful sessions.
 
-**Last updated:** 2026-05-07
-**Updated by:** Codex — A0-PR03 golden questions citation contract
+**Last updated:** 2026-05-08
+**Updated by:** Codex — A0-PR04 deterministic domain routing
 
 ---
 
-## Active Sprint: Agent-0 / Golden Questions Citation Contract
+## Active Sprint: Agent-0 / Deterministic Domain Routing
 
-**Goal:** add six citation-only Agent-0 golden questions, a frozen `Citation`
-contract, an offline dry-run harness and a sanitized report proving expected
-source evidence by collection.
+**Goal:** add deterministic, local-only Agent-0 domain routing that classifies
+queries by keyword/regex, reads thresholds from `config/rag_config.yaml`, and
+chooses `local_rag`, `local_think` or `local_chat` from retrieval confidence and
+system state.
 
-Current branch: `feat/agent0-golden-questions`
-Current issue: `[A0-PR03] Add golden questions citation contract`
+Current branch: `feat/agent0-domain-routing`
+Current issue: <https://github.com/franciscosalido/OPENCLAW/issues/80>
 
-A0-PR03 starts after A0-PR02. It validates retrieval evidence and citation
-metadata only; it must not generate answers.
+A0-PR04 starts after A0-PR03. It routes evidence-seeking Agent-0 questions but
+does not retrieve live Qdrant data, mutate collections, call LLMs or generate
+answers.
 
 ```text
-tests/golden/internal_questions.yaml
-tests/golden/financial_questions.yaml
-  -> GoldenQuestion schema
-  -> A0-PR02 corpus manifest doc-id validation
-  -> FakeRetriever dry-run
-  -> frozen Citation metadata
-  -> sanitized report
+query/question_id
+  -> deterministic domain classifier
+  -> config-backed thresholds
+  -> injected retrieval confidence scorer
+  -> frozen RouteDecision
+  -> sanitized routing report
 ```
 
 Current runtime path:
@@ -83,35 +84,43 @@ Hard constraints remain:
 - No `openclaw_knowledge` mutation in verify-only.
 - No Qdrant mutation unless `--commit` is explicit and a future writer is wired.
 - No arbitrary collection override for dual corpus bootstrap.
-- No answer generation in A0-PR03 golden question harness.
+- No answer generation in A0-PR03 golden question harness or A0-PR04 routing.
 - No LLM-as-judge.
 - No Qdrant mutation or live Qdrant requirement in A0-PR03 unit tests.
+- No LLM classifier, embeddings, rerankers, remote providers or live Qdrant
+  dependency in A0-PR04 classifier/routing unit tests.
 - No final local merge into `main`; GitHub PR approval is the integration path.
 
-## A0-PR03 Current Work
+## A0-PR04 Current Work
 
-A0-PR03 adds citation-only golden question primitives:
+A0-PR04 adds deterministic domain routing primitives:
 
-- `tests/golden/internal_questions.yaml` with `iq-001` through `iq-003`.
-- `tests/golden/financial_questions.yaml` with `fq-001` through `fq-003`.
-- `backend/agent0/golden_questions.py` with frozen Pydantic question models,
-  frozen `Citation`, `GoldenRetriever` protocol and offline harness logic.
-- `scripts/run_golden_questions.py --dry-run`.
-- `docs/AGENT0_GOLDEN_QUESTIONS.md`.
+- `backend/agent0/domain_classifier.py` with pure keyword/regex rules.
+- `backend/agent0/domain_routing.py` with typed config, `SystemState`,
+  `ConfidenceScorer`, `FakeConfidenceScorer`, frozen `RouteDecision`,
+  golden-question gate and dry-run p95 measurement.
+- `backend/agent0/routing_report.py` with sanitized routing reports.
+- `config/rag_config.yaml` `agent0.domain_routing` thresholds and rule
+  metadata.
+- `docs/AGENT0_DOMAIN_ROUTING.md`.
 
 Rules:
 
-- Dry-run is default and uses `FakeRetriever`; no Qdrant, Ollama, LiteLLM or LLM
-  answer generation.
-- Smoke mode is guarded by `RUN_GOLDEN_SMOKE=1`.
-- Internal questions route only to `openclaw_internal`.
-- Financial questions route only to `openclaw_financial`.
-- Expected doc ids must exist in A0-PR02 corpus manifests.
-- Success is citation evidence only: expected doc id, expected corpus and
-  expected collection.
-- Reports remain sanitized and contain no answer, question text, chunks, vectors,
-  embeddings, payloads, prompts, secrets, headers, raw exceptions, tracebacks,
-  absolute paths or usernames.
+- Domain classifier imports no gateway clients, Ollama, LiteLLM, Qdrant,
+  embedders, retrievers or remote providers.
+- Thresholds are loaded from `rag_config.yaml`; do not hardcode route
+  thresholds in Python.
+- `iq-*` routes to `internal` / `openclaw_internal`; financial keywords route
+  to `macroeconomia`, `renda_fixa` or `valuation` in `openclaw_financial`.
+- Qdrant unavailable or unknown domain returns `local_chat` with safe
+  `reason_code`.
+- High confidence returns `local_rag`; medium confidence returns `local_think`;
+  low confidence returns `local_chat`.
+- A0-PR03 golden routing gate is currently 6/6 with fake high confidence.
+- Offline dry-run p95 is currently ~0.003 ms against a 100 ms budget.
+- Reports and `RouteDecision.to_dict()` contain safe metadata only; never query,
+  answer, prompt, chunks, vectors, embeddings, payloads, secrets, headers, raw
+  exceptions, tracebacks, absolute paths or usernames.
 
 ---
 

--- a/docs/AGENT0_DOMAIN_ROUTING.md
+++ b/docs/AGENT0_DOMAIN_ROUTING.md
@@ -40,6 +40,19 @@ Keyword examples:
 - `ebitda`, `valuation`, `fluxo de caixa` -> `valuation`
 - `gw-07`, `alias`, `timeout`, `decisions` -> `internal`
 
+In A0-PR04 the executable classifier rules are code-owned in
+`domain_classifier.py` so the classifier can remain tiny, auditable and free of
+config-loader imports. The `agent0.domain_routing.domain_rules` YAML section is
+validated routing metadata for review, documentation and future config-driven
+classifier work; changing YAML rule text alone does not change classifier
+behavior in this PR.
+
+Financial question IDs without a financial-domain keyword are treated as
+financial collection hints only. They produce `corpus=financial` and
+`collection_name=openclaw_financial` at the classifier boundary, but keep
+`domain=unknown`; `route(...)` then falls back to `local_chat` with
+`no_domain_match` until a concrete domain rule matches.
+
 ## Configuration
 
 Thresholds and domain-rule metadata live in `config/rag_config.yaml`:
@@ -105,7 +118,8 @@ embeddings, payloads, secrets, headers, tracebacks or absolute paths.
 `validate_routing_against_golden_questions()` reuses A0-PR03 golden questions
 with a fake high-confidence scorer. The gate checks that at least 5 of 6
 questions route to the expected corpus and collection. The current deterministic
-rules route all 6 of 6 to `local_rag` with the expected namespace.
+rules route all 6 of 6 to `local_rag` with the expected namespace. Failures are
+reported explicitly through `failed_question_ids`.
 
 ## Dry-Run Latency Gate
 

--- a/docs/AGENT0_DOMAIN_ROUTING.md
+++ b/docs/AGENT0_DOMAIN_ROUTING.md
@@ -1,0 +1,142 @@
+# Agent-0 Domain Routing
+
+## Purpose
+
+A0-PR04 adds deterministic Agent-0 domain routing. It classifies a local query
+with keyword/regex rules, combines the result with retrieval confidence and
+system state, then chooses one local route:
+
+- `local_rag`
+- `local_think`
+- `local_chat`
+
+The router does not generate answers and does not call Qdrant, Ollama, LiteLLM
+or remote providers.
+
+## Deterministic Classifier
+
+`backend/agent0/domain_classifier.py` is intentionally small and offline. It
+does not import gateway clients, embedders, retrievers, vector stores or LLM
+providers.
+
+Supported domains:
+
+- `internal`
+- `macroeconomia`
+- `renda_fixa`
+- `valuation`
+- `unknown`
+
+Question ID prefixes are recognized:
+
+- `iq-*` routes to `internal` and `openclaw_internal`.
+- `fq-*` routes to the financial collection. Keyword/regex rules refine the
+  financial domain when the query contains enough signal.
+
+Keyword examples:
+
+- `selic`, `inflacao`, `ipca` -> `macroeconomia`
+- `duration`, `renda fixa`, `curva de juros` -> `renda_fixa`
+- `ebitda`, `valuation`, `fluxo de caixa` -> `valuation`
+- `gw-07`, `alias`, `timeout`, `decisions` -> `internal`
+
+## Configuration
+
+Thresholds and domain-rule metadata live in `config/rag_config.yaml`:
+
+```yaml
+agent0:
+  domain_routing:
+    retrieval_score_min: 0.75
+    escalate_to_think_below: 0.45
+    p95_routing_budget_ms: 100.0
+    citation_weight: 0.2
+    domain_rules:
+      internal:
+        corpus: internal
+        collection_name: openclaw_internal
+```
+
+Validation enforces:
+
+- `0 < escalate_to_think_below < retrieval_score_min <= 1.0`
+- `p95_routing_budget_ms > 0`
+- domain rules use only allowed corpora and collections
+- regex patterns compile at load time
+- `openclaw_knowledge` is not an allowed Agent-0 routing collection
+
+## Route Decision Logic
+
+`route(query, state, config, scorer, question_id=None)` performs:
+
+1. Classify the domain.
+2. If Qdrant is unavailable, return `local_chat` with reason
+   `qdrant_unavailable`.
+3. If the domain is unknown, return `local_chat` with reason
+   `no_domain_match`.
+4. Ask the injected `ConfidenceScorer` for retrieval confidence.
+5. If confidence is at least `retrieval_score_min`, return `local_rag`.
+6. If confidence is at least `escalate_to_think_below`, return `local_think`.
+7. Otherwise return `local_chat`.
+
+The router never calls Qdrant directly. Unit tests use `FakeConfidenceScorer`.
+
+## RouteDecision Contract
+
+`RouteDecision` is a frozen dataclass. Its `to_dict()` method is allowlisted and
+contains only:
+
+- `route`
+- `corpus`
+- `domain`
+- `collection_name`
+- `confidence_score`
+- `threshold_used`
+- `reason_code`
+- `latency_ms`
+- `fallback_reason` when present
+- `routing_mode`
+
+It never contains query text, retrieved text, prompts, answers, chunks, vectors,
+embeddings, payloads, secrets, headers, tracebacks or absolute paths.
+
+## Golden Question Gate
+
+`validate_routing_against_golden_questions()` reuses A0-PR03 golden questions
+with a fake high-confidence scorer. The gate checks that at least 5 of 6
+questions route to the expected corpus and collection. The current deterministic
+rules route all 6 of 6 to `local_rag` with the expected namespace.
+
+## Dry-Run Latency Gate
+
+`route_dry_run_p95()` runs 100 synthetic route decisions offline. It uses no
+network, no Qdrant, no Ollama and no LLM generation. The p95 must stay below
+`agent0.domain_routing.p95_routing_budget_ms`.
+
+## Routing Report
+
+`backend/agent0/routing_report.py` builds sanitized routing reports with:
+
+- `run_id`
+- `timestamp_utc`
+- `total_decisions`
+- `passed`
+- `failed`
+- `coverage`
+- `p50_routing_ms`
+- `p95_routing_ms`
+- `route_counts`
+- `reason_code_counts`
+- `golden_accuracy`
+- `per_decision`
+
+Forbidden report keys include query, text, raw text, answer, prompt, chunks,
+chunk text, vectors, embeddings, payloads, headers, API keys, authorization,
+secrets, raw exceptions, tracebacks, absolute paths and usernames.
+
+## Future Extension Points
+
+Future PRs may wire a real confidence scorer that reads retrieval metadata from
+an existing local retriever. That scorer must remain injectable and testable
+with fakes, must not mutate Qdrant, and must preserve the same sanitized
+decision/report contracts.

--- a/tests/unit/test_domain_classifier.py
+++ b/tests/unit/test_domain_classifier.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from backend.agent0 import domain_classifier
+from backend.agent0.domain_classifier import classify_domain
+
+
+FORBIDDEN_IMPORT_PREFIXES = (
+    "backend.gateway",
+    "backend.rag.embeddings",
+    "backend.rag.retriever",
+    "backend.rag.qdrant_store",
+    "qdrant_client",
+    "openai",
+    "anthropic",
+    "litellm",
+    "ollama",
+)
+
+
+class DomainClassifierTests(unittest.TestCase):
+    def test_classifier_has_no_forbidden_imports(self) -> None:
+        module_path = Path(domain_classifier.__file__)
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        imports: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imports.append(node.module)
+
+        for imported in imports:
+            with self.subTest(imported=imported):
+                self.assertFalse(
+                    imported.startswith(FORBIDDEN_IMPORT_PREFIXES),
+                    imported,
+                )
+
+    def test_iq_prefix_routes_to_internal(self) -> None:
+        result = classify_domain("pergunta sem palavra chave", question_id="iq-001")
+
+        self.assertEqual(result.domain, "internal")
+        self.assertEqual(result.corpus, "internal")
+        self.assertEqual(result.collection_name, "openclaw_internal")
+        self.assertEqual(result.reason_code, "question_id_internal")
+
+    def test_fq_prefix_routes_to_financial_collection(self) -> None:
+        result = classify_domain("pergunta sem palavra chave", question_id="fq-001")
+
+        self.assertEqual(result.corpus, "financial")
+        self.assertEqual(result.collection_name, "openclaw_financial")
+        self.assertEqual(result.reason_code, "question_id_financial")
+
+    def test_keyword_selic_routes_to_macroeconomia(self) -> None:
+        result = classify_domain("como a Selic afeta a inflacao?")
+
+        self.assertEqual(result.domain, "macroeconomia")
+        self.assertEqual(result.corpus, "financial")
+        self.assertEqual(result.reason_code, "keyword_selic")
+
+    def test_keyword_duration_routes_to_renda_fixa(self) -> None:
+        result = classify_domain("o que e duration de renda fixa?")
+
+        self.assertEqual(result.domain, "renda_fixa")
+        self.assertEqual(result.corpus, "financial")
+        self.assertEqual(result.reason_code, "keyword_duration")
+
+    def test_keyword_ebitda_routes_to_valuation(self) -> None:
+        result = classify_domain("como calcular o EBITDA?")
+
+        self.assertEqual(result.domain, "valuation")
+        self.assertEqual(result.corpus, "financial")
+        self.assertEqual(result.reason_code, "keyword_ebitda")
+
+    def test_unknown_routes_to_unknown(self) -> None:
+        result = classify_domain("pergunta generica sem dominio mapeado")
+
+        self.assertEqual(result.domain, "unknown")
+        self.assertEqual(result.corpus, "none")
+        self.assertEqual(result.collection_name, "none")
+        self.assertEqual(result.reason_code, "no_domain_match")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_domain_routing.py
+++ b/tests/unit/test_domain_routing.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from backend.agent0.domain_routing import (
+    FakeConfidenceScorer,
+    RouteDecision,
+    SystemState,
+    load_domain_routing_config,
+    route,
+    route_dry_run_p95,
+    validate_routing_against_golden_questions,
+)
+
+
+FORBIDDEN_SERIALIZED_KEYS = {
+    "query",
+    "text",
+    "raw_text",
+    "answer",
+    "prompt",
+    "chunks",
+    "chunk_text",
+    "vectors",
+    "embeddings",
+    "payload",
+    "headers",
+    "api_key",
+    "authorization",
+    "raw_exception",
+    "traceback",
+    "absolute_path",
+    "username",
+}
+
+
+class DomainRoutingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = load_domain_routing_config()
+        self.state = SystemState(qdrant_available=True)
+
+    def test_high_confidence_routes_local_rag(self) -> None:
+        decision = route(
+            "como calcular o EBITDA?",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=self.config.retrieval_score_min),
+        )
+
+        self.assertEqual(decision.route, "local_rag")
+        self.assertEqual(decision.corpus, "financial")
+        self.assertEqual(decision.collection_name, "openclaw_financial")
+        self.assertEqual(decision.reason_code, "retrieval_confident")
+
+    def test_medium_confidence_routes_local_think(self) -> None:
+        medium_score = (
+            self.config.retrieval_score_min + self.config.escalate_to_think_below
+        ) / 2
+        decision = route(
+            "o que e duration de renda fixa?",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=medium_score),
+        )
+
+        self.assertEqual(decision.route, "local_think")
+        self.assertEqual(decision.corpus, "financial")
+        self.assertEqual(decision.reason_code, "retrieval_uncertain")
+
+    def test_low_confidence_routes_local_chat(self) -> None:
+        decision = route(
+            "como a Selic afeta a inflacao?",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=0.01),
+        )
+
+        self.assertEqual(decision.route, "local_chat")
+        self.assertEqual(decision.corpus, "none")
+        self.assertEqual(decision.fallback_reason, "retrieval_low_confidence")
+
+    def test_qdrant_unavailable_routes_local_chat(self) -> None:
+        decision = route(
+            "como calcular o EBITDA?",
+            SystemState(qdrant_available=False),
+            self.config,
+            FakeConfidenceScorer(default_score=1.0),
+        )
+
+        self.assertEqual(decision.route, "local_chat")
+        self.assertEqual(decision.corpus, "none")
+        self.assertEqual(decision.collection_name, "none")
+        self.assertEqual(decision.reason_code, "qdrant_unavailable")
+
+    def test_unknown_domain_routes_local_chat(self) -> None:
+        decision = route(
+            "pergunta generica sem dominio mapeado",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=1.0),
+        )
+
+        self.assertEqual(decision.route, "local_chat")
+        self.assertEqual(decision.domain, "unknown")
+        self.assertEqual(decision.reason_code, "no_domain_match")
+
+    def test_route_decision_is_frozen(self) -> None:
+        decision = route(
+            "qual o estado atual do GW-07?",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=1.0),
+        )
+
+        with self.assertRaises(FrozenInstanceError):
+            decision.route = "local_chat"  # type: ignore[misc]
+
+    def test_route_decision_to_dict_is_allowlisted(self) -> None:
+        decision = route(
+            "qual o estado atual do GW-07?",
+            self.state,
+            self.config,
+            FakeConfidenceScorer(default_score=1.0),
+        )
+
+        data = decision.to_dict()
+
+        self.assertTrue(FORBIDDEN_SERIALIZED_KEYS.isdisjoint(data))
+        self.assertEqual(
+            set(data),
+            {
+                "route",
+                "corpus",
+                "domain",
+                "collection_name",
+                "confidence_score",
+                "threshold_used",
+                "reason_code",
+                "latency_ms",
+                "routing_mode",
+            },
+        )
+
+    def test_golden_question_gate_routes_at_least_five_of_six(self) -> None:
+        result = validate_routing_against_golden_questions(config=self.config)
+
+        self.assertGreaterEqual(result.accuracy, 0.833)
+        self.assertEqual(result.passed, 6)
+        self.assertEqual(result.failed, 0)
+        self.assertTrue(
+            all(decision.route == "local_rag" for decision in result.decisions)
+        )
+
+    def test_p95_routing_dry_run_under_config_budget(self) -> None:
+        p95 = route_dry_run_p95(config=self.config)
+
+        self.assertLess(p95, self.config.p95_routing_budget_ms)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_domain_routing.py
+++ b/tests/unit/test_domain_routing.py
@@ -148,9 +148,24 @@ class DomainRoutingTests(unittest.TestCase):
         self.assertGreaterEqual(result.accuracy, 0.833)
         self.assertEqual(result.passed, 6)
         self.assertEqual(result.failed, 0)
+        self.assertEqual(result.failed_question_ids, ())
         self.assertTrue(
             all(decision.route == "local_rag" for decision in result.decisions)
         )
+
+    def test_golden_question_gate_reports_failed_question_ids(self) -> None:
+        result = validate_routing_against_golden_questions(
+            config=self.config,
+            scorer=FakeConfidenceScorer(
+                default_score=self.config.retrieval_score_min,
+                scores_by_domain={"valuation": 0.01},
+            ),
+        )
+
+        self.assertEqual(result.total_questions, 6)
+        self.assertEqual(result.passed, 5)
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.failed_question_ids, ("fq-002",))
 
     def test_p95_routing_dry_run_under_config_budget(self) -> None:
         p95 = route_dry_run_p95(config=self.config)

--- a/tests/unit/test_domain_routing_config.py
+++ b/tests/unit/test_domain_routing_config.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from backend.agent0.domain_routing import load_domain_routing_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RAG_CONFIG = REPO_ROOT / "config" / "rag_config.yaml"
+
+
+class DomainRoutingConfigTests(unittest.TestCase):
+    def test_thresholds_loaded_from_rag_config_yaml(self) -> None:
+        config = load_domain_routing_config(RAG_CONFIG)
+
+        self.assertEqual(config.retrieval_score_min, 0.75)
+        self.assertEqual(config.escalate_to_think_below, 0.45)
+        self.assertEqual(config.p95_routing_budget_ms, 100.0)
+        self.assertEqual(config.citation_weight, 0.2)
+        self.assertIn("valuation", config.domain_rules)
+
+    def test_invalid_threshold_order_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(
+                yaml.safe_dump(
+                    _config_with_domain_routing(
+                        retrieval_score_min=0.4,
+                        escalate_to_think_below=0.5,
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_domain_routing_config(path)
+
+    def test_regex_compile_failure_rejected(self) -> None:
+        config = _config_with_domain_routing()
+        config["agent0"]["domain_routing"]["domain_rules"]["internal"]["regex"] = ["["]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                load_domain_routing_config(path)
+
+    def test_invalid_collection_rejected(self) -> None:
+        config = _config_with_domain_routing()
+        config["agent0"]["domain_routing"]["domain_rules"]["internal"][
+            "collection_name"
+        ] = "openclaw_knowledge"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "rag_config.yaml"
+            path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+            with self.assertRaises(ValueError):
+                load_domain_routing_config(path)
+
+
+def _config_with_domain_routing(
+    *,
+    retrieval_score_min: float = 0.75,
+    escalate_to_think_below: float = 0.45,
+) -> dict[str, Any]:
+    return {
+        "agent0": {
+            "domain_routing": {
+                "retrieval_score_min": retrieval_score_min,
+                "escalate_to_think_below": escalate_to_think_below,
+                "p95_routing_budget_ms": 100.0,
+                "citation_weight": 0.2,
+                "domain_rules": {
+                    "internal": {
+                        "corpus": "internal",
+                        "collection_name": "openclaw_internal",
+                        "keywords": ["gw-07"],
+                        "regex": [r"\bgw-?\d+\b"],
+                    },
+                    "macroeconomia": {
+                        "corpus": "financial",
+                        "collection_name": "openclaw_financial",
+                        "keywords": ["selic"],
+                        "regex": [r"\bselic\b"],
+                    },
+                },
+            }
+        }
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_domain_routing_report.py
+++ b/tests/unit/test_domain_routing_report.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import unittest
+
+from backend.agent0.domain_routing import (
+    FakeConfidenceScorer,
+    SystemState,
+    load_domain_routing_config,
+    route,
+)
+from backend.agent0.routing_report import (
+    ROUTING_FORBIDDEN_KEYS,
+    assert_routing_report_sanitized,
+    build_routing_report,
+)
+
+
+class DomainRoutingReportTests(unittest.TestCase):
+    def test_report_contains_no_forbidden_keys(self) -> None:
+        config = load_domain_routing_config()
+        decisions = (
+            route(
+                "qual o estado atual do GW-07?",
+                SystemState(qdrant_available=True),
+                config,
+                FakeConfidenceScorer(default_score=1.0),
+            ),
+            route(
+                "como calcular o EBITDA?",
+                SystemState(qdrant_available=True),
+                config,
+                FakeConfidenceScorer(default_score=1.0),
+            ),
+        )
+
+        report = build_routing_report(
+            decisions=decisions,
+            passed=2,
+            failed=0,
+            golden_accuracy=1.0,
+        )
+
+        assert_routing_report_sanitized(report)
+        self.assertTrue(_forbidden_keys_absent(report, ROUTING_FORBIDDEN_KEYS))
+        self.assertEqual(report["total_decisions"], 2)
+        self.assertEqual(report["coverage"], 1.0)
+        self.assertEqual(report["golden_accuracy"], 1.0)
+        self.assertIn("local_rag", report["route_counts"])
+
+    def test_report_sanitizer_rejects_forbidden_keys(self) -> None:
+        with self.assertRaises(ValueError):
+            assert_routing_report_sanitized({"query": "redacted"})
+        with self.assertRaises(ValueError):
+            assert_routing_report_sanitized({"payload": {"safe": True}})
+
+
+def _forbidden_keys_absent(value: object, forbidden: frozenset[str]) -> bool:
+    if isinstance(value, dict):
+        return all(
+            key not in forbidden and _forbidden_keys_absent(nested, forbidden)
+            for key, nested in value.items()
+        )
+    if isinstance(value, list):
+        return all(_forbidden_keys_absent(item, forbidden) for item in value)
+    return True
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #80

## Summary
- Add deterministic Agent-0 domain classification for internal, macroeconomia, renda_fixa, valuation and unknown queries.
- Add config-backed routing thresholds under `agent0.domain_routing` in `config/rag_config.yaml`.
- Add frozen `RouteDecision`, `SystemState`, `RetrievalConfidence`, `ConfidenceScorer` protocol and offline `FakeConfidenceScorer`.
- Add golden question routing gate and 100-decision dry-run p95 measurement.
- Add sanitized routing report contract and A0-PR04 documentation/memory updates.

## Config fields added
- `agent0.domain_routing.retrieval_score_min`
- `agent0.domain_routing.escalate_to_think_below`
- `agent0.domain_routing.p95_routing_budget_ms`
- `agent0.domain_routing.citation_weight`
- `agent0.domain_routing.domain_rules`

## Classifier rules
- `iq-*` -> `internal` / `openclaw_internal`
- `fq-*` -> financial collection, refined by keywords when present
- `selic`, `inflacao`, `ipca` -> `macroeconomia`
- `duration`, `renda fixa`, `curva de juros` -> `renda_fixa`
- `ebitda`, `valuation`, `fluxo de caixa` -> `valuation`
- unknown queries -> `unknown` / `none`

## Route decision logic
- Qdrant unavailable -> `local_chat`, corpus `none`
- Unknown domain -> `local_chat`, corpus `none`
- confidence >= `retrieval_score_min` -> `local_rag`
- confidence >= `escalate_to_think_below` -> `local_think`
- lower confidence -> `local_chat`

## Golden / p95 results
- Golden routing gate: `6/6`, accuracy `1.0`
- Golden gate p95: `0.02ms`
- 100-decision dry-run p95: `0.003ms` against `100.0ms` budget

## Validation
- `git diff --check`
- `uv run pytest tests/unit/test_domain_classifier.py -v`
- `uv run pytest tests/unit/test_domain_routing.py -v`
- `uv run pytest tests/unit/test_domain_routing_config.py -v`
- `uv run pytest tests/unit/test_domain_routing_report.py -v`
- `uv run pytest -v` -> `546 passed, 7 skipped, 195 subtests passed`
- `uv run mypy --strict .` -> success
- `uv run pyright` -> 0 errors
- `uv run pytest tests/smoke/ -v` -> `5 passed, 7 skipped`

## Safety
- No LLM classifier.
- No remote providers.
- No Qdrant live dependency in unit tests.
- No Qdrant mutation.
- No `openclaw_knowledge` routing target.
- Reports contain no query/text/answer/prompt/chunk/vector/payload/secret fields.
