### PR TITLE
[RAG-1A] PR 04A — Embedding Provider Contract & Versioned Embedding Metadata

### DIFF
--- a/backend/rag/embedding_config.py
+++ b/backend/rag/embedding_config.py
@@ -3,6 +3,9 @@
 This module validates embedding metadata only. It must not instantiate
 embedding models, connect to vector stores, create collections, or alter the
 current dense-only runtime behavior.
+
+Pydantic ``frozen=True`` protects normal assignment/deletion. It is not a
+security boundary against CPython escape hatches such as ``object.__setattr__``.
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ from typing import cast
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-STRICT_MODEL_CONFIG = ConfigDict(extra="forbid", frozen=True)
+STRICT_MODEL_CONFIG = ConfigDict(extra="forbid", frozen=True, strict=True)
 RAG1A_ALLOWED_ACTIVE_PROFILES = frozenset({"nomic_dense_v1"})
 KNOWN_MODEL_DIMENSIONS = {
     "nomic": 768,
@@ -87,6 +90,17 @@ class EmbeddingProfileConfig(BaseModel):
     def normalize_model_family(cls, value: str) -> str:
         """Normalize model family names for deterministic guards."""
         return value.strip().lower()
+
+    @field_validator("query_instruction", "document_instruction", mode="before")
+    @classmethod
+    def normalize_optional_instruction(cls, value: object) -> object:
+        """Normalize blank instructions and reject null-byte payloads."""
+        if value is None or not isinstance(value, str):
+            return value
+        if "\x00" in value:
+            raise ValueError("instruction fields cannot contain null bytes")
+        clean = value.strip()
+        return clean if clean else None
 
     @model_validator(mode="after")
     def validate_known_dimensions(self) -> EmbeddingProfileConfig:
@@ -298,7 +312,7 @@ def load_embeddings_config(path: Path) -> EmbeddingsConfig:
 
 
 def _has_text(value: str | None) -> bool:
-    return value is not None and bool(value.strip())
+    return value is not None and "\x00" not in value and bool(value.strip())
 
 
 __all__ = [

--- a/backend/rag/embedding_config.py
+++ b/backend/rag/embedding_config.py
@@ -1,0 +1,293 @@
+"""Versioned embedding profile contract for RAG-1A PR-04A.
+
+This module validates embedding metadata only. It must not instantiate
+embedding models, connect to vector stores, create collections, or alter the
+current dense-only runtime behavior.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+STRICT_MODEL_CONFIG = ConfigDict(extra="forbid", frozen=True)
+RAG1A_ALLOWED_ACTIVE_PROFILES = frozenset({"nomic_dense_v1"})
+KNOWN_MODEL_DIMENSIONS = {
+    "nomic": 768,
+    "qwen3": 4096,
+}
+KNOWN_CONTEXT_LIMITS = {
+    "nomic": 2048,
+    "qwen3": 32768,
+}
+SUPPORTED_NORMALIZED_DISTANCES = frozenset({"cosine", "dot"})
+VERSION_PATTERN = re.compile(r"^v\d+(?:\.\d+)?$")
+
+
+class EmbeddingProfileConfig(BaseModel):
+    """Immutable contract for one embedding vector space."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    provider: str
+    model: str
+    model_family: str
+    version: str
+    dimensions: int = Field(gt=0)
+    effective_dimensions: int | None = Field(default=None, gt=0)
+    mrl_supported: bool = False
+    context_length: int | None = Field(default=None, gt=0)
+    distance: str
+    normalized: bool
+    instruction_aware: bool = False
+    query_instruction: str | None = None
+    document_instruction: str | None = None
+    profile_fingerprint: str | None = None
+
+    @field_validator(
+        "provider",
+        "model",
+        "model_family",
+        "version",
+        "distance",
+        mode="after",
+    )
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        """Reject empty strings in required text fields."""
+        clean = value.strip()
+        if not clean:
+            raise ValueError("required string fields cannot be empty")
+        return clean
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def validate_version_format(cls, value: object) -> object:
+        """Require profile versions like ``v1`` or ``v1.2``."""
+        if not isinstance(value, str) or VERSION_PATTERN.fullmatch(value) is None:
+            raise ValueError("version must match 'v<major>' or 'v<major>.<minor>'")
+        return value
+
+    @field_validator("distance", mode="after")
+    @classmethod
+    def normalize_distance(cls, value: str) -> str:
+        """Normalize distance names for stable fingerprinting."""
+        return value.strip().lower()
+
+    @field_validator("model_family", mode="after")
+    @classmethod
+    def normalize_model_family(cls, value: str) -> str:
+        """Normalize model family names for deterministic guards."""
+        return value.strip().lower()
+
+    @model_validator(mode="after")
+    def validate_known_dimensions(self) -> EmbeddingProfileConfig:
+        """Reject known model families configured with incompatible dimensions."""
+        expected_dimensions = KNOWN_MODEL_DIMENSIONS.get(self.model_family)
+        if expected_dimensions is not None and self.dimensions != expected_dimensions:
+            raise ValueError(
+                f"model_family {self.model_family!r} requires "
+                f"dimensions={expected_dimensions}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_mrl_consistency(self) -> EmbeddingProfileConfig:
+        """Ensure Matryoshka dimensions are explicit and internally valid."""
+        if self.effective_dimensions is not None and not self.mrl_supported:
+            raise ValueError(
+                "effective_dimensions requires mrl_supported=true"
+            )
+        if (
+            self.effective_dimensions is not None
+            and self.effective_dimensions > self.dimensions
+        ):
+            raise ValueError("effective_dimensions must be <= dimensions")
+        return self
+
+    @model_validator(mode="after")
+    def validate_instruction_contract(self) -> EmbeddingProfileConfig:
+        """Keep query instructions aligned with instruction-aware models."""
+        if self.instruction_aware and not _has_text(self.query_instruction):
+            raise ValueError(
+                "instruction_aware=true requires query_instruction"
+            )
+        if not self.instruction_aware and self.query_instruction is not None:
+            raise ValueError(
+                "instruction_aware=false requires query_instruction=null"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_distance_normalization(self) -> EmbeddingProfileConfig:
+        """Validate distance semantics against vector normalization."""
+        if self.normalized and self.distance not in SUPPORTED_NORMALIZED_DISTANCES:
+            raise ValueError("normalized=true requires distance in {'cosine', 'dot'}")
+        if not self.normalized and self.distance == "dot":
+            raise ValueError("normalized=false cannot use distance='dot'")
+        return self
+
+    @model_validator(mode="after")
+    def validate_context_length(self) -> EmbeddingProfileConfig:
+        """Reject context windows above known family limits."""
+        if self.context_length is None:
+            return self
+        max_context_length = KNOWN_CONTEXT_LIMITS.get(self.model_family)
+        if (
+            max_context_length is not None
+            and self.context_length > max_context_length
+        ):
+            raise ValueError(
+                f"model_family {self.model_family!r} supports context_length "
+                f"<= {max_context_length}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_declared_fingerprint(self) -> EmbeddingProfileConfig:
+        """Validate a declared fingerprint without requiring one in YAML."""
+        if self.profile_fingerprint is None:
+            return self
+        from backend.rag.embedding_metadata import compute_profile_fingerprint
+
+        expected = compute_profile_fingerprint(self)
+        if self.profile_fingerprint != expected:
+            raise ValueError("profile_fingerprint does not match profile metadata")
+        return self
+
+
+class CollectionBindingConfig(BaseModel):
+    """Declarative mapping from collection name to embedding profile."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    profile: str
+
+    @field_validator("profile", mode="after")
+    @classmethod
+    def profile_must_not_be_empty(cls, value: str) -> str:
+        """Reject empty profile references."""
+        clean = value.strip()
+        if not clean:
+            raise ValueError("collection binding profile cannot be empty")
+        return clean
+
+
+class EmbeddingsConfig(BaseModel):
+    """Versioned embedding profile registry for the RAG config contract."""
+
+    model_config = STRICT_MODEL_CONFIG
+
+    config_version: str
+    active_profile: str
+    candidate_profiles: list[str] = Field(default_factory=list)
+    profiles: dict[str, EmbeddingProfileConfig]
+    collection_bindings: dict[str, CollectionBindingConfig]
+
+    @field_validator("config_version", mode="after")
+    @classmethod
+    def config_version_must_be_v1(cls, value: str) -> str:
+        """Accept only schema version 1.x in PR-04A."""
+        if not value.startswith("1."):
+            raise ValueError("embeddings.config_version must start with '1.'")
+        return value
+
+    @field_validator("active_profile", mode="after")
+    @classmethod
+    def active_profile_must_not_be_empty(cls, value: str) -> str:
+        """Reject empty active profile identifiers."""
+        clean = value.strip()
+        if not clean:
+            raise ValueError("active_profile cannot be empty")
+        return clean
+
+    @model_validator(mode="after")
+    def validate_active_profile_exists(self) -> EmbeddingsConfig:
+        """Require the active profile to exist in the profile registry."""
+        if self.active_profile not in self.profiles:
+            raise ValueError(f"active_profile {self.active_profile!r} is not defined")
+        return self
+
+    @model_validator(mode="after")
+    def validate_candidate_profiles_exist(self) -> EmbeddingsConfig:
+        """Require all candidates to exist in the profile registry."""
+        missing = sorted(set(self.candidate_profiles) - set(self.profiles))
+        if missing:
+            raise ValueError(f"candidate_profiles are not defined: {missing}")
+        return self
+
+    @model_validator(mode="after")
+    def validate_collection_bindings(self) -> EmbeddingsConfig:
+        """Require every collection binding to reference a known profile."""
+        missing = sorted(
+            {
+                binding.profile
+                for binding in self.collection_bindings.values()
+                if binding.profile not in self.profiles
+            }
+        )
+        if missing:
+            raise ValueError(f"collection_bindings reference unknown profiles: {missing}")
+        return self
+
+    @model_validator(mode="after")
+    def validate_sprint_guards(self) -> EmbeddingsConfig:
+        """Keep RAG-1A runtime on the current Nomic profile only."""
+        if self.active_profile not in RAG1A_ALLOWED_ACTIVE_PROFILES:
+            allowed = sorted(RAG1A_ALLOWED_ACTIVE_PROFILES)
+            raise ValueError(
+                f"active_profile {self.active_profile!r} is not enabled in RAG-1A "
+                f"- allowed profiles: {allowed}"
+            )
+        for collection_name, binding in self.collection_bindings.items():
+            if binding.profile != self.active_profile:
+                raise ValueError(
+                    f"collection {collection_name!r} must remain bound to "
+                    f"active_profile {self.active_profile!r} in RAG-1A"
+                )
+        return self
+
+
+def load_embeddings_config(path: Path) -> EmbeddingsConfig:
+    """Load and validate the ``embeddings`` config block.
+
+    Args:
+        path: YAML file containing either an ``embeddings`` top-level block or
+            the embeddings mapping itself.
+
+    Returns:
+        The validated embedding profile registry.
+
+    Raises:
+        ValueError: If the YAML shape is invalid or violates PR-04A guards.
+        yaml.YAMLError: If the YAML file cannot be parsed.
+    """
+    raw_yaml = path.read_text(encoding="utf-8")
+    raw_config = yaml.safe_load(raw_yaml)
+    if not isinstance(raw_config, Mapping):
+        raise ValueError("embedding config YAML must contain a mapping")
+
+    embeddings_config = raw_config.get("embeddings", raw_config)
+    if not isinstance(embeddings_config, Mapping):
+        raise ValueError("embeddings block must contain a mapping")
+
+    return EmbeddingsConfig.model_validate(
+        cast("dict[str, object]", embeddings_config)
+    )
+
+
+def _has_text(value: str | None) -> bool:
+    return value is not None and bool(value.strip())
+
+
+__all__ = [
+    "CollectionBindingConfig",
+    "EmbeddingProfileConfig",
+    "EmbeddingsConfig",
+    "load_embeddings_config",
+]

--- a/backend/rag/embedding_config.py
+++ b/backend/rag/embedding_config.py
@@ -69,9 +69,12 @@ class EmbeddingProfileConfig(BaseModel):
     @classmethod
     def validate_version_format(cls, value: object) -> object:
         """Require profile versions like ``v1`` or ``v1.2``."""
-        if not isinstance(value, str) or VERSION_PATTERN.fullmatch(value) is None:
+        if not isinstance(value, str):
             raise ValueError("version must match 'v<major>' or 'v<major>.<minor>'")
-        return value
+        clean = value.strip()
+        if VERSION_PATTERN.fullmatch(clean) is None:
+            raise ValueError("version must match 'v<major>' or 'v<major>.<minor>'")
+        return clean
 
     @field_validator("distance", mode="after")
     @classmethod

--- a/backend/rag/embedding_config.py
+++ b/backend/rag/embedding_config.py
@@ -153,6 +153,7 @@ class EmbeddingProfileConfig(BaseModel):
         """Validate a declared fingerprint without requiring one in YAML."""
         if self.profile_fingerprint is None:
             return self
+        # deferred import: breaks circular dependency with embedding_metadata.
         from backend.rag.embedding_metadata import compute_profile_fingerprint
 
         expected = compute_profile_fingerprint(self)
@@ -206,6 +207,14 @@ class EmbeddingsConfig(BaseModel):
             raise ValueError("active_profile cannot be empty")
         return clean
 
+    @field_validator("candidate_profiles", mode="after")
+    @classmethod
+    def candidate_profiles_must_be_unique(cls, value: list[str]) -> list[str]:
+        """Reject duplicate candidate profile identifiers."""
+        if len(value) != len(set(value)):
+            raise ValueError("candidate_profiles must not contain duplicates")
+        return value
+
     @model_validator(mode="after")
     def validate_active_profile_exists(self) -> EmbeddingsConfig:
         """Require the active profile to exist in the profile registry."""
@@ -237,7 +246,11 @@ class EmbeddingsConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_sprint_guards(self) -> EmbeddingsConfig:
-        """Keep RAG-1A runtime on the current Nomic profile only."""
+        """Keep RAG-1A runtime on the current Nomic profile only.
+
+        Sprint guard: relax this when Qwen3 becomes an allowed
+        ``active_profile`` during the embedding migration sprint.
+        """
         if self.active_profile not in RAG1A_ALLOWED_ACTIVE_PROFILES:
             allowed = sorted(RAG1A_ALLOWED_ACTIVE_PROFILES)
             raise ValueError(

--- a/backend/rag/embedding_metadata.py
+++ b/backend/rag/embedding_metadata.py
@@ -1,0 +1,63 @@
+"""Pure helpers for versioned embedding metadata compatibility."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from backend.rag.embedding_config import EmbeddingProfileConfig
+
+
+def compute_profile_fingerprint(profile: EmbeddingProfileConfig) -> str:
+    """Return a stable short fingerprint for an embedding vector space.
+
+    Args:
+        profile: Validated embedding profile metadata.
+
+    Returns:
+        A 16-character SHA-256 hex prefix derived from vector-space-defining
+        fields only.
+    """
+    effective_dimensions = profile.effective_dimensions or profile.dimensions
+    key_fields = {
+        "model": profile.model,
+        "model_family": profile.model_family,
+        "effective_dimensions": effective_dimensions,
+        "distance": profile.distance,
+        "normalized": profile.normalized,
+        "document_instruction": profile.document_instruction,
+    }
+    canonical = json.dumps(key_fields, sort_keys=True, ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def profiles_are_compatible(
+    a: EmbeddingProfileConfig,
+    b: EmbeddingProfileConfig,
+) -> bool:
+    """Return whether two profiles define the same embedding vector space.
+
+    Args:
+        a: First validated embedding profile.
+        b: Second validated embedding profile.
+
+    Returns:
+        ``True`` only when model identity, effective dimensions, distance,
+        normalization, and document-side instruction metadata are identical.
+    """
+    effective_a = a.effective_dimensions or a.dimensions
+    effective_b = b.effective_dimensions or b.dimensions
+    return (
+        a.model == b.model
+        and a.model_family == b.model_family
+        and effective_a == effective_b
+        and a.distance == b.distance
+        and a.normalized == b.normalized
+        and a.document_instruction == b.document_instruction
+    )
+
+
+__all__ = [
+    "compute_profile_fingerprint",
+    "profiles_are_compatible",
+]

--- a/tests/unit/test_embedding_config.py
+++ b/tests/unit/test_embedding_config.py
@@ -191,6 +191,14 @@ class EmbeddingConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "dimensions=4096"):
             _load_config(wrong_qwen3)
 
+    def test_numeric_strings_are_rejected_for_dimensions(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "nomic_dense_v1")["dimensions"] = "768"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("Input should be a valid integer", str(ctx.exception))
+
     def test_mrl_inconsistent_effective_dimensions(self) -> None:
         unsupported_mrl = _valid_embeddings_config()
         _profile(unsupported_mrl, "nomic_dense_v1")["effective_dimensions"] = 512
@@ -219,6 +227,31 @@ class EmbeddingConfigTests(unittest.TestCase):
         ] = "Use this query instruction."
         with self.assertRaisesRegex(ValueError, "query_instruction=null"):
             _load_config(nomic_with_instruction)
+
+    def test_query_instruction_rejects_null_byte(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "qwen3_dense_8b_v1")["query_instruction"] = "\x00"
+
+        with self.assertRaisesRegex(ValueError, "cannot contain null bytes"):
+            _load_config(data)
+
+    def test_document_instruction_blank_normalizes_to_none_for_fingerprint(self) -> None:
+        data = _valid_embeddings_config()
+        blank_document_instruction = deepcopy(_profile(data, "nomic_dense_v1"))
+        blank_document_instruction["document_instruction"] = ""
+
+        blank_profile = EmbeddingProfileConfig.model_validate(
+            blank_document_instruction
+        )
+        none_profile = EmbeddingProfileConfig.model_validate(
+            _profile(data, "nomic_dense_v1")
+        )
+
+        self.assertIsNone(blank_profile.document_instruction)
+        self.assertEqual(
+            compute_profile_fingerprint(blank_profile),
+            compute_profile_fingerprint(none_profile),
+        )
 
     def test_distance_normalization_contract(self) -> None:
         invalid_normalized = _valid_embeddings_config()

--- a/tests/unit/test_embedding_config.py
+++ b/tests/unit/test_embedding_config.py
@@ -1,0 +1,361 @@
+"""Tests for the PR-04A versioned embedding profile contract."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from pydantic import ValidationError
+
+from backend.rag.embedding_config import (
+    EmbeddingProfileConfig,
+    EmbeddingsConfig,
+    load_embeddings_config,
+)
+from backend.rag.embedding_metadata import (
+    compute_profile_fingerprint,
+    profiles_are_compatible,
+)
+
+
+def _valid_embeddings_config() -> dict[str, Any]:
+    return {
+        "embeddings": {
+            "config_version": "1.0.0",
+            "active_profile": "nomic_dense_v1",
+            "candidate_profiles": ["qwen3_dense_8b_v1"],
+            "profiles": {
+                "nomic_dense_v1": {
+                    "provider": "ollama",
+                    "model": "nomic-embed-text",
+                    "model_family": "nomic",
+                    "version": "v1",
+                    "dimensions": 768,
+                    "effective_dimensions": None,
+                    "mrl_supported": False,
+                    "context_length": 2048,
+                    "distance": "cosine",
+                    "normalized": True,
+                    "instruction_aware": False,
+                    "query_instruction": None,
+                    "document_instruction": None,
+                    "profile_fingerprint": None,
+                },
+                "qwen3_dense_8b_v1": {
+                    "provider": "sentence_transformers",
+                    "model": "Qwen/Qwen3-Embedding-8B",
+                    "model_family": "qwen3",
+                    "version": "v1",
+                    "dimensions": 4096,
+                    "effective_dimensions": None,
+                    "mrl_supported": True,
+                    "context_length": 32768,
+                    "distance": "cosine",
+                    "normalized": True,
+                    "instruction_aware": True,
+                    "query_instruction": (
+                        "Given a financial knowledge retrieval query in Brazilian "
+                        "Portuguese or English, retrieve relevant passages that "
+                        "answer the query."
+                    ),
+                    "document_instruction": None,
+                    "profile_fingerprint": None,
+                },
+            },
+            "collection_bindings": {
+                "openclaw_internal": {"profile": "nomic_dense_v1"},
+                "openclaw_financial": {"profile": "nomic_dense_v1"},
+            },
+        }
+    }
+
+
+def _embeddings_section(data: dict[str, Any]) -> dict[str, Any]:
+    embeddings = data["embeddings"]
+    if not isinstance(embeddings, dict):
+        raise AssertionError("embeddings is not a mapping")
+    return cast("dict[str, Any]", embeddings)
+
+
+def _profiles(data: dict[str, Any]) -> dict[str, Any]:
+    profiles = _embeddings_section(data)["profiles"]
+    if not isinstance(profiles, dict):
+        raise AssertionError("profiles is not a mapping")
+    return cast("dict[str, Any]", profiles)
+
+
+def _profile(data: dict[str, Any], profile_id: str) -> dict[str, Any]:
+    profile = _profiles(data)[profile_id]
+    if not isinstance(profile, dict):
+        raise AssertionError(f"profile {profile_id!r} is not a mapping")
+    return cast("dict[str, Any]", profile)
+
+
+def _collection_bindings(data: dict[str, Any]) -> dict[str, Any]:
+    bindings = _embeddings_section(data)["collection_bindings"]
+    if not isinstance(bindings, dict):
+        raise AssertionError("collection_bindings is not a mapping")
+    return cast("dict[str, Any]", bindings)
+
+
+def _load_config(data: dict[str, Any]) -> EmbeddingsConfig:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "embeddings.yaml"
+        path.write_text(
+            yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        return load_embeddings_config(path)
+
+
+def _load_embeddings_mapping(data: dict[str, Any]) -> EmbeddingsConfig:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "embeddings.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                _embeddings_section(data),
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        return load_embeddings_config(path)
+
+
+class EmbeddingConfigTests(unittest.TestCase):
+    """Schema and contract tests for embedding profile metadata."""
+
+    def test_valid_nomic_profile(self) -> None:
+        config = _load_config(_valid_embeddings_config())
+
+        nomic = config.profiles["nomic_dense_v1"]
+        self.assertEqual(config.active_profile, "nomic_dense_v1")
+        self.assertEqual(nomic.provider, "ollama")
+        self.assertEqual(nomic.model, "nomic-embed-text")
+        self.assertEqual(nomic.dimensions, 768)
+        self.assertFalse(nomic.instruction_aware)
+
+    def test_valid_qwen3_profile_as_candidate(self) -> None:
+        config = _load_config(_valid_embeddings_config())
+
+        qwen3 = config.profiles["qwen3_dense_8b_v1"]
+        self.assertIn("qwen3_dense_8b_v1", config.candidate_profiles)
+        self.assertEqual(qwen3.model, "Qwen/Qwen3-Embedding-8B")
+        self.assertEqual(qwen3.dimensions, 4096)
+        self.assertEqual(qwen3.context_length, 32768)
+        self.assertTrue(qwen3.mrl_supported)
+        self.assertTrue(qwen3.instruction_aware)
+        self.assertIsNotNone(qwen3.query_instruction)
+
+    def test_model_family_is_normalized_before_known_dimension_checks(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "qwen3_dense_8b_v1")["model_family"] = "Qwen3"
+
+        config = _load_config(data)
+
+        self.assertEqual(config.profiles["qwen3_dense_8b_v1"].model_family, "qwen3")
+
+    def test_load_accepts_embeddings_mapping_without_wrapper(self) -> None:
+        config = _load_embeddings_mapping(_valid_embeddings_config())
+
+        self.assertEqual(config.config_version, "1.0.0")
+        self.assertEqual(config.active_profile, "nomic_dense_v1")
+
+    def test_active_profile_guard_blocks_qwen3(self) -> None:
+        data = _valid_embeddings_config()
+        _embeddings_section(data)["active_profile"] = "qwen3_dense_8b_v1"
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "active_profile 'qwen3_dense_8b_v1' is not enabled in RAG-1A",
+        ):
+            _load_config(data)
+
+    def test_dimensions_required_and_correct(self) -> None:
+        missing_dimensions = _valid_embeddings_config()
+        del _profile(missing_dimensions, "nomic_dense_v1")["dimensions"]
+        with self.assertRaises(ValidationError):
+            _load_config(missing_dimensions)
+
+        wrong_nomic = _valid_embeddings_config()
+        _profile(wrong_nomic, "nomic_dense_v1")["dimensions"] = 4096
+        with self.assertRaisesRegex(ValueError, "dimensions=768"):
+            _load_config(wrong_nomic)
+
+        wrong_qwen3 = _valid_embeddings_config()
+        _profile(wrong_qwen3, "qwen3_dense_8b_v1")["dimensions"] = 768
+        with self.assertRaisesRegex(ValueError, "dimensions=4096"):
+            _load_config(wrong_qwen3)
+
+    def test_mrl_inconsistent_effective_dimensions(self) -> None:
+        unsupported_mrl = _valid_embeddings_config()
+        _profile(unsupported_mrl, "nomic_dense_v1")["effective_dimensions"] = 512
+        with self.assertRaisesRegex(ValueError, "mrl_supported=true"):
+            _load_config(unsupported_mrl)
+
+        too_large = _valid_embeddings_config()
+        _profile(too_large, "qwen3_dense_8b_v1")["effective_dimensions"] = 8192
+        with self.assertRaisesRegex(
+            ValueError,
+            "effective_dimensions must be <= dimensions",
+        ):
+            _load_config(too_large)
+
+    def test_instruction_aware_contract(self) -> None:
+        qwen_without_instruction = _valid_embeddings_config()
+        _profile(qwen_without_instruction, "qwen3_dense_8b_v1")[
+            "query_instruction"
+        ] = None
+        with self.assertRaisesRegex(ValueError, "requires query_instruction"):
+            _load_config(qwen_without_instruction)
+
+        nomic_with_instruction = _valid_embeddings_config()
+        _profile(nomic_with_instruction, "nomic_dense_v1")[
+            "query_instruction"
+        ] = "Use this query instruction."
+        with self.assertRaisesRegex(ValueError, "query_instruction=null"):
+            _load_config(nomic_with_instruction)
+
+    def test_distance_normalization_contract(self) -> None:
+        invalid_normalized = _valid_embeddings_config()
+        _profile(invalid_normalized, "nomic_dense_v1")["distance"] = "euclidean"
+        with self.assertRaisesRegex(ValueError, "distance in"):
+            _load_config(invalid_normalized)
+
+        invalid_dot = _valid_embeddings_config()
+        nomic = _profile(invalid_dot, "nomic_dense_v1")
+        nomic["normalized"] = False
+        nomic["distance"] = "dot"
+        with self.assertRaisesRegex(ValueError, "cannot use distance='dot'"):
+            _load_config(invalid_dot)
+
+    def test_context_length_limits(self) -> None:
+        nomic_too_long = _valid_embeddings_config()
+        _profile(nomic_too_long, "nomic_dense_v1")["context_length"] = 2049
+        with self.assertRaisesRegex(ValueError, "context_length <= 2048"):
+            _load_config(nomic_too_long)
+
+        qwen_too_long = _valid_embeddings_config()
+        _profile(qwen_too_long, "qwen3_dense_8b_v1")["context_length"] = 32769
+        with self.assertRaisesRegex(ValueError, "context_length <= 32768"):
+            _load_config(qwen_too_long)
+
+    def test_active_profile_exists_and_bindings_resolve(self) -> None:
+        missing_active = _valid_embeddings_config()
+        _embeddings_section(missing_active)["active_profile"] = "missing_profile"
+        with self.assertRaisesRegex(ValueError, "active_profile 'missing_profile'"):
+            _load_config(missing_active)
+
+        missing_binding = _valid_embeddings_config()
+        _collection_bindings(missing_binding)["openclaw_internal"] = {
+            "profile": "missing_profile"
+        }
+        with self.assertRaisesRegex(ValueError, "collection_bindings"):
+            _load_config(missing_binding)
+
+    def test_candidate_profiles_must_exist(self) -> None:
+        data = _valid_embeddings_config()
+        _embeddings_section(data)["candidate_profiles"] = ["missing_profile"]
+
+        with self.assertRaisesRegex(ValueError, "candidate_profiles"):
+            _load_config(data)
+
+    def test_collection_bindings_must_remain_on_active_nomic_in_rag1a(self) -> None:
+        data = _valid_embeddings_config()
+        _collection_bindings(data)["openclaw_financial"] = {
+            "profile": "qwen3_dense_8b_v1"
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "must remain bound to active_profile 'nomic_dense_v1'",
+        ):
+            _load_config(data)
+
+    def test_extra_fields_are_forbidden(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "nomic_dense_v1")["unexpected"] = "blocked"
+
+        with self.assertRaises(ValidationError) as ctx:
+            _load_config(data)
+        self.assertIn("Extra inputs are not permitted", str(ctx.exception))
+
+    def test_config_version_must_start_with_one(self) -> None:
+        data = _valid_embeddings_config()
+        _embeddings_section(data)["config_version"] = "2.0.0"
+
+        with self.assertRaisesRegex(ValueError, "config_version"):
+            _load_config(data)
+
+    def test_version_format_is_fixed(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "nomic_dense_v1")["version"] = "1"
+
+        with self.assertRaisesRegex(ValueError, "version must match"):
+            _load_config(data)
+
+    def test_profile_fingerprint_is_computed_and_validated_when_declared(self) -> None:
+        data = _valid_embeddings_config()
+        profile = EmbeddingProfileConfig.model_validate(
+            _profile(data, "nomic_dense_v1")
+        )
+        fingerprint = compute_profile_fingerprint(profile)
+        _profile(data, "nomic_dense_v1")["profile_fingerprint"] = fingerprint
+
+        config = _load_config(data)
+
+        self.assertEqual(
+            config.profiles["nomic_dense_v1"].profile_fingerprint,
+            fingerprint,
+        )
+        self.assertEqual(len(fingerprint), 16)
+
+    def test_profile_fingerprint_mismatch_is_rejected(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "nomic_dense_v1")["profile_fingerprint"] = "badfingerprint"
+
+        with self.assertRaisesRegex(ValueError, "profile_fingerprint"):
+            _load_config(data)
+
+    def test_profiles_are_compatible_only_for_same_vector_space(self) -> None:
+        data = _valid_embeddings_config()
+        nomic_a = EmbeddingProfileConfig.model_validate(
+            _profile(data, "nomic_dense_v1")
+        )
+        nomic_b = EmbeddingProfileConfig.model_validate(
+            deepcopy(_profile(data, "nomic_dense_v1"))
+        )
+        qwen3 = EmbeddingProfileConfig.model_validate(
+            _profile(data, "qwen3_dense_8b_v1")
+        )
+
+        self.assertTrue(profiles_are_compatible(nomic_a, nomic_b))
+        self.assertFalse(profiles_are_compatible(nomic_a, qwen3))
+
+    def test_profile_fingerprint_changes_with_vector_space_fields(self) -> None:
+        data = _valid_embeddings_config()
+        profile_data = deepcopy(_profile(data, "nomic_dense_v1"))
+        first = EmbeddingProfileConfig.model_validate(profile_data)
+        profile_data["document_instruction"] = "Different document instruction."
+        second = EmbeddingProfileConfig.model_validate(profile_data)
+
+        self.assertNotEqual(
+            compute_profile_fingerprint(first),
+            compute_profile_fingerprint(second),
+        )
+
+    def test_loader_rejects_non_mapping_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "embeddings.yaml"
+            path.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "must contain a mapping"):
+                load_embeddings_config(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_embedding_config.py
+++ b/tests/unit/test_embedding_config.py
@@ -264,6 +264,16 @@ class EmbeddingConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "candidate_profiles"):
             _load_config(data)
 
+    def test_candidate_profiles_must_not_contain_duplicates(self) -> None:
+        data = _valid_embeddings_config()
+        _embeddings_section(data)["candidate_profiles"] = [
+            "qwen3_dense_8b_v1",
+            "qwen3_dense_8b_v1",
+        ]
+
+        with self.assertRaisesRegex(ValueError, "must not contain duplicates"):
+            _load_config(data)
+
     def test_collection_bindings_must_remain_on_active_nomic_in_rag1a(self) -> None:
         data = _valid_embeddings_config()
         _collection_bindings(data)["openclaw_financial"] = {

--- a/tests/unit/test_embedding_config.py
+++ b/tests/unit/test_embedding_config.py
@@ -308,6 +308,14 @@ class EmbeddingConfigTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "version must match"):
             _load_config(data)
 
+    def test_version_format_strips_outer_whitespace_before_validation(self) -> None:
+        data = _valid_embeddings_config()
+        _profile(data, "nomic_dense_v1")["version"] = " v1 "
+
+        config = _load_config(data)
+
+        self.assertEqual(config.profiles["nomic_dense_v1"].version, "v1")
+
     def test_profile_fingerprint_is_computed_and_validated_when_declared(self) -> None:
         data = _valid_embeddings_config()
         profile = EmbeddingProfileConfig.model_validate(


### PR DESCRIPTION
## Objetivo
Definir o contrato de perfis de embedding (Nomic e Qwen3) com metadata versionada e proteção contra mistura de vetores incompatíveis, sem ativar Qwen3 nem alterar o retriever atual.

Closes #91

## Escopo
- Cria backend/rag/embedding_config.py com EmbeddingProfileConfig, EmbeddingsConfig e load_embeddings_config(path).
- Cria backend/rag/embedding_metadata.py com compute_profile_fingerprint() e profiles_are_compatible().
- Cria tests/unit/test_embedding_config.py cobrindo os cenários positivos e negativos do planejamento.

## Fora de escopo preservado
- Sem carregar ou usar Qwen3 em runtime.
- Sem criar/migrar collections em Qdrant.
- Sem ingestão, reembedding, MRL runtime, sparse/BM25 ou mudanças no retriever.
- Sem alterações em configs operacionais ou evaluation/*.

## Validação
- uv run pytest tests/unit/test_embedding_config.py -v
- uv run mypy --strict backend/rag/embedding_config.py backend/rag/embedding_metadata.py tests/unit/test_embedding_config.py
- uv run pyright backend/rag/embedding_config.py backend/rag/embedding_metadata.py tests/unit/test_embedding_config.py
- uv run pytest tests/unit/test_embedding_config.py tests/unit/test_rag_embedder_factory.py tests/unit/test_embedding_contract_config.py tests/unit/test_collection_guard.py -v
- git diff --check
