### PR TITLE
feat(agent): add OpenClaw ask CLI and readiness gates

### DIFF
--- a/backend/agent0/__init__.py
+++ b/backend/agent0/__init__.py
@@ -1,1 +1,5 @@
 """Agent-0 contracts and offline evaluation helpers."""
+
+from backend.agent0.openclaw import Answer, OpenClaw
+
+__all__ = ["Answer", "OpenClaw"]

--- a/backend/agent0/e2e_report.py
+++ b/backend/agent0/e2e_report.py
@@ -1,0 +1,125 @@
+"""Sanitized Agent-0 E2E SLO report."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from statistics import median
+from typing import Any
+from uuid import uuid4
+
+from backend.agent0.golden_questions import Citation, assert_golden_report_sanitized
+from backend.agent0.openclaw import Answer
+
+
+E2E_FORBIDDEN_KEYS = frozenset(
+    {
+        "question",
+        "query",
+        "text",
+        "raw_text",
+        "prompt",
+        "chunks",
+        "chunk",
+        "chunk_text",
+        "vectors",
+        "vector",
+        "embeddings",
+        "embedding",
+        "payload",
+        "headers",
+        "api_key",
+        "authorization",
+        "secret",
+        "raw_exception",
+        "traceback",
+        "answer",
+    }
+)
+
+
+def build_e2e_report(results: Sequence[tuple[str, Answer]]) -> dict[str, Any]:
+    """Build a sanitized E2E report without question or answer text."""
+
+    total = len(results)
+    passed = sum(1 for _, answer in results if answer.citation_present)
+    failed_question_ids = tuple(
+        question_id for question_id, answer in results if not answer.citation_present
+    )
+    latencies = [answer.latency_ms for _, answer in results]
+    answers = [answer for _, answer in results]
+    report: dict[str, Any] = {
+        "run_id": uuid4().hex,
+        "timestamp_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "total_questions": total,
+        "passed": passed,
+        "failed": total - passed,
+        "citation_hit_rate": _ratio(passed, total),
+        "p50_latency_ms": round(median(latencies), 3) if latencies else 0.0,
+        "p95_latency_ms": _percentile(latencies, 95),
+        "route_counts": dict(Counter(answer.route for answer in answers)),
+        "corpus_counts": dict(Counter(answer.corpus for answer in answers)),
+        "failed_question_ids": list(failed_question_ids),
+        "safe_citations": [
+            _safe_citation_dict(citation)
+            for answer in answers
+            for citation in answer.citations
+        ],
+    }
+    assert_e2e_report_sanitized(report)
+    return report
+
+
+def assert_e2e_report_sanitized(report: Mapping[str, Any]) -> None:
+    """Reject report keys that could leak content or secrets."""
+
+    assert_golden_report_sanitized(report)
+    hits = _forbidden_key_hits(report)
+    if hits:
+        raise ValueError(f"e2e report contains forbidden keys: {hits}")
+
+
+def _safe_citation_dict(citation: Citation) -> dict[str, object]:
+    return {
+        "question_id": citation.question_id,
+        "source_id": citation.source_id,
+        "doc_id": citation.doc_id,
+        "chunk_id": citation.chunk_id,
+        "corpus": citation.corpus,
+        "collection_name": citation.collection_name,
+        "origin_path": citation.origin_path,
+        "score": citation.score,
+        "rank": citation.rank,
+        "retrieval_mode": citation.retrieval_mode,
+        "chunk_index": citation.chunk_index,
+    }
+
+
+def _forbidden_key_hits(value: object, path: str = "$") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key)
+            next_path = f"{path}.{key_text}"
+            if key_text in E2E_FORBIDDEN_KEYS:
+                hits.append(next_path)
+            hits.extend(_forbidden_key_hits(nested, next_path))
+    elif isinstance(value, list | tuple):
+        for index, nested in enumerate(value):
+            hits.extend(_forbidden_key_hits(nested, f"{path}[{index}]"))
+    return hits
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 3)
+
+
+def _percentile(values: Sequence[float], percentile: int) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((percentile / 100) * (len(ordered) - 1))))
+    return round(ordered[index], 3)

--- a/backend/agent0/openclaw.py
+++ b/backend/agent0/openclaw.py
@@ -1,0 +1,286 @@
+"""Public OpenClaw Agent-0 ask API."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from backend.agent0.domain_routing import (
+    ConfidenceScorer,
+    FakeConfidenceScorer,
+    RouteDecision,
+    SystemState,
+    load_domain_routing_config,
+    route,
+)
+from backend.agent0.golden_questions import Citation
+from backend.rag.context_packer import RetrievedChunk
+from backend.rag.generator import LocalGenerator
+from backend.rag.pipeline import LocalRagPipeline
+from backend.rag.prompt_builder import PromptBuilder
+from backend.rag.qdrant_store import QdrantVectorStore
+from backend.rag.retriever import Retriever
+from backend.rag.embedder_factory import create_rag_embedder
+
+
+ANSWER_FORBIDDEN_KEYS = frozenset(
+    {
+        "prompt",
+        "chunks",
+        "chunk",
+        "chunk_text",
+        "vectors",
+        "vector",
+        "embeddings",
+        "embedding",
+        "payload",
+        "headers",
+        "api_key",
+        "authorization",
+        "secret",
+        "raw_exception",
+        "traceback",
+    }
+)
+
+
+class AskBackend(Protocol):
+    """Callable used to execute the routed local answer path."""
+
+    def __call__(self, question: str, decision: RouteDecision) -> "Answer":
+        """Return an answer for one already-routed question."""
+        ...
+
+
+@dataclass(frozen=True)
+class Answer:
+    """Stable public OpenClaw answer contract."""
+
+    answer: str
+    citations: tuple[Citation, ...]
+    route: str
+    corpus: str
+    latency_ms: float
+    citation_present: bool
+    fallback_reason: str | None
+    error_category: str | None
+
+    def __post_init__(self) -> None:
+        if self.latency_ms < 0:
+            raise ValueError("latency_ms cannot be negative")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a safe allowlisted dictionary for CLI JSON output."""
+
+        data: dict[str, object] = {
+            "answer": self.answer,
+            "citations": [_citation_to_dict(citation) for citation in self.citations],
+            "route": self.route,
+            "corpus": self.corpus,
+            "latency_ms": round(self.latency_ms, 3),
+            "citation_present": self.citation_present,
+        }
+        if self.fallback_reason is not None:
+            data["fallback_reason"] = self.fallback_reason
+        if self.error_category is not None:
+            data["error_category"] = self.error_category
+        assert_answer_sanitized(data)
+        return data
+
+
+class OpenClaw:
+    """Minimal stable public interface for Agent-0."""
+
+    def __init__(
+        self,
+        *,
+        state: SystemState | None = None,
+        confidence_scorer: ConfidenceScorer | None = None,
+        ask_backend: AskBackend | None = None,
+    ) -> None:
+        self._state = state or SystemState(qdrant_available=True)
+        self._config = load_domain_routing_config()
+        self._confidence_scorer = confidence_scorer or FakeConfidenceScorer(
+            default_score=self._config.retrieval_score_min
+        )
+        self._ask_backend = ask_backend or _default_ask_backend
+
+    def ask(self, question: str) -> Answer:
+        """Answer one question through deterministic Agent-0 local routing."""
+
+        clean_question = _validate_question(question)
+        started_at = time.perf_counter()
+        try:
+            decision = route(
+                clean_question,
+                self._state,
+                self._config,
+                self._confidence_scorer,
+            )
+            if decision.route != "local_rag":
+                return Answer(
+                    answer="Não há contexto local suficiente para responder com segurança.",
+                    citations=(),
+                    route=decision.route,
+                    corpus=decision.corpus,
+                    latency_ms=_elapsed_ms(started_at),
+                    citation_present=False,
+                    fallback_reason=decision.fallback_reason,
+                    error_category=None,
+                )
+            result = self._ask_backend(clean_question, decision)
+            return Answer(
+                answer=result.answer,
+                citations=result.citations,
+                route=decision.route,
+                corpus=decision.corpus,
+                latency_ms=_elapsed_ms(started_at),
+                citation_present=bool(result.citations),
+                fallback_reason=result.fallback_reason,
+                error_category=result.error_category,
+            )
+        except Exception as exc:
+            return Answer(
+                answer="Local Agent-0 execution failed.",
+                citations=(),
+                route="local_chat",
+                corpus="none",
+                latency_ms=_elapsed_ms(started_at),
+                citation_present=False,
+                fallback_reason="local_execution_failed",
+                error_category=_safe_error_category(exc),
+            )
+
+
+def assert_answer_sanitized(value: object) -> None:
+    """Reject forbidden content-bearing keys in Answer output structures."""
+
+    hits = _forbidden_key_hits(value)
+    if hits:
+        raise ValueError(f"answer output contains forbidden keys: {hits}")
+
+
+def _default_ask_backend(question: str, decision: RouteDecision) -> Answer:
+    return asyncio.run(_run_local_rag(question, decision))
+
+
+async def _run_local_rag(question: str, decision: RouteDecision) -> Answer:
+    store = QdrantVectorStore(collection_name=decision.collection_name)
+    embedder = create_rag_embedder()
+    generator = LocalGenerator(model="local_rag")
+    try:
+        retriever = Retriever(embedder=embedder, store=store)
+        pipeline = LocalRagPipeline(
+            retriever=retriever,
+            generator=generator,
+            prompt_builder=PromptBuilder(),
+        )
+        result = await pipeline.ask(question)
+        citations = tuple(
+            _citation_from_chunk(
+                chunk,
+                question_id="ad_hoc",
+                corpus=decision.corpus,
+                collection_name=decision.collection_name,
+            )
+            for chunk in result.chunks_used
+        )
+        return Answer(
+            answer=result.answer,
+            citations=citations,
+            route=decision.route,
+            corpus=decision.corpus,
+            latency_ms=float(result.latency_ms.get("total_ms", 0.0)),
+            citation_present=bool(citations),
+            fallback_reason=None,
+            error_category=None,
+        )
+    finally:
+        await _close_async_resource(embedder)
+        await generator.aclose()
+        store.close()
+
+
+def _citation_from_chunk(
+    chunk: RetrievedChunk,
+    *,
+    question_id: str,
+    corpus: str,
+    collection_name: str,
+) -> Citation:
+    payload = dict(chunk.payload)
+    source_id = str(payload.get("source_id") or chunk.doc_id)
+    origin_path = str(payload.get("origin_path") or "unknown")
+    return Citation(
+        question_id=question_id,
+        source_id=source_id,
+        doc_id=chunk.doc_id,
+        chunk_id=chunk.citation_id,
+        corpus=corpus,  # type: ignore[arg-type]
+        collection_name=collection_name,  # type: ignore[arg-type]
+        origin_path=origin_path,
+        score=chunk.score,
+        rank=chunk.rank or 1,
+        retrieval_mode="qdrant",
+        chunk_index=chunk.chunk_index,
+    )
+
+
+async def _close_async_resource(resource: object) -> None:
+    close = getattr(resource, "aclose", None)
+    if callable(close):
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+
+
+def _citation_to_dict(citation: Citation) -> dict[str, object]:
+    return {
+        "question_id": citation.question_id,
+        "source_id": citation.source_id,
+        "doc_id": citation.doc_id,
+        "chunk_id": citation.chunk_id,
+        "corpus": citation.corpus,
+        "collection_name": citation.collection_name,
+        "origin_path": citation.origin_path,
+        "score": citation.score,
+        "rank": citation.rank,
+        "retrieval_mode": citation.retrieval_mode,
+        "chunk_index": citation.chunk_index,
+    }
+
+
+def _validate_question(question: str) -> str:
+    if not isinstance(question, str):
+        raise TypeError("question must be a string")
+    clean_question = question.strip()
+    if not clean_question:
+        raise ValueError("question cannot be empty")
+    return clean_question
+
+
+def _safe_error_category(exc: Exception) -> str:
+    return exc.__class__.__name__.lower()
+
+
+def _elapsed_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
+def _forbidden_key_hits(value: object, path: str = "$") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key)
+            next_path = f"{path}.{key_text}"
+            if key_text in ANSWER_FORBIDDEN_KEYS:
+                hits.append(next_path)
+            hits.extend(_forbidden_key_hits(nested, next_path))
+    elif isinstance(value, list | tuple):
+        for index, nested in enumerate(value):
+            hits.extend(_forbidden_key_hits(nested, f"{path}[{index}]"))
+    return hits

--- a/docs/04_MEM/AGENT_CONTEXT.md
+++ b/docs/04_MEM/AGENT_CONTEXT.md
@@ -264,7 +264,8 @@ data/corpus/manifest.yaml
 | A0-PR01 | `feat/agent0-ingestion` | Controlled verify-only corpus ingestion pipeline | ✅ Complete |
 | A0-PR02 | `feat/agent0-dual-corpus-bootstrap` | Bootstrap internal and financial corpora into isolated Qdrant collections | ✅ Complete |
 | A0-PR03 | `feat/agent0-golden-questions` | Six golden questions and frozen citation contract | ✅ Complete |
-| A0-PR04 | `feat/agent0-domain-routing` | Deterministic domain routing by rules, confidence and state | 🚧 Current |
+| A0-PR04 | `feat/agent0-domain-routing` | Deterministic domain routing by rules, confidence and state | ✅ Complete |
+| A0-PR05 | `feat/agent0-cli-and-readiness` | OpenClaw ask CLI, readiness, opt-in E2E SLO gates and rollback docs | 🚧 Current |
 
 A0-PR01 rules:
 
@@ -337,6 +338,31 @@ A0-PR04 rules:
 - Routing reports contain safe metadata only; never query, text, answer, prompt,
   chunks, vectors, embeddings, payloads, headers, secrets, raw exceptions,
   tracebacks, absolute paths or usernames.
+
+A0-PR05 rules:
+
+- `backend/agent0/openclaw.py` exposes the first stable public interface:
+  `OpenClaw.ask(question: str) -> Answer`.
+- `Answer` is frozen and allowlisted. It may contain answer text and safe
+  citation metadata, but not prompt, chunks, chunk text, vectors, embeddings,
+  payloads, headers, API keys, Authorization values, raw exceptions or
+  tracebacks.
+- `scripts/openclaw.py ask "..."` is the supported CLI path for this PR.
+  It delegates to `OpenClaw.ask`, supports `--json`, and prints safe errors
+  without tracebacks by default.
+- Readiness lives in `scripts/check_agent0_readiness.py`. It checks local
+  Qdrant, `openclaw_internal`, `openclaw_financial`, LiteLLM, Ollama models,
+  required aliases, remote routing disabled, corpus manifests and golden
+  questions. It must not mutate Qdrant, bootstrap, ingest or reindex.
+- E2E lives in `tests/e2e/test_agent0_e2e.py` and is opt-in only via
+  `RUN_AGENT0_E2E=1`. If local services or bootstrapped corpora are unavailable,
+  it skips with a clear reason.
+- E2E report SLOs are p95 latency < 15s and citation hit rate >= 5/6 on the
+  six A0-PR03 golden questions. Reports omit answer text and question text.
+- Remote-call audit covers public Agent-0 modules and rejects imports of remote
+  provider SDKs such as OpenAI, Anthropic, Gemini/OpenRouter and Azure AI.
+- Rollback docs may delete only `openclaw_internal` and `openclaw_financial`.
+  Never delete or mutate `openclaw_knowledge` as part of Agent-0 rollback.
 
 G2-PR06 rules:
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,31 +5,30 @@
 > meaningful sessions.
 
 **Last updated:** 2026-05-08
-**Updated by:** Codex — A0-PR04 deterministic domain routing
+**Updated by:** Codex — A0-PR05 OpenClaw ask CLI and readiness
 
 ---
 
-## Active Sprint: Agent-0 / Deterministic Domain Routing
+## Active Sprint: Agent-0 / CLI and Readiness
 
-**Goal:** add deterministic, local-only Agent-0 domain routing that classifies
-queries by keyword/regex, reads thresholds from `config/rag_config.yaml`, and
-chooses `local_rag`, `local_think` or `local_chat` from retrieval confidence and
-system state.
+**Goal:** expose the first stable public Agent-0 interface,
+`OpenClaw.ask(question) -> Answer`, plus a local CLI, readiness checks,
+opt-in E2E SLO gates, sanitized reports and rollback docs.
 
-Current branch: `feat/agent0-domain-routing`
-Current issue: <https://github.com/franciscosalido/OPENCLAW/issues/80>
+Current branch: `feat/agent0-cli-and-readiness`
+Current issue: <https://github.com/franciscosalido/OPENCLAW/issues/82>
 
-A0-PR04 starts after A0-PR03. It routes evidence-seeking Agent-0 questions but
-does not retrieve live Qdrant data, mutate collections, call LLMs or generate
-answers.
+A0-PR05 starts after A0-PR04 and closes the Agent-0 MVP sprint surface. It
+does not add multi-agent orchestration, FastAPI, MCP, UI, remote providers,
+remote fallback, new ingestion, reindexing or Qdrant mutation in readiness.
 
 ```text
-query/question_id
-  -> deterministic domain classifier
-  -> config-backed thresholds
-  -> injected retrieval confidence scorer
-  -> frozen RouteDecision
-  -> sanitized routing report
+question
+  -> OpenClaw.ask
+  -> deterministic domain routing
+  -> existing local RAG path when route == local_rag
+  -> frozen Answer with metadata-only citations
+  -> CLI / sanitized E2E report
 ```
 
 Current runtime path:
@@ -89,38 +88,44 @@ Hard constraints remain:
 - No Qdrant mutation or live Qdrant requirement in A0-PR03 unit tests.
 - No LLM classifier, embeddings, rerankers, remote providers or live Qdrant
   dependency in A0-PR04 classifier/routing unit tests.
+- No Qdrant mutation, reindexing or bootstrap in A0-PR05 readiness checks.
+- A0-PR05 E2E is opt-in only via `RUN_AGENT0_E2E=1`; unit tests remain offline.
+- A0-PR05 reports must not serialize prompt, question text, answer text, chunks,
+  vectors, embeddings, payloads, headers, secrets, raw exceptions or tracebacks.
 - No final local merge into `main`; GitHub PR approval is the integration path.
 
-## A0-PR04 Current Work
+## A0-PR05 Current Work
 
-A0-PR04 adds deterministic domain routing primitives:
+A0-PR05 adds the final Agent-0 MVP public/readiness surface:
 
-- `backend/agent0/domain_classifier.py` with pure keyword/regex rules.
-- `backend/agent0/domain_routing.py` with typed config, `SystemState`,
-  `ConfidenceScorer`, `FakeConfidenceScorer`, frozen `RouteDecision`,
-  golden-question gate and dry-run p95 measurement.
-- `backend/agent0/routing_report.py` with sanitized routing reports.
-- `config/rag_config.yaml` `agent0.domain_routing` thresholds and rule
-  metadata.
-- `docs/AGENT0_DOMAIN_ROUTING.md`.
+- `backend/agent0/openclaw.py` with `OpenClaw.ask(...)` and frozen `Answer`.
+- `scripts/openclaw.py` with `ask` command and safe JSON/human output.
+- `scripts/check_agent0_readiness.py` with idempotent local readiness checks.
+- `backend/agent0/e2e_report.py` with sanitized E2E SLO report builder.
+- `tests/e2e/test_agent0_e2e.py`, guarded by `RUN_AGENT0_E2E=1`.
+- `docs/AGENT0_RUNBOOK.md` and `docs/AGENT0_ROLLBACK.md`.
 
 Rules:
 
-- Domain classifier imports no gateway clients, Ollama, LiteLLM, Qdrant,
-  embedders, retrievers or remote providers.
-- Thresholds are loaded from `rag_config.yaml`; do not hardcode route
-  thresholds in Python.
-- `iq-*` routes to `internal` / `openclaw_internal`; financial keywords route
-  to `macroeconomia`, `renda_fixa` or `valuation` in `openclaw_financial`.
-- Qdrant unavailable or unknown domain returns `local_chat` with safe
-  `reason_code`.
-- High confidence returns `local_rag`; medium confidence returns `local_think`;
-  low confidence returns `local_chat`.
-- A0-PR03 golden routing gate is currently 6/6 with fake high confidence.
-- Offline dry-run p95 is currently ~0.003 ms against a 100 ms budget.
-- Reports and `RouteDecision.to_dict()` contain safe metadata only; never query,
-  answer, prompt, chunks, vectors, embeddings, payloads, secrets, headers, raw
-  exceptions, tracebacks, absolute paths or usernames.
+- `OpenClaw.ask` must reuse existing routing, citation and RAG components; do
+  not duplicate the pipeline in the public API wrapper.
+- CLI must call `OpenClaw.ask`, support `--json`, avoid tracebacks by default
+  and never print prompt/chunks/vectors/payloads/secrets.
+- Readiness checks verify Qdrant reachability/collections, local LiteLLM,
+  Ollama models, aliases, remote routing disabled, corpus manifests and golden
+  questions. They do not mutate Qdrant or bootstrap collections.
+- E2E SLO gate is opt-in and expects already-bootstrapped
+  `openclaw_internal` / `openclaw_financial`.
+- Final SLOs: E2E p95 < 15s and citation hit rate >= 5/6 on the six golden
+  questions when local services and corpora are available.
+- Rollback deletes only `openclaw_internal` and `openclaw_financial`; never
+  delete `openclaw_knowledge`.
+- Validation on Python 3.12.13:
+  `pytest -v` 561 passed / 9 skipped / 217 subtests passed,
+  `mypy --strict .` 0 errors, `pyright` 0 errors, smoke 5 passed / 7 skipped.
+- Optional live check status: CLI returns a sanitized local auth failure when
+  local gateway credentials are absent; readiness reported 7/9 with only
+  Agent-0 Qdrant collections missing in this local environment.
 
 ---
 

--- a/docs/AGENT0_ROLLBACK.md
+++ b/docs/AGENT0_ROLLBACK.md
@@ -1,0 +1,15 @@
+# Agent-0 Rollback
+
+Use this runbook only for rolling back the Agent-0 sprint surface.
+
+```bash
+git revert <A0_MERGE_COMMIT>
+qdrant collection delete openclaw_internal
+qdrant collection delete openclaw_financial
+uv run pytest tests/unit -v
+uv run mypy --strict .
+uv run pyright
+```
+
+Do not delete `openclaw_knowledge`. It is outside the Agent-0 dual-corpus
+bootstrap namespace.

--- a/docs/AGENT0_RUNBOOK.md
+++ b/docs/AGENT0_RUNBOOK.md
@@ -1,0 +1,71 @@
+# Agent-0 Runbook
+
+## Purpose
+
+Agent-0 exposes the first public OpenClaw question interface:
+
+```python
+class OpenClaw:
+    def ask(self, question: str) -> Answer: ...
+```
+
+The CLI wrapper is:
+
+```bash
+uv run python scripts/openclaw.py ask "qual o estado do GW-07?"
+uv run python scripts/openclaw.py ask "qual o estado do GW-07?" --json
+```
+
+## Prerequisites
+
+- Python 3.12 via `uv`.
+- Local Qdrant reachable on localhost.
+- LiteLLM local gateway reachable on `http://127.0.0.1:4000/v1`.
+- Ollama has `qwen3:14b` and `nomic-embed-text`.
+- A0-PR02 corpora have already been bootstrapped into:
+  - `openclaw_internal`
+  - `openclaw_financial`
+
+Agent-0 readiness does not bootstrap, ingest, reindex or mutate Qdrant.
+
+## Readiness
+
+```bash
+uv run python scripts/check_agent0_readiness.py --json
+```
+
+The readiness report is sanitized and checks:
+
+- Qdrant collections exist.
+- LiteLLM config has required aliases.
+- Ollama models are available.
+- Remote routing remains disabled.
+- Golden questions and corpus manifests load.
+
+## E2E SLOs
+
+The live E2E suite is opt-in:
+
+```bash
+RUN_AGENT0_E2E=1 uv run pytest tests/e2e/test_agent0_e2e.py -v
+```
+
+Final SLOs:
+
+- E2E p95 latency `< 15s`.
+- `citation_present >= 5/6` on golden questions.
+- zero remote provider imports in public Agent-0 modules.
+- zero forbidden content keys in reports/log-like outputs.
+- no regression in existing tests.
+
+## Safe Output
+
+`Answer.to_dict()` and E2E/readiness reports never include prompt, chunks,
+chunk text, vectors, embeddings, payloads, headers, API keys, authorization,
+raw exceptions or tracebacks.
+
+## Rollback
+
+See `docs/AGENT0_ROLLBACK.md`.
+
+Never delete `openclaw_knowledge` during Agent-0 rollback.

--- a/scripts/check_agent0_readiness.py
+++ b/scripts/check_agent0_readiness.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+"""Agent-0 local readiness checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+import httpx
+from qdrant_client import QdrantClient
+
+from backend.agent0.golden_questions import load_all_golden_questions
+from backend.gateway.config import REQUIRED_ALIASES, load_gateway_config
+from backend.gateway.health import REQUIRED_CHAT_MODEL, REQUIRED_EMBED_MODEL
+from backend.gateway.routing_policy import load_routing_policy
+from backend.ingestion.bootstrap import manifest_path_for_corpus
+from backend.ingestion.commit_store import DUAL_CORPUS_COLLECTIONS
+from backend.ingestion.manifest import load_manifest
+from backend.ingestion.report import assert_report_is_sanitized
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RAG_CONFIG_PATH = REPO_ROOT / "config" / "rag_config.yaml"
+LITELLM_CONFIG_PATH = REPO_ROOT / "config" / "litellm_config.yaml"
+READINESS_FORBIDDEN_KEYS = frozenset(
+    {
+        "query",
+        "question",
+        "text",
+        "answer",
+        "prompt",
+        "chunk",
+        "chunks",
+        "vector",
+        "vectors",
+        "embedding",
+        "embeddings",
+        "payload",
+        "headers",
+        "api_key",
+        "authorization",
+        "secret",
+        "raw_exception",
+        "traceback",
+    }
+)
+
+
+class CollectionClient(Protocol):
+    def collection_exists(self, collection_name: str) -> bool:
+        """Return whether a Qdrant collection exists."""
+        ...
+
+
+@dataclass(frozen=True)
+class ReadinessCheck:
+    """One sanitized readiness check result."""
+
+    name: str
+    passed: bool
+    reason_code: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "reason_code": self.reason_code,
+        }
+
+
+def run_readiness(
+    *,
+    qdrant_client_factory: Callable[[], CollectionClient] | None = None,
+    http_get: Callable[..., httpx.Response] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Run idempotent Agent-0 readiness checks without mutating Qdrant."""
+
+    checks: list[ReadinessCheck] = []
+    qdrant_client = (qdrant_client_factory or _default_qdrant_client_factory)()
+    try:
+        for collection in DUAL_CORPUS_COLLECTIONS.values():
+            checks.append(
+                _check_bool(
+                    f"qdrant_collection_{collection}",
+                    qdrant_client.collection_exists(collection),
+                    "collection_exists",
+                    "collection_missing",
+                )
+            )
+    except Exception:
+        checks.append(ReadinessCheck("qdrant_reachable", False, "qdrant_unreachable"))
+
+    checks.extend(_check_gateway_config())
+    checks.extend(_check_remote_disabled())
+    checks.extend(_check_manifests())
+    checks.extend(_check_golden_questions())
+    checks.extend(_check_live_services(http_get or httpx.get, env=env))
+
+    passed = sum(1 for check in checks if check.passed)
+    report: dict[str, Any] = {
+        "run_id": uuid4().hex,
+        "timestamp_utc": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "total_checks": len(checks),
+        "passed": passed,
+        "failed": len(checks) - passed,
+        "checks": [check.to_dict() for check in checks],
+    }
+    assert_readiness_report_sanitized(report)
+    return report
+
+
+def assert_readiness_report_sanitized(report: Mapping[str, Any]) -> None:
+    assert_report_is_sanitized(dict(report))
+    hits = _forbidden_key_hits(report)
+    if hits:
+        raise ValueError(f"readiness report contains forbidden keys: {hits}")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check Agent-0 local readiness.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = run_readiness()
+    if args.json:
+        sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(
+            f"Agent-0 readiness: {report['passed']}/{report['total_checks']} passed\n"
+        )
+    return 0 if report["failed"] == 0 else 1
+
+
+def _default_qdrant_client_factory() -> CollectionClient:
+    return QdrantClient(host="localhost", port=6333)
+
+
+def _check_gateway_config() -> list[ReadinessCheck]:
+    try:
+        config = load_gateway_config(LITELLM_CONFIG_PATH)
+        missing = REQUIRED_ALIASES - config.alias_names
+        return [
+            _check_bool(
+                "gateway_aliases",
+                not missing,
+                "aliases_present",
+                "aliases_missing",
+            )
+        ]
+    except Exception:
+        return [ReadinessCheck("gateway_aliases", False, "config_invalid")]
+
+
+def _check_remote_disabled() -> list[ReadinessCheck]:
+    try:
+        policy = load_routing_policy(RAG_CONFIG_PATH)
+        return [
+            _check_bool(
+                "remote_routing_disabled",
+                not policy.remote_enabled,
+                "remote_disabled",
+                "remote_enabled",
+            )
+        ]
+    except Exception:
+        return [ReadinessCheck("remote_routing_disabled", False, "config_invalid")]
+
+
+def _check_manifests() -> list[ReadinessCheck]:
+    checks: list[ReadinessCheck] = []
+    for corpus in ("internal", "financial"):
+        try:
+            manifest = load_manifest(manifest_path_for_corpus(corpus))
+            checks.append(
+                _check_bool(
+                    f"{corpus}_manifest",
+                    bool(manifest.documents),
+                    "manifest_loaded",
+                    "manifest_empty",
+                )
+            )
+        except Exception:
+            checks.append(ReadinessCheck(f"{corpus}_manifest", False, "manifest_invalid"))
+    return checks
+
+
+def _check_golden_questions() -> list[ReadinessCheck]:
+    try:
+        questions = load_all_golden_questions()
+        return [_check_bool("golden_questions", len(questions) == 6, "loaded", "invalid")]
+    except Exception:
+        return [ReadinessCheck("golden_questions", False, "invalid")]
+
+
+def _check_live_services(
+    http_get: Callable[..., httpx.Response],
+    *,
+    env: Mapping[str, str] | None,
+) -> list[ReadinessCheck]:
+    del env
+    return [
+        _check_litellm(http_get),
+        _check_ollama_models(http_get),
+    ]
+
+
+def _check_litellm(http_get: Callable[..., httpx.Response]) -> ReadinessCheck:
+    try:
+        response = http_get("http://127.0.0.1:4000/v1/models", timeout=3.0)
+        return _check_bool(
+            "litellm_local_reachable",
+            response.status_code < 500,
+            "reachable",
+            "unreachable",
+        )
+    except Exception:
+        return ReadinessCheck("litellm_local_reachable", False, "unreachable")
+
+
+def _check_ollama_models(http_get: Callable[..., httpx.Response]) -> ReadinessCheck:
+    try:
+        response = http_get("http://localhost:11434/api/tags", timeout=3.0)
+        raw = response.json()
+        if not isinstance(raw, Mapping):
+            return ReadinessCheck("ollama_models", False, "invalid_response")
+        models = raw.get("models")
+        if not isinstance(models, list):
+            return ReadinessCheck("ollama_models", False, "models_missing")
+        names = {str(model.get("name", "")) for model in models if isinstance(model, Mapping)}
+        base_names = {name.split(":")[0] for name in names}
+        chat_ok = REQUIRED_CHAT_MODEL in names or REQUIRED_CHAT_MODEL.split(":")[0] in base_names
+        embed_ok = REQUIRED_EMBED_MODEL in names or REQUIRED_EMBED_MODEL.split(":")[0] in base_names
+        return _check_bool("ollama_models", chat_ok and embed_ok, "models_present", "models_missing")
+    except Exception:
+        return ReadinessCheck("ollama_models", False, "unreachable")
+
+
+def _check_bool(name: str, value: bool, ok: str, fail: str) -> ReadinessCheck:
+    return ReadinessCheck(name=name, passed=value, reason_code=ok if value else fail)
+
+
+def _forbidden_key_hits(value: object, path: str = "$") -> list[str]:
+    hits: list[str] = []
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            key_text = str(key)
+            next_path = f"{path}.{key_text}"
+            if key_text in READINESS_FORBIDDEN_KEYS:
+                hits.append(next_path)
+            hits.extend(_forbidden_key_hits(nested, next_path))
+    elif isinstance(value, list | tuple):
+        for index, nested in enumerate(value):
+            hits.extend(_forbidden_key_hits(nested, f"{path}[{index}]"))
+    return hits
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/openclaw.py
+++ b/scripts/openclaw.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Public OpenClaw CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+
+from backend.agent0.openclaw import Answer, OpenClaw
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OpenClaw local-first CLI.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    ask_parser = subparsers.add_parser("ask", help="Ask one local Agent-0 question.")
+    ask_parser.add_argument("question", help="Question to answer locally.")
+    ask_parser.add_argument("--json", action="store_true", help="Emit safe JSON.")
+    ask_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Include safe error category only; never traceback.",
+    )
+    return parser.parse_args(argv)
+
+
+def render_answer(answer: Answer, *, json_output: bool) -> str:
+    """Render an answer without exposing prompt, chunks or payloads."""
+
+    if json_output:
+        return json.dumps(answer.to_dict(), ensure_ascii=False, sort_keys=True)
+    lines = [answer.answer]
+    if answer.citations:
+        lines.append("")
+        lines.append("Citations:")
+        for citation in answer.citations:
+            lines.append(
+                "- "
+                f"{citation.doc_id}#{citation.chunk_index} "
+                f"({citation.collection_name})"
+            )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        if args.command == "ask":
+            answer = OpenClaw().ask(args.question)
+            sys.stdout.write(render_answer(answer, json_output=args.json) + "\n")
+            return 1 if answer.error_category else 0
+        return 2
+    except Exception as exc:
+        error = {"error_category": exc.__class__.__name__.lower()}
+        sys.stderr.write(json.dumps(error, sort_keys=True) + "\n")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/test_agent0_e2e.py
+++ b/tests/e2e/test_agent0_e2e.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.agent0.e2e_report import assert_e2e_report_sanitized, build_e2e_report
+from backend.agent0.golden_questions import load_all_golden_questions
+from backend.agent0.openclaw import OpenClaw
+
+
+RUN_AGENT0_E2E = "RUN_AGENT0_E2E"
+E2E_P95_BUDGET_MS = 15_000.0
+MIN_CITATION_HITS = 5
+
+
+@unittest.skipUnless(
+    os.environ.get(RUN_AGENT0_E2E) == "1",
+    "Agent-0 E2E requires RUN_AGENT0_E2E=1 and local services/corpora.",
+)
+class Agent0E2ETests(unittest.TestCase):
+    def test_golden_questions_meet_slos(self) -> None:
+        api = OpenClaw()
+        results = []
+        try:
+            for question in load_all_golden_questions():
+                if question.enabled:
+                    answer = api.ask(question.text)
+                    if answer.error_category is not None:
+                        self.skipTest(
+                            "local Agent-0 services unavailable: "
+                            f"{answer.error_category}"
+                        )
+                    results.append((question.question_id, answer))
+        except Exception as exc:
+            self.skipTest(f"local Agent-0 services unavailable: {exc.__class__.__name__}")
+
+        report = build_e2e_report(results)
+
+        assert_e2e_report_sanitized(report)
+        self.assertLess(report["p95_latency_ms"], E2E_P95_BUDGET_MS)
+        self.assertGreaterEqual(report["passed"], MIN_CITATION_HITS)
+
+    def test_required_human_case_returns_citation(self) -> None:
+        try:
+            answer = OpenClaw().ask("qual o estado do GW-07?")
+        except Exception as exc:
+            self.skipTest(f"local Agent-0 services unavailable: {exc.__class__.__name__}")
+        if answer.error_category is not None:
+            self.skipTest(f"local Agent-0 services unavailable: {answer.error_category}")
+
+        self.assertTrue(answer.answer)
+        self.assertTrue(answer.citation_present)
+        self.assertGreaterEqual(len(answer.citations), 1)
+        self.assertNotIn("prompt", answer.to_dict())
+        self.assertNotIn("chunks", answer.to_dict())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent0_e2e_report.py
+++ b/tests/unit/test_agent0_e2e_report.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+
+from backend.agent0.e2e_report import (
+    assert_e2e_report_sanitized,
+    build_e2e_report,
+)
+from backend.agent0.golden_questions import Citation
+from backend.agent0.openclaw import Answer
+
+
+class Agent0E2EReportTests(unittest.TestCase):
+    def test_e2e_report_sanitized(self) -> None:
+        report = build_e2e_report(
+            [
+                ("iq-001", _answer(citation_present=True)),
+                ("fq-001", _answer(citation_present=False)),
+            ]
+        )
+
+        assert_e2e_report_sanitized(report)
+        self.assertEqual(report["total_questions"], 2)
+        self.assertEqual(report["failed_question_ids"], ["fq-001"])
+        self.assertEqual(report["citation_hit_rate"], 0.5)
+        self.assertNotIn("answer", report)
+        self.assertNotIn("question", report)
+
+    def test_e2e_report_rejects_forbidden_fields(self) -> None:
+        with self.assertRaises(ValueError):
+            assert_e2e_report_sanitized({"answer": "redacted"})
+
+
+def _answer(*, citation_present: bool) -> Answer:
+    return Answer(
+        answer="Resposta omitida do relatório.",
+        citations=(
+            (
+                Citation(
+                    question_id="iq-001",
+                    source_id="source",
+                    doc_id="internal_current_state",
+                    chunk_id="internal_current_state#0",
+                    corpus="internal",
+                    collection_name="openclaw_internal",
+                    origin_path="docs/current_state.md",
+                    score=1.0,
+                    rank=1,
+                    retrieval_mode="fake",
+                    chunk_index=0,
+                )
+            ),
+        )
+        if citation_present
+        else (),
+        route="local_rag",
+        corpus="internal",
+        latency_ms=10.0,
+        citation_present=citation_present,
+        fallback_reason=None,
+        error_category=None,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent0_readiness.py
+++ b/tests/unit/test_agent0_readiness.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import unittest
+
+import httpx
+
+from scripts.check_agent0_readiness import (
+    assert_readiness_report_sanitized,
+    run_readiness,
+)
+
+
+class Agent0ReadinessTests(unittest.TestCase):
+    def test_readiness_no_mutation_and_sanitized_report(self) -> None:
+        fake_qdrant = _FakeQdrant()
+
+        report = run_readiness(
+            qdrant_client_factory=lambda: fake_qdrant,
+            http_get=_fake_http_get,
+        )
+
+        self.assertEqual(fake_qdrant.mutations, [])
+        self.assertGreaterEqual(report["total_checks"], 8)
+        assert_readiness_report_sanitized(report)
+        self.assertNotIn("prompt", report)
+        self.assertNotIn("payload", report)
+
+    def test_readiness_report_sanitizer_rejects_forbidden_keys(self) -> None:
+        with self.assertRaises(ValueError):
+            assert_readiness_report_sanitized({"api_key": "sentinel"})
+
+
+class _FakeQdrant:
+    def __init__(self) -> None:
+        self.mutations: list[str] = []
+
+    def collection_exists(self, collection_name: str) -> bool:
+        return collection_name in {"openclaw_internal", "openclaw_financial"}
+
+    def create_collection(self, collection_name: str) -> None:
+        self.mutations.append(collection_name)
+
+
+def _fake_http_get(url: str, **kwargs: object) -> httpx.Response:
+    del kwargs
+    if url.endswith("/models"):
+        return httpx.Response(200, json={"data": [{"id": "local_chat"}]})
+    if url.endswith("/api/tags"):
+        return httpx.Response(
+            200,
+            json={
+                "models": [
+                    {"name": "qwen3:14b"},
+                    {"name": "nomic-embed-text"},
+                ]
+            },
+        )
+    return httpx.Response(404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent0_remote_audit.py
+++ b/tests/unit/test_agent0_remote_audit.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN_REMOTE_IMPORTS = (
+    "openai",
+    "anthropic",
+    "google.generativeai",
+    "gemini",
+    "openrouter",
+    "azure.ai",
+)
+PUBLIC_AGENT0_MODULES = (
+    REPO_ROOT / "backend" / "agent0" / "openclaw.py",
+    REPO_ROOT / "scripts" / "openclaw.py",
+)
+
+
+class Agent0RemoteAuditTests(unittest.TestCase):
+    def test_public_agent0_modules_do_not_import_remote_provider_sdks(self) -> None:
+        for module_path in PUBLIC_AGENT0_MODULES:
+            imports = _imports(module_path)
+            for imported in imports:
+                with self.subTest(module=str(module_path), imported=imported):
+                    self.assertFalse(imported.startswith(FORBIDDEN_REMOTE_IMPORTS))
+
+    def test_remote_config_disabled_and_aliases_local_only(self) -> None:
+        rag_config = yaml.safe_load(
+            (REPO_ROOT / "config" / "rag_config.yaml").read_text(encoding="utf-8")
+        )
+        gateway_config = yaml.safe_load(
+            (REPO_ROOT / "config" / "litellm_config.yaml").read_text(encoding="utf-8")
+        )
+        rag = cast(dict[str, Any], rag_config)
+        gateway = cast(dict[str, Any], rag["gateway"])
+        routing = cast(dict[str, Any], gateway["routing"])
+        self.assertFalse(routing["remote_enabled"])
+
+        litellm = cast(dict[str, Any], gateway_config)
+        model_list = cast(list[dict[str, Any]], litellm["model_list"])
+        for item in model_list:
+            params = cast(dict[str, Any], item["litellm_params"])
+            api_base = str(params.get("api_base", ""))
+            self.assertTrue(
+                api_base.startswith(("http://localhost:", "http://127.0.0.1:")),
+                api_base,
+            )
+
+    def test_rollback_doc_only_deletes_agent0_collections(self) -> None:
+        text = (REPO_ROOT / "docs" / "AGENT0_ROLLBACK.md").read_text(encoding="utf-8")
+
+        self.assertIn("qdrant collection delete openclaw_internal", text)
+        self.assertIn("qdrant collection delete openclaw_financial", text)
+        self.assertIn("Do not delete `openclaw_knowledge`", text)
+        self.assertNotIn("qdrant collection delete openclaw_knowledge", text)
+
+
+def _imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imports.append(node.module)
+    return imports
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_openclaw_api.py
+++ b/tests/unit/test_openclaw_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from backend.agent0.golden_questions import Citation
+from backend.agent0.openclaw import Answer, OpenClaw, assert_answer_sanitized
+
+
+class OpenClawApiTests(unittest.TestCase):
+    def test_ask_validates_non_empty_question(self) -> None:
+        api = OpenClaw(ask_backend=_fake_backend)
+
+        with self.assertRaises(ValueError):
+            api.ask("   ")
+
+    def test_ask_returns_safe_answer_with_citation(self) -> None:
+        api = OpenClaw(ask_backend=_fake_backend)
+
+        result = api.ask("qual o estado atual do GW-07?")
+
+        self.assertEqual(result.answer, "Resposta local sintética.")
+        self.assertEqual(result.route, "local_rag")
+        self.assertEqual(result.corpus, "internal")
+        self.assertTrue(result.citation_present)
+        self.assertEqual(result.citations[0].doc_id, "internal_current_state")
+        assert_answer_sanitized(result.to_dict())
+
+    def test_answer_is_frozen_and_safe(self) -> None:
+        answer = _answer()
+
+        with self.assertRaises(FrozenInstanceError):
+            answer.answer = "mutated"  # type: ignore[misc]
+
+        data = answer.to_dict()
+        self.assertNotIn("prompt", data)
+        self.assertNotIn("chunks", data)
+        self.assertNotIn("payload", data)
+
+    def test_answer_sanitizer_rejects_forbidden_keys(self) -> None:
+        with self.assertRaises(ValueError):
+            assert_answer_sanitized({"prompt": "redacted"})
+
+
+def _fake_backend(question: str, decision: object) -> Answer:
+    del question, decision
+    return _answer()
+
+
+def _answer() -> Answer:
+    return Answer(
+        answer="Resposta local sintética.",
+        citations=(
+            Citation(
+                question_id="iq-001",
+                source_id="internal-current-state-001",
+                doc_id="internal_current_state",
+                chunk_id="internal_current_state#0",
+                corpus="internal",
+                collection_name="openclaw_internal",
+                origin_path="docs/current_state.md",
+                score=1.0,
+                rank=1,
+                retrieval_mode="fake",
+                chunk_index=0,
+            ),
+        ),
+        route="local_rag",
+        corpus="internal",
+        latency_ms=1.0,
+        citation_present=True,
+        fallback_reason=None,
+        error_category=None,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_openclaw_cli.py
+++ b/tests/unit/test_openclaw_cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from backend.agent0.golden_questions import Citation
+from backend.agent0.openclaw import Answer
+from scripts import openclaw as openclaw_cli
+
+
+class OpenClawCliTests(unittest.TestCase):
+    def test_cli_delegates_to_openclaw_ask(self) -> None:
+        fake = _FakeOpenClaw()
+        stdout = StringIO()
+
+        with (
+            patch.object(openclaw_cli, "OpenClaw", return_value=fake),
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = openclaw_cli.main(["ask", "qual o estado do GW-07?"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(fake.questions, ["qual o estado do GW-07?"])
+        self.assertIn("Resposta local.", stdout.getvalue())
+
+    def test_cli_json_output_safe(self) -> None:
+        stdout = StringIO()
+        with (
+            patch.object(openclaw_cli, "OpenClaw", return_value=_FakeOpenClaw()),
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = openclaw_cli.main(["ask", "qual o estado do GW-07?", "--json"])
+
+        data = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(data["answer"], "Resposta local.")
+        self.assertNotIn("prompt", data)
+        self.assertNotIn("chunks", data)
+        self.assertNotIn("payload", data)
+
+    def test_cli_errors_are_safe(self) -> None:
+        stderr = StringIO()
+        with (
+            patch.object(openclaw_cli, "OpenClaw", side_effect=RuntimeError("boom")),
+            patch("sys.stderr", stderr),
+        ):
+            exit_code = openclaw_cli.main(["ask", "qual o estado do GW-07?"])
+
+        self.assertEqual(exit_code, 1)
+        data = json.loads(stderr.getvalue())
+        self.assertEqual(data, {"error_category": "runtimeerror"})
+
+
+class _FakeOpenClaw:
+    def __init__(self) -> None:
+        self.questions: list[str] = []
+
+    def ask(self, question: str) -> Answer:
+        self.questions.append(question)
+        return Answer(
+            answer="Resposta local.",
+            citations=(
+                Citation(
+                    question_id="iq-001",
+                    source_id="source",
+                    doc_id="internal_current_state",
+                    chunk_id="internal_current_state#0",
+                    corpus="internal",
+                    collection_name="openclaw_internal",
+                    origin_path="docs/current_state.md",
+                    score=1.0,
+                    rank=1,
+                    retrieval_mode="fake",
+                    chunk_index=0,
+                ),
+            ),
+            route="local_rag",
+            corpus="internal",
+            latency_ms=1.0,
+            citation_present=True,
+            fallback_reason=None,
+            error_category=None,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #82

## Summary
- Adds the stable public Agent-0 API: `OpenClaw.ask(question: str) -> Answer`.
- Adds `scripts/openclaw.py ask` with safe human and JSON output.
- Adds idempotent readiness checks for local Qdrant collections, LiteLLM, Ollama models, aliases, manifests, golden questions and remote-disabled policy.
- Adds opt-in E2E SLO tests guarded by `RUN_AGENT0_E2E=1` and sanitized E2E report builder.
- Adds Agent-0 runbook and rollback docs; rollback deletes only `openclaw_internal` and `openclaw_financial`, never `openclaw_knowledge`.

## Public API
`backend.agent0.OpenClaw.ask(...)` returns a frozen `Answer` with answer text, metadata-only citations, route/corpus, latency, citation flag and safe fallback/error categories.

## CLI
- `uv run python scripts/openclaw.py --help`
- `uv run python scripts/openclaw.py ask "qual o estado do GW-07?"`
- `uv run python scripts/openclaw.py ask "qual o estado do GW-07?" --json`

## Readiness
`uv run python scripts/check_agent0_readiness.py --json` is read-only and does not mutate, bootstrap, ingest or reindex Qdrant.

## E2E / SLO
`RUN_AGENT0_E2E=1 uv run pytest tests/e2e/test_agent0_e2e.py -v` is opt-in. It expects local services and the A0-PR02 corpora already bootstrapped. SLOs: p95 < 15s and citation hit rate >= 5/6.

## Validation
- `git diff --check`
- `uv run python scripts/openclaw.py --help`
- `uv run python scripts/openclaw.py ask "qual o estado do GW-07?" --help`
- `uv run python scripts/check_agent0_readiness.py --help`
- `uv run pytest tests/unit/test_openclaw_api.py tests/unit/test_openclaw_cli.py tests/unit/test_agent0_readiness.py tests/unit/test_agent0_remote_audit.py tests/unit/test_agent0_e2e_report.py -v` -> 14 passed, 22 subtests passed
- `uv run pytest -v` -> 561 passed, 9 skipped, 217 subtests passed
- `uv run mypy --strict .` -> 0 errors
- `uv run pyright` -> 0 errors
- `uv run pytest tests/smoke/ -v` -> 5 passed, 7 skipped

## Optional live results
- `uv run python scripts/openclaw.py ask "qual o estado do GW-07?" --json` returned a sanitized local auth failure (`gatewayauthenticationerror`) with no traceback or unsafe fields because local gateway credentials are not present in this shell.
- `uv run python scripts/check_agent0_readiness.py --json` reported 7/9 passing; only `openclaw_internal` and `openclaw_financial` are missing locally, as expected when the A0-PR02 bootstrap collections are not present.