### PR TITLE
[RAG-1A] PR 04 — Hybrid & Agentic Retrieval Config Contract

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,3 @@
+"""Configuration schemas and static YAML contracts for OpenClaw."""
+
+from __future__ import annotations

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -47,7 +47,7 @@ agentic_policy:
 
 tool_metadata:
   name: "search_knowledge"
-  description: "Read-only retrieval tool contract for future Agentic RAG wiring."
+  description: "Busca os top-k trechos mais relevantes dos corpora do QUIMERA. Use antes de gerar qualquer resposta que dependa de informação factual de documentos internos ou ativos financeiros."
   parameters:
     - name: "query"
       type: "string"

--- a/config/rag_config.yaml
+++ b/config/rag_config.yaml
@@ -1,6 +1,69 @@
 # RAG Pipeline Configuration — OPENCLAW RAG-0
 # All runtime values live here. Never hardcode in Python files.
 
+config_version: "1.0.0"
+
+retrieval:
+  mode: "dense"
+  max_rounds: 1
+  top_k: 10
+  fusion:
+    strategy: "rrf"
+    rrf_k: 60
+  min_score: null
+  no_result_fallback: "empty"
+  query_rewrite:
+    enabled: false
+    model: null
+    max_attempts: 1
+
+hybrid_search:
+  enabled: false
+  dense_vector_name: "dense"
+  sparse_vector_name: "sparse"
+  collections:
+    internal: "openclaw_internal"
+    financial: "openclaw_financial"
+    default: "openclaw_internal"
+  dense:
+    provider: "ollama"
+    model: "nomic-embed-text"
+    dimensions: 768
+    model_version: "1.0"
+  sparse:
+    provider: "fastembed"
+    model: "Qdrant/bm25"
+    tokenizer_language: "portuguese"
+    model_version: "1.0"
+
+agentic_policy:
+  enabled: false
+  allow_query_decomposition: false
+  allow_iterative_retrieval: false
+  max_retrieval_steps: 1
+  max_tool_calls: 1
+  max_query_rewrites: 0
+  max_context_reads: 1
+
+tool_metadata:
+  name: "search_knowledge"
+  description: "Read-only retrieval tool contract for future Agentic RAG wiring."
+  parameters:
+    - name: "query"
+      type: "string"
+      required: true
+    - name: "corpus"
+      type: "string"
+      required: false
+      enum:
+        - "internal"
+        - "financial"
+      default: "internal"
+    - name: "top_k"
+      type: "integer"
+      required: false
+      default: 10
+
 rag:
   chunking:
     max_tokens: 400

--- a/config/rag_config_model.py
+++ b/config/rag_config_model.py
@@ -30,14 +30,14 @@ class FusionConfig(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
     strategy: FusionStrategy
-    rrf_k: int = Field(gt=0)
+    rrf_k: int = Field(default=60, gt=0)
 
     @field_validator("strategy", mode="before")
     @classmethod
     def strategy_must_be_rrf(cls, value: object) -> object:
         """Reject future fusion strategies with a sprint-specific message."""
         if value != "rrf":
-            raise ValueError("fusion.strategy accepts only 'rrf' in RAG-1A PR04")
+            raise ValueError("fusion.strategy only supports 'rrf' in RAG-1A")
         return value
 
 
@@ -49,6 +49,14 @@ class QueryRewriteConfig(BaseModel):
     enabled: Literal[False] = False
     model: str | None
     max_attempts: int = Field(ge=1)
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def enabled_must_be_false(cls, value: object) -> object:
+        """Keep query rewriting impossible before its dedicated sprint."""
+        if value is not False:
+            raise ValueError("query_rewrite.enabled must be false in PR04")
+        return value
 
 
 class RetrievalConfig(BaseModel):
@@ -109,6 +117,14 @@ class HybridSearchConfig(BaseModel):
     dense: DenseVectorConfig
     sparse: SparseVectorConfig
 
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def enabled_must_be_false(cls, value: object) -> object:
+        """Keep hybrid retrieval impossible before its dedicated sprint."""
+        if value is not False:
+            raise ValueError("hybrid_search.enabled must be false in PR04")
+        return value
+
 
 class AgenticPolicyConfig(BaseModel):
     """Agentic retrieval policy block, present but disabled in PR-04."""
@@ -122,6 +138,14 @@ class AgenticPolicyConfig(BaseModel):
     max_tool_calls: int = Field(ge=1)
     max_query_rewrites: int = Field(ge=0)
     max_context_reads: int = Field(ge=1)
+
+    @field_validator("enabled", mode="before")
+    @classmethod
+    def enabled_must_be_false(cls, value: object) -> object:
+        """Keep agentic policy inactive until the Agentic RAG sprint."""
+        if value is not False:
+            raise ValueError("agentic_policy.enabled must be false in PR04")
+        return value
 
 
 class ToolParameterConfig(BaseModel):
@@ -204,25 +228,19 @@ def _validate_pr04_runtime_guards(config: RagConfig) -> None:
         raise ValueError("retrieval.mode 'hybrid' requires future RAG sprint")
 
     if config.retrieval.mode == "agentic":
-        raise ValueError(
-            "retrieval.mode 'agentic' reserved for Agentic RAG sprint"
-        )
+        raise ValueError("retrieval.mode 'agentic' not implemented in RAG-1A")
 
     if config.hybrid_search.enabled:
-        raise ValueError("hybrid_search.enabled must be false in RAG-1A PR04")
+        raise ValueError("hybrid_search.enabled must be false in PR04")
 
     if config.retrieval.no_result_fallback != "empty":
-        raise ValueError(
-            "retrieval.no_result_fallback must be 'empty' in RAG-1A PR04"
-        )
+        raise ValueError("no_result_fallback must be 'empty' in PR04")
 
     if config.retrieval.query_rewrite.enabled:
-        raise ValueError(
-            "retrieval.query_rewrite.enabled must be false in RAG-1A PR04"
-        )
+        raise ValueError("query_rewrite.enabled must be false in PR04")
 
     if config.agentic_policy.enabled:
-        raise ValueError("agentic_policy.enabled must be false in RAG-1A PR04")
+        raise ValueError("agentic_policy.enabled must be false in PR04")
 
 
 __all__ = [

--- a/config/rag_config_model.py
+++ b/config/rag_config_model.py
@@ -1,0 +1,233 @@
+"""Validated RAG retrieval configuration contract for RAG-1A PR-04.
+
+This module defines the YAML contract for dense, hybrid, and future agentic
+retrieval settings. PR-04 is intentionally configuration-only: loading this
+contract must not instantiate retrievers, connect to Qdrant, build sparse
+indexes, or alter collections.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+RetrievalMode = Literal["dense", "hybrid", "agentic"]
+FusionStrategy = Literal["rrf"]
+NoResultFallback = Literal["empty", "relax_threshold", "rewrite_query"]
+DenseProvider = Literal["ollama"]
+SparseProvider = Literal["fastembed"]
+ToolParameterType = Literal["string", "integer"]
+
+STRICT_MODEL_CONFIG = ConfigDict(extra="forbid", frozen=True)
+
+
+class FusionConfig(BaseModel):
+    """Reciprocal-rank-fusion configuration contract."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    strategy: FusionStrategy
+    rrf_k: int = Field(gt=0)
+
+
+class QueryRewriteConfig(BaseModel):
+    """Future query rewrite policy, disabled in PR-04."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    enabled: bool
+    model: str | None
+    max_attempts: int = Field(ge=1)
+
+
+class RetrievalConfig(BaseModel):
+    """Top-level retrieval policy shared by dense and future modes."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    mode: RetrievalMode
+    max_rounds: int = Field(ge=1)
+    top_k: int = Field(gt=0)
+    fusion: FusionConfig
+    min_score: float | None
+    no_result_fallback: NoResultFallback
+    query_rewrite: QueryRewriteConfig
+
+
+class HybridCollectionsConfig(BaseModel):
+    """Logical corpus-to-collection names for future hybrid retrieval."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    internal: str
+    financial: str
+    default: str
+
+
+class DenseVectorConfig(BaseModel):
+    """Dense vector model metadata for the current dense-only baseline."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    provider: DenseProvider
+    model: str
+    dimensions: int = Field(gt=0)
+    model_version: str
+
+
+class SparseVectorConfig(BaseModel):
+    """Sparse vector model metadata reserved for a future RAG sprint."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    provider: SparseProvider
+    model: str
+    tokenizer_language: str
+    model_version: str
+
+
+class HybridSearchConfig(BaseModel):
+    """Hybrid retrieval config block, present but disabled in PR-04."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    enabled: bool
+    dense_vector_name: str
+    sparse_vector_name: str
+    collections: HybridCollectionsConfig
+    dense: DenseVectorConfig
+    sparse: SparseVectorConfig
+
+
+class AgenticPolicyConfig(BaseModel):
+    """Agentic retrieval policy block, present but disabled in PR-04."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    enabled: bool
+    allow_query_decomposition: bool
+    allow_iterative_retrieval: bool
+    max_retrieval_steps: int = Field(ge=1)
+    max_tool_calls: int = Field(ge=1)
+    max_query_rewrites: int = Field(ge=0)
+    max_context_reads: int = Field(ge=1)
+
+
+class ToolParameterConfig(BaseModel):
+    """Metadata for one future retrieval tool parameter."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    name: str
+    type: ToolParameterType
+    required: bool
+    enum: tuple[str, ...] | None = None
+    default: str | int | None = None
+
+
+class ToolMetadataConfig(BaseModel):
+    """Read-only tool metadata contract for future Agentic RAG."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    name: str
+    description: str
+    parameters: tuple[ToolParameterConfig, ...]
+
+
+class RagConfig(BaseModel):
+    """Validated RAG retrieval configuration.
+
+    The legacy ``rag``, ``gateway``, and ``agent0`` mappings remain accepted so
+    the existing runtime loaders can keep reading ``config/rag_config.yaml``
+    without behavior changes while PR-04 introduces the stricter retrieval
+    contract at the top level.
+    """
+
+    model_config = STRICT_MODEL_CONFIG
+
+    config_version: str
+    retrieval: RetrievalConfig
+    hybrid_search: HybridSearchConfig
+    agentic_policy: AgenticPolicyConfig
+    tool_metadata: ToolMetadataConfig
+    rag: dict[str, object] | None = None
+    gateway: dict[str, object] | None = None
+    agent0: dict[str, object] | None = None
+
+
+def load_rag_config(path: Path) -> RagConfig:
+    """Load and validate the PR-04 RAG configuration contract.
+
+    Args:
+        path: Path to a YAML file matching the PR-04 RAG config schema.
+
+    Returns:
+        A fully validated ``RagConfig`` instance.
+
+    Raises:
+        ValueError: If YAML is not a mapping, config version is unsupported,
+            hybrid/agentic behavior is enabled, or another future-only option
+            is activated in this dense-only sprint.
+        yaml.YAMLError: If the YAML file cannot be parsed.
+
+    Example:
+        ``config = load_rag_config(Path("config/rag_config.yaml"))``
+    """
+    raw_yaml = path.read_text(encoding="utf-8")
+    raw_config = yaml.safe_load(raw_yaml)
+    if not isinstance(raw_config, dict):
+        raise ValueError("rag_config.yaml must contain a YAML mapping")
+
+    config = RagConfig.model_validate(cast("dict[str, object]", raw_config))
+    _validate_pr04_runtime_guards(config)
+    return config
+
+
+def _validate_pr04_runtime_guards(config: RagConfig) -> None:
+    """Reject future retrieval modes while PR-04 remains config-only."""
+    if not config.config_version.startswith("1."):
+        raise ValueError("config_version must start with '1.'")
+
+    if config.retrieval.mode == "hybrid":
+        raise ValueError("retrieval.mode 'hybrid' requires future RAG sprint")
+
+    if config.retrieval.mode == "agentic":
+        raise ValueError(
+            "retrieval.mode 'agentic' reserved for Agentic RAG sprint"
+        )
+
+    if config.hybrid_search.enabled:
+        raise ValueError("hybrid_search.enabled must be false in RAG-1A PR04")
+
+    if config.retrieval.no_result_fallback != "empty":
+        raise ValueError(
+            "retrieval.no_result_fallback must be 'empty' in RAG-1A PR04"
+        )
+
+    if config.retrieval.query_rewrite.enabled:
+        raise ValueError(
+            "retrieval.query_rewrite.enabled must be false in RAG-1A PR04"
+        )
+
+    if config.agentic_policy.enabled:
+        raise ValueError("agentic_policy.enabled must be false in RAG-1A PR04")
+
+
+__all__ = [
+    "AgenticPolicyConfig",
+    "DenseVectorConfig",
+    "FusionConfig",
+    "HybridCollectionsConfig",
+    "HybridSearchConfig",
+    "QueryRewriteConfig",
+    "RagConfig",
+    "RetrievalConfig",
+    "SparseVectorConfig",
+    "ToolMetadataConfig",
+    "ToolParameterConfig",
+    "load_rag_config",
+]

--- a/config/rag_config_model.py
+++ b/config/rag_config_model.py
@@ -12,14 +12,14 @@ from pathlib import Path
 from typing import Literal, cast
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 RetrievalMode = Literal["dense", "hybrid", "agentic"]
 FusionStrategy = Literal["rrf"]
 NoResultFallback = Literal["empty", "relax_threshold", "rewrite_query"]
 DenseProvider = Literal["ollama"]
 SparseProvider = Literal["fastembed"]
-ToolParameterType = Literal["string", "integer"]
+ToolParameterType = Literal["string", "integer", "boolean", "array", "object"]
 
 STRICT_MODEL_CONFIG = ConfigDict(extra="forbid", frozen=True)
 
@@ -32,13 +32,21 @@ class FusionConfig(BaseModel):
     strategy: FusionStrategy
     rrf_k: int = Field(gt=0)
 
+    @field_validator("strategy", mode="before")
+    @classmethod
+    def strategy_must_be_rrf(cls, value: object) -> object:
+        """Reject future fusion strategies with a sprint-specific message."""
+        if value != "rrf":
+            raise ValueError("fusion.strategy accepts only 'rrf' in RAG-1A PR04")
+        return value
+
 
 class QueryRewriteConfig(BaseModel):
     """Future query rewrite policy, disabled in PR-04."""
 
     model_config = STRICT_MODEL_CONFIG
 
-    enabled: bool
+    enabled: Literal[False] = False
     model: str | None
     max_attempts: int = Field(ge=1)
 
@@ -49,7 +57,7 @@ class RetrievalConfig(BaseModel):
     model_config = STRICT_MODEL_CONFIG
 
     mode: RetrievalMode
-    max_rounds: int = Field(ge=1)
+    max_rounds: int = Field(default=1, ge=1)
     top_k: int = Field(gt=0)
     fusion: FusionConfig
     min_score: float | None
@@ -94,7 +102,7 @@ class HybridSearchConfig(BaseModel):
 
     model_config = STRICT_MODEL_CONFIG
 
-    enabled: bool
+    enabled: Literal[False] = False
     dense_vector_name: str
     sparse_vector_name: str
     collections: HybridCollectionsConfig
@@ -107,7 +115,7 @@ class AgenticPolicyConfig(BaseModel):
 
     model_config = STRICT_MODEL_CONFIG
 
-    enabled: bool
+    enabled: Literal[False] = False
     allow_query_decomposition: bool
     allow_iterative_retrieval: bool
     max_retrieval_steps: int = Field(ge=1)

--- a/tests/unit/test_rag_config_model.py
+++ b/tests/unit/test_rag_config_model.py
@@ -1,0 +1,256 @@
+"""Tests for the RAG-1A PR-04 retrieval config contract."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic import ValidationError
+
+from config.rag_config_model import RagConfig, load_rag_config
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PROJECT_RAG_CONFIG = REPO_ROOT / "config" / "rag_config.yaml"
+
+
+def _valid_config() -> dict[str, Any]:
+    return {
+        "config_version": "1.0.0",
+        "retrieval": {
+            "mode": "dense",
+            "max_rounds": 1,
+            "top_k": 10,
+            "fusion": {"strategy": "rrf", "rrf_k": 60},
+            "min_score": None,
+            "no_result_fallback": "empty",
+            "query_rewrite": {
+                "enabled": False,
+                "model": None,
+                "max_attempts": 1,
+            },
+        },
+        "hybrid_search": {
+            "enabled": False,
+            "dense_vector_name": "dense",
+            "sparse_vector_name": "sparse",
+            "collections": {
+                "internal": "openclaw_internal",
+                "financial": "openclaw_financial",
+                "default": "openclaw_internal",
+            },
+            "dense": {
+                "provider": "ollama",
+                "model": "nomic-embed-text",
+                "dimensions": 768,
+                "model_version": "1.0",
+            },
+            "sparse": {
+                "provider": "fastembed",
+                "model": "Qdrant/bm25",
+                "tokenizer_language": "portuguese",
+                "model_version": "1.0",
+            },
+        },
+        "agentic_policy": {
+            "enabled": False,
+            "allow_query_decomposition": False,
+            "allow_iterative_retrieval": False,
+            "max_retrieval_steps": 1,
+            "max_tool_calls": 1,
+            "max_query_rewrites": 0,
+            "max_context_reads": 1,
+        },
+        "tool_metadata": {
+            "name": "search_knowledge",
+            "description": "Read-only retrieval tool contract.",
+            "parameters": [
+                {"name": "query", "type": "string", "required": True},
+                {
+                    "name": "corpus",
+                    "type": "string",
+                    "required": False,
+                    "enum": ["internal", "financial"],
+                    "default": "internal",
+                },
+                {
+                    "name": "top_k",
+                    "type": "integer",
+                    "required": False,
+                    "default": 10,
+                },
+            ],
+        },
+    }
+
+
+def _section(data: dict[str, Any], name: str) -> dict[str, Any]:
+    section = data[name]
+    if not isinstance(section, dict):
+        raise AssertionError(f"section {name!r} is not a mapping")
+    return cast("dict[str, Any]", section)
+
+
+def _load_config(data: dict[str, Any]) -> RagConfig:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "rag_config.yaml"
+        path.write_text(
+            yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        return load_rag_config(path)
+
+
+def _load_text(raw_yaml: str) -> RagConfig:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "rag_config.yaml"
+        path.write_text(raw_yaml, encoding="utf-8")
+        return load_rag_config(path)
+
+
+class RagConfigModelTests(unittest.TestCase):
+    """Positive and negative tests for ``load_rag_config``."""
+
+    def test_valid_dense_only_config(self) -> None:
+        config = _load_config(_valid_config())
+
+        self.assertEqual(config.config_version, "1.0.0")
+        self.assertEqual(config.retrieval.mode, "dense")
+        self.assertEqual(config.retrieval.top_k, 10)
+        self.assertEqual(config.retrieval.fusion.strategy, "rrf")
+        self.assertFalse(config.hybrid_search.enabled)
+        self.assertEqual(config.hybrid_search.dense.model, "nomic-embed-text")
+        self.assertEqual(
+            config.hybrid_search.collections.internal,
+            "openclaw_internal",
+        )
+
+    def test_project_rag_config_example_loads(self) -> None:
+        config = load_rag_config(PROJECT_RAG_CONFIG)
+
+        self.assertEqual(config.retrieval.mode, "dense")
+        self.assertFalse(config.hybrid_search.enabled)
+        self.assertEqual(config.hybrid_search.dense.dimensions, 768)
+        self.assertIsNotNone(config.rag)
+        self.assertIsNotNone(config.gateway)
+        self.assertIsNotNone(config.agent0)
+
+    def test_dense_only_contract_preserves_current_runtime_fields(self) -> None:
+        config = _load_config(_valid_config())
+
+        self.assertEqual(config.retrieval.top_k, 10)
+        self.assertEqual(config.hybrid_search.dense.provider, "ollama")
+        self.assertEqual(config.hybrid_search.dense.model, "nomic-embed-text")
+        self.assertEqual(config.hybrid_search.dense.dimensions, 768)
+        self.assertEqual(
+            config.hybrid_search.collections.default,
+            "openclaw_internal",
+        )
+
+    def test_invalid_config_version(self) -> None:
+        data = _valid_config()
+        data["config_version"] = "2.0.0"
+
+        with self.assertRaisesRegex(ValueError, "config_version"):
+            _load_config(data)
+
+    def test_mode_hybrid_not_allowed(self) -> None:
+        data = _valid_config()
+        _section(data, "retrieval")["mode"] = "hybrid"
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "retrieval.mode 'hybrid' requires future RAG sprint",
+        ):
+            _load_config(data)
+
+    def test_mode_agentic_not_allowed(self) -> None:
+        data = _valid_config()
+        _section(data, "retrieval")["mode"] = "agentic"
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "retrieval.mode 'agentic' reserved for Agentic RAG sprint",
+        ):
+            _load_config(data)
+
+    def test_hybrid_enabled_not_allowed(self) -> None:
+        data = _valid_config()
+        _section(data, "hybrid_search")["enabled"] = True
+
+        with self.assertRaisesRegex(ValueError, "hybrid_search.enabled"):
+            _load_config(data)
+
+    def test_agentic_policy_enabled_not_allowed(self) -> None:
+        data = _valid_config()
+        _section(data, "agentic_policy")["enabled"] = True
+
+        with self.assertRaisesRegex(ValueError, "agentic_policy.enabled"):
+            _load_config(data)
+
+    def test_query_rewrite_enabled_not_allowed(self) -> None:
+        data = _valid_config()
+        retrieval = _section(data, "retrieval")
+        _section(retrieval, "query_rewrite")["enabled"] = True
+
+        with self.assertRaisesRegex(ValueError, "query_rewrite.enabled"):
+            _load_config(data)
+
+    def test_invalid_fusion_strategy(self) -> None:
+        data = _valid_config()
+        retrieval = _section(data, "retrieval")
+        _section(retrieval, "fusion")["strategy"] = "dbsf"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("rrf", str(ctx.exception))
+
+    def test_invalid_no_result_fallback(self) -> None:
+        data = _valid_config()
+        _section(data, "retrieval")["no_result_fallback"] = "rewrite_query"
+
+        with self.assertRaisesRegex(ValueError, "no_result_fallback"):
+            _load_config(data)
+
+    def test_sparse_tokenizer_language_present(self) -> None:
+        config = RagConfig.model_validate(_valid_config())
+
+        self.assertEqual(
+            config.hybrid_search.sparse.tokenizer_language,
+            "portuguese",
+        )
+
+    def test_extra_fields_forbidden(self) -> None:
+        data = _valid_config()
+        _section(data, "retrieval")["unexpected"] = "blocked"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+
+    def test_extra_fields_forbidden_in_nested_blocks(self) -> None:
+        data = _valid_config()
+        retrieval = _section(data, "retrieval")
+        _section(retrieval, "fusion")["unexpected"] = "blocked"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+
+    def test_invalid_top_level_field_forbidden(self) -> None:
+        data = _valid_config()
+        data["runtime_side_effect"] = "blocked"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+
+    def test_config_requires_yaml_mapping(self) -> None:
+        with self.assertRaisesRegex(ValueError, "YAML mapping"):
+            _load_text("- not\n- a\n- mapping\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_rag_config_model.py
+++ b/tests/unit/test_rag_config_model.py
@@ -124,6 +124,7 @@ class RagConfigModelTests(unittest.TestCase):
         self.assertEqual(config.retrieval.mode, "dense")
         self.assertEqual(config.retrieval.top_k, 10)
         self.assertEqual(config.retrieval.fusion.strategy, "rrf")
+        self.assertEqual(config.retrieval.fusion.rrf_k, 60)
         self.assertFalse(config.hybrid_search.enabled)
         self.assertEqual(config.hybrid_search.dense.model, "nomic-embed-text")
         self.assertEqual(
@@ -138,6 +139,15 @@ class RagConfigModelTests(unittest.TestCase):
         config = _load_config(data)
 
         self.assertEqual(config.retrieval.max_rounds, 1)
+
+    def test_fusion_rrf_k_defaults_to_sixty(self) -> None:
+        data = _valid_config()
+        retrieval = _section(data, "retrieval")
+        del _section(retrieval, "fusion")["rrf_k"]
+
+        config = _load_config(data)
+
+        self.assertEqual(config.retrieval.fusion.rrf_k, 60)
 
     def test_project_rag_config_example_loads(self) -> None:
         config = load_rag_config(PROJECT_RAG_CONFIG)
@@ -192,7 +202,7 @@ class RagConfigModelTests(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "retrieval.mode 'agentic' reserved for Agentic RAG sprint",
+            "retrieval.mode 'agentic' not implemented in RAG-1A",
         ):
             _load_config(data)
 
@@ -200,23 +210,35 @@ class RagConfigModelTests(unittest.TestCase):
         data = _valid_config()
         _section(data, "hybrid_search")["enabled"] = True
 
-        with self.assertRaisesRegex(ValidationError, "hybrid_search.enabled"):
+        with self.assertRaises(ValidationError) as ctx:
             _load_config(data)
+        self.assertIn(
+            "hybrid_search.enabled must be false in PR04",
+            str(ctx.exception),
+        )
 
     def test_agentic_policy_enabled_not_allowed(self) -> None:
         data = _valid_config()
         _section(data, "agentic_policy")["enabled"] = True
 
-        with self.assertRaisesRegex(ValidationError, "agentic_policy.enabled"):
+        with self.assertRaises(ValidationError) as ctx:
             _load_config(data)
+        self.assertIn(
+            "agentic_policy.enabled must be false in PR04",
+            str(ctx.exception),
+        )
 
     def test_query_rewrite_enabled_not_allowed(self) -> None:
         data = _valid_config()
         retrieval = _section(data, "retrieval")
         _section(retrieval, "query_rewrite")["enabled"] = True
 
-        with self.assertRaisesRegex(ValidationError, "query_rewrite.enabled"):
+        with self.assertRaises(ValidationError) as ctx:
             _load_config(data)
+        self.assertIn(
+            "query_rewrite.enabled must be false in PR04",
+            str(ctx.exception),
+        )
 
     def test_invalid_fusion_strategy(self) -> None:
         data = _valid_config()
@@ -225,13 +247,19 @@ class RagConfigModelTests(unittest.TestCase):
 
         with self.assertRaises(ValidationError) as ctx:
             _load_config(data)
-        self.assertIn("fusion.strategy accepts only 'rrf' in RAG-1A PR04", str(ctx.exception))
+        self.assertIn(
+            "fusion.strategy only supports 'rrf' in RAG-1A",
+            str(ctx.exception),
+        )
 
     def test_invalid_no_result_fallback(self) -> None:
         data = _valid_config()
         _section(data, "retrieval")["no_result_fallback"] = "rewrite_query"
 
-        with self.assertRaisesRegex(ValueError, "no_result_fallback"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "no_result_fallback must be 'empty' in PR04",
+        ):
             _load_config(data)
 
     def test_sparse_tokenizer_language_present(self) -> None:

--- a/tests/unit/test_rag_config_model.py
+++ b/tests/unit/test_rag_config_model.py
@@ -65,7 +65,11 @@ def _valid_config() -> dict[str, Any]:
         },
         "tool_metadata": {
             "name": "search_knowledge",
-            "description": "Read-only retrieval tool contract.",
+            "description": (
+                "Busca os top-k trechos mais relevantes dos corpora do QUIMERA. "
+                "Use antes de gerar qualquer resposta que dependa de informação "
+                "factual de documentos internos ou ativos financeiros."
+            ),
             "parameters": [
                 {"name": "query", "type": "string", "required": True},
                 {
@@ -127,6 +131,14 @@ class RagConfigModelTests(unittest.TestCase):
             "openclaw_internal",
         )
 
+    def test_retrieval_max_rounds_defaults_to_one(self) -> None:
+        data = _valid_config()
+        del _section(data, "retrieval")["max_rounds"]
+
+        config = _load_config(data)
+
+        self.assertEqual(config.retrieval.max_rounds, 1)
+
     def test_project_rag_config_example_loads(self) -> None:
         config = load_rag_config(PROJECT_RAG_CONFIG)
 
@@ -136,6 +148,14 @@ class RagConfigModelTests(unittest.TestCase):
         self.assertIsNotNone(config.rag)
         self.assertIsNotNone(config.gateway)
         self.assertIsNotNone(config.agent0)
+
+    def test_project_tool_description_is_actionable_for_function_calling(self) -> None:
+        config = load_rag_config(PROJECT_RAG_CONFIG)
+
+        self.assertIn("Busca os top-k trechos", config.tool_metadata.description)
+        self.assertIn("Use antes de gerar", config.tool_metadata.description)
+        self.assertIn("documentos internos", config.tool_metadata.description)
+        self.assertIn("ativos financeiros", config.tool_metadata.description)
 
     def test_dense_only_contract_preserves_current_runtime_fields(self) -> None:
         config = _load_config(_valid_config())
@@ -180,14 +200,14 @@ class RagConfigModelTests(unittest.TestCase):
         data = _valid_config()
         _section(data, "hybrid_search")["enabled"] = True
 
-        with self.assertRaisesRegex(ValueError, "hybrid_search.enabled"):
+        with self.assertRaisesRegex(ValidationError, "hybrid_search.enabled"):
             _load_config(data)
 
     def test_agentic_policy_enabled_not_allowed(self) -> None:
         data = _valid_config()
         _section(data, "agentic_policy")["enabled"] = True
 
-        with self.assertRaisesRegex(ValueError, "agentic_policy.enabled"):
+        with self.assertRaisesRegex(ValidationError, "agentic_policy.enabled"):
             _load_config(data)
 
     def test_query_rewrite_enabled_not_allowed(self) -> None:
@@ -195,7 +215,7 @@ class RagConfigModelTests(unittest.TestCase):
         retrieval = _section(data, "retrieval")
         _section(retrieval, "query_rewrite")["enabled"] = True
 
-        with self.assertRaisesRegex(ValueError, "query_rewrite.enabled"):
+        with self.assertRaisesRegex(ValidationError, "query_rewrite.enabled"):
             _load_config(data)
 
     def test_invalid_fusion_strategy(self) -> None:
@@ -205,7 +225,7 @@ class RagConfigModelTests(unittest.TestCase):
 
         with self.assertRaises(ValidationError) as ctx:
             _load_config(data)
-        self.assertIn("rrf", str(ctx.exception))
+        self.assertIn("fusion.strategy accepts only 'rrf' in RAG-1A PR04", str(ctx.exception))
 
     def test_invalid_no_result_fallback(self) -> None:
         data = _valid_config()
@@ -221,6 +241,25 @@ class RagConfigModelTests(unittest.TestCase):
             config.hybrid_search.sparse.tokenizer_language,
             "portuguese",
         )
+
+    def test_tool_parameter_type_accepts_function_calling_json_schema_types(self) -> None:
+        data = _valid_config()
+        tool_metadata = _section(data, "tool_metadata")
+        parameters = tool_metadata["parameters"]
+        if not isinstance(parameters, list):
+            raise AssertionError("tool_metadata.parameters is not a list")
+        parameters.extend(
+            [
+                {"name": "include_metadata", "type": "boolean", "required": False},
+                {"name": "filters", "type": "object", "required": False},
+                {"name": "tags", "type": "array", "required": False},
+            ]
+        )
+
+        config = _load_config(data)
+        observed_types = {parameter.type for parameter in config.tool_metadata.parameters}
+
+        self.assertTrue({"boolean", "object", "array"}.issubset(observed_types))
 
     def test_extra_fields_forbidden(self) -> None:
         data = _valid_config()


### PR DESCRIPTION
## Objetivo
Definir o contrato YAML/Pydantic para retrieval (dense/hybrid/agentic), sem alterar o comportamento dense-only atual.

Closes #89

## Escopo incluído
- Atualiza config/rag_config.yaml com contrato v1.0.0 aditivo.
- Cria config/rag_config_model.py com Pydantic v2 e extra=forbid em todos os blocos novos.
- Cria load_rag_config(path: Path) -> RagConfig com guardas explícitas para manter hybrid/agentic/query rewrite desativados neste sprint.
- Cria tests/unit/test_rag_config_model.py com validações positivas e negativas.

## Fora de escopo preservado
- Sem implementação de retrieval híbrido, BM25, FastEmbed ou Agentic loops.
- Sem alteração de Qdrant, collections, ingest ou schema.
- Sem mudanças em evaluation/* ou no baseline runner PR-03.

## Validação
- uv run pytest tests/unit/test_rag_config_model.py -v
- uv run mypy --strict config/rag_config_model.py tests/unit/test_rag_config_model.py
- uv run pyright config/rag_config_model.py tests/unit/test_rag_config_model.py
- uv run pytest tests/unit/test_rag_embedder_factory.py tests/unit/test_embedding_contract_config.py tests/unit/test_gateway_routing_policy.py tests/unit/test_domain_routing_config.py tests/unit/test_domain_routing.py tests/unit/test_generation_budget.py tests/unit/test_model_residency.py tests/unit/test_context_packer.py tests/unit/test_rag_observability_config.py -v
- git diff --check
