### PR TITLE
[RAG-1A] PR 04B — Qwen3-Embedding-8B Adapter + Shadow Dense Collection Contract

### DIFF
--- a/backend/rag/embedder_protocol.py
+++ b/backend/rag/embedder_protocol.py
@@ -1,0 +1,35 @@
+"""Synchronous dense embedder protocol for PR-04B shadow adapters."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DenseEmbedder(Protocol):
+    """Common interface for synchronous dense embedding adapters."""
+
+    @property
+    def dimensions(self) -> int:
+        """Return the output vector dimension."""
+        ...
+
+    @property
+    def model_family(self) -> str:
+        """Return the embedding model family."""
+        ...
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed one retrieval query."""
+        ...
+
+    def embed_document(self, text: str) -> list[float]:
+        """Embed one document passage."""
+        ...
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Embed document passages, preserving input order."""
+        ...
+
+
+__all__ = ["DenseEmbedder"]

--- a/backend/rag/embedder_registry.py
+++ b/backend/rag/embedder_registry.py
@@ -1,0 +1,69 @@
+"""Read-only provider registry for dense embedding adapters.
+
+The registry is intentionally tiny in PR-04B: it only provides an immutable
+lookup surface and duplicate-provider guards. Runtime promotion of Qwen3 or any
+other provider remains out of scope.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from threading import RLock
+from types import MappingProxyType
+from typing import Protocol
+
+from backend.rag.embedder_protocol import DenseEmbedder
+from backend.rag.embedding_config import EmbeddingProfileConfig
+
+
+class EmbedderFactory(Protocol):
+    """Factory that builds a dense embedder from a validated profile."""
+
+    def __call__(self, profile: EmbeddingProfileConfig) -> DenseEmbedder:
+        """Return a dense embedder for ``profile``."""
+        ...
+
+
+_REGISTRY: dict[str, EmbedderFactory] = {}
+_REGISTRY_LOCK = RLock()
+
+
+def get_registry() -> Mapping[str, EmbedderFactory]:
+    """Return a read-only snapshot of registered dense embedder factories.
+
+    Returns:
+        Immutable provider-to-factory mapping. Mutating the returned object is
+        impossible, and later registrations do not mutate previous snapshots.
+    """
+    with _REGISTRY_LOCK:
+        return MappingProxyType(dict(_REGISTRY))
+
+
+def register(provider: str, factory: EmbedderFactory) -> None:
+    """Register a provider factory exactly once.
+
+    Args:
+        provider: Provider key, normalized with ``strip().casefold()``.
+        factory: Factory callable for the provider.
+
+    Raises:
+        ValueError: If ``provider`` is empty, contains a null byte, or was
+            already registered.
+    """
+    provider_key = _normalize_provider(provider)
+    with _REGISTRY_LOCK:
+        if provider_key in _REGISTRY:
+            raise ValueError(f"embedder provider {provider_key!r} is already registered")
+        _REGISTRY[provider_key] = factory
+
+
+def _normalize_provider(provider: str) -> str:
+    if "\x00" in provider:
+        raise ValueError("provider cannot contain null bytes")
+    provider_key = provider.strip().casefold()
+    if not provider_key:
+        raise ValueError("provider cannot be empty")
+    return provider_key
+
+
+__all__ = ["EmbedderFactory", "get_registry", "register"]

--- a/backend/rag/embedder_registry.py
+++ b/backend/rag/embedder_registry.py
@@ -57,6 +57,16 @@ def register(provider: str, factory: EmbedderFactory) -> None:
         _REGISTRY[provider_key] = factory
 
 
+def clear_registry_for_tests() -> None:
+    """Clear registered providers for isolated unit tests.
+
+    Production code should not call this helper. It exists so randomized test
+    order and repeated local test runs do not depend on global module state.
+    """
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+
+
 def _normalize_provider(provider: str) -> str:
     if "\x00" in provider:
         raise ValueError("provider cannot contain null bytes")
@@ -66,4 +76,4 @@ def _normalize_provider(provider: str) -> str:
     return provider_key
 
 
-__all__ = ["EmbedderFactory", "get_registry", "register"]
+__all__ = ["EmbedderFactory", "clear_registry_for_tests", "get_registry", "register"]

--- a/backend/rag/qwen3_embedder.py
+++ b/backend/rag/qwen3_embedder.py
@@ -1,0 +1,202 @@
+"""Qwen3-Embedding-8B dense adapter for shadow embedding experiments.
+
+The adapter is intentionally isolated from the current dense runtime. It does
+not touch retrievers, vector stores, or Qdrant collections; it only formats
+texts, calls an injected or lazily loaded encoder, and validates output vectors.
+"""
+
+from __future__ import annotations
+
+import math
+from importlib import import_module
+from collections.abc import Sequence
+from typing import Protocol, cast
+
+from backend.rag.embedder_protocol import DenseEmbedder
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from backend.rag.embedding_metadata import compute_profile_fingerprint
+
+DEFAULT_QWEN3_BATCH_SIZE = 8
+
+
+class SentenceTransformerLike(Protocol):
+    """Minimal encoder surface used by ``Qwen3Embedder``."""
+
+    def encode(
+        self,
+        sentences: Sequence[str],
+        *,
+        batch_size: int,
+        normalize_embeddings: bool,
+        show_progress_bar: bool,
+    ) -> object:
+        """Encode a batch of strings and return a matrix-like object."""
+        ...
+
+
+class Qwen3Embedder(DenseEmbedder):
+    """Instruction-aware adapter for a validated Qwen3 embedding profile."""
+
+    def __init__(
+        self,
+        profile: EmbeddingProfileConfig,
+        *,
+        device: str = "cpu",
+        encoder: SentenceTransformerLike | None = None,
+    ) -> None:
+        if profile.model_family != "qwen3":
+            raise ValueError(
+                "Qwen3Embedder requires model_family 'qwen3', "
+                f"got {profile.model_family!r}"
+            )
+        if not profile.instruction_aware:
+            raise ValueError("Qwen3Embedder requires instruction_aware=True")
+        if profile.query_instruction is None:
+            raise ValueError("Qwen3Embedder requires query_instruction to be set")
+
+        self._profile = profile
+        self._effective_dimensions = profile.effective_dimensions or profile.dimensions
+        self._truncate = self._effective_dimensions < profile.dimensions
+        self._profile_fingerprint = compute_profile_fingerprint(profile)
+        self._encoder = encoder if encoder is not None else self._load_model(
+            profile.model,
+            device,
+        )
+
+    @staticmethod
+    def _load_model(model_name: str, device: str) -> SentenceTransformerLike:
+        try:
+            sentence_transformers = import_module("sentence_transformers")
+        except ImportError as exc:
+            raise ImportError(
+                "Qwen3Embedder requires sentence-transformers>=2.7.0 and "
+                "transformers>=4.51.0. Install optional extras with: "
+                "pip install 'openclaw[qwen3]'"
+            ) from exc
+        sentence_transformer = getattr(sentence_transformers, "SentenceTransformer")
+        return cast(
+            SentenceTransformerLike,
+            sentence_transformer(model_name, device=device, trust_remote_code=True),
+        )
+
+    @property
+    def dimensions(self) -> int:
+        """Return effective Qwen3 vector dimensions."""
+        return self._effective_dimensions
+
+    @property
+    def model_family(self) -> str:
+        """Return ``qwen3`` for this adapter."""
+        return self._profile.model_family
+
+    @property
+    def profile_fingerprint(self) -> str:
+        """Return the PR-04A profile fingerprint."""
+        return self._profile_fingerprint
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a query with the configured Qwen3 query instruction."""
+        [vector] = self._encode_batch([self._format_query(text)], batch_size=1)
+        self._validate_vector(vector)
+        return vector
+
+    def embed_document(self, text: str) -> list[float]:
+        """Embed a document without adding a query instruction."""
+        [vector] = self._encode_batch([self._format_document(text)], batch_size=1)
+        self._validate_vector(vector)
+        return vector
+
+    def embed_documents(
+        self,
+        texts: list[str],
+        batch_size: int = DEFAULT_QWEN3_BATCH_SIZE,
+    ) -> list[list[float]]:
+        """Embed documents in batches while preserving input order."""
+        if not texts:
+            raise ValueError("texts cannot be empty")
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
+        results: list[list[float]] = []
+        for offset in range(0, len(texts), batch_size):
+            batch = texts[offset : offset + batch_size]
+            formatted = [self._format_document(text) for text in batch]
+            vectors = self._encode_batch(formatted, batch_size=batch_size)
+            for vector in vectors:
+                self._validate_vector(vector)
+            results.extend(vectors)
+        return results
+
+    def _format_query(self, text: str) -> str:
+        query = _clean_text(text, "query")
+        instruction = self._profile.query_instruction
+        if instruction is None:
+            raise RuntimeError("Qwen3 query_instruction unexpectedly missing")
+        return f"{instruction.strip()}\n{query}"
+
+    def _format_document(self, text: str) -> str:
+        document = _clean_text(text, "document")
+        instruction = self._profile.document_instruction
+        if instruction is None:
+            return document
+        return f"{instruction.strip()}\n{document}"
+
+    def _encode_batch(self, texts: list[str], *, batch_size: int) -> list[list[float]]:
+        encoded = self._encoder.encode(
+            texts,
+            batch_size=batch_size,
+            normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        raw_vectors = _coerce_vectors(encoded)
+        return [self._truncate_and_normalize(vector) for vector in raw_vectors]
+
+    def _truncate_and_normalize(self, vector: list[float]) -> list[float]:
+        active = vector[: self._effective_dimensions] if self._truncate else vector
+        norm = math.sqrt(sum(value * value for value in active))
+        if norm == 0.0:
+            return active
+        return [value / norm for value in active]
+
+    def _validate_vector(self, vector: list[float]) -> None:
+        if len(vector) != self._effective_dimensions:
+            raise RuntimeError(
+                "Qwen3Embedder expected "
+                f"{self._effective_dimensions} dims, got {len(vector)}"
+            )
+
+
+def _clean_text(text: str, label: str) -> str:
+    if "\x00" in text:
+        raise ValueError(f"{label} text cannot contain null bytes")
+    clean = text.strip()
+    if not clean:
+        raise ValueError(f"{label} text cannot be empty")
+    return clean
+
+
+def _coerce_vectors(encoded: object) -> list[list[float]]:
+    materialized = _tolist(encoded)
+    if not isinstance(materialized, Sequence) or isinstance(
+        materialized,
+        (str, bytes),
+    ):
+        raise RuntimeError("encoder returned a non-sequence embedding result")
+
+    vectors: list[list[float]] = []
+    for row in materialized:
+        vector = _tolist(row)
+        if not isinstance(vector, Sequence) or isinstance(vector, (str, bytes)):
+            raise RuntimeError("encoder returned a malformed embedding vector")
+        vectors.append([float(value) for value in vector])
+    return vectors
+
+
+def _tolist(value: object) -> object:
+    method = getattr(value, "tolist", None)
+    if callable(method):
+        return method()
+    return value
+
+
+__all__ = ["Qwen3Embedder", "SentenceTransformerLike"]

--- a/backend/rag/qwen3_embedder.py
+++ b/backend/rag/qwen3_embedder.py
@@ -199,4 +199,4 @@ def _tolist(value: object) -> object:
     return value
 
 
-__all__ = ["Qwen3Embedder", "SentenceTransformerLike"]
+__all__ = ["DEFAULT_QWEN3_BATCH_SIZE", "Qwen3Embedder", "SentenceTransformerLike"]

--- a/backend/rag/shadow_collection.py
+++ b/backend/rag/shadow_collection.py
@@ -1,0 +1,87 @@
+"""Shadow collection contract for Qwen3 dense embedding experiments."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Final
+
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from backend.rag.embedding_metadata import compute_profile_fingerprint
+
+QWEN3_SHADOW_COLLECTION: Final[str] = "quimera_knowledge_qwen3_dense_v1"
+SHADOW_COLLECTIONS: Final[frozenset[str]] = frozenset({QWEN3_SHADOW_COLLECTION})
+PROTECTED_COLLECTIONS: Final[frozenset[str]] = frozenset(
+    {
+        "quimera_knowledge",
+        "quimera_knowledge_v2",
+    }
+)
+
+
+def assert_collection_is_shadow(name: str) -> None:
+    """Validate that *name* is an explicitly declared shadow collection."""
+    clean_name = name.strip()
+    if clean_name in PROTECTED_COLLECTIONS:
+        raise ValueError(
+            f"Collection {clean_name!r} is protected; PR-04B may only target "
+            f"shadow collections: {sorted(SHADOW_COLLECTIONS)}"
+        )
+    if clean_name not in SHADOW_COLLECTIONS:
+        raise ValueError(
+            f"Collection {clean_name!r} is not a declared shadow collection"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class VectorPayloadMetadata:
+    """Embedding provenance metadata safe to attach to vector payloads."""
+
+    model: str
+    model_family: str
+    dimensions: int
+    effective_dimensions: int
+    distance: str
+    normalized: bool
+    version: str
+    query_instruction: str | None
+    provider: str
+    profile_fingerprint: str
+    indexed_at: str
+
+    @classmethod
+    def from_profile(
+        cls,
+        profile: EmbeddingProfileConfig,
+        *,
+        indexed_at: datetime | None = None,
+    ) -> VectorPayloadMetadata:
+        """Build payload metadata from a validated PR-04A profile."""
+        effective_dimensions = profile.effective_dimensions or profile.dimensions
+        timestamp = indexed_at or datetime.now(tz=timezone.utc)
+        return cls(
+            model=profile.model,
+            model_family=profile.model_family,
+            dimensions=profile.dimensions,
+            effective_dimensions=effective_dimensions,
+            distance=profile.distance,
+            normalized=profile.normalized,
+            version=profile.version,
+            query_instruction=profile.query_instruction,
+            provider=profile.provider,
+            profile_fingerprint=compute_profile_fingerprint(profile),
+            indexed_at=timestamp.isoformat(),
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        """Return a JSON-serializable payload metadata mapping."""
+        return asdict(self)
+
+
+__all__ = [
+    "PROTECTED_COLLECTIONS",
+    "QWEN3_SHADOW_COLLECTION",
+    "SHADOW_COLLECTIONS",
+    "VectorPayloadMetadata",
+    "assert_collection_is_shadow",
+]

--- a/backend/rag/shadow_collection.py
+++ b/backend/rag/shadow_collection.py
@@ -21,6 +21,8 @@ PROTECTED_COLLECTIONS: Final[frozenset[str]] = frozenset(
 
 def assert_collection_is_shadow(name: str) -> None:
     """Validate that *name* is an explicitly declared shadow collection."""
+    if "\x00" in name:
+        raise ValueError("collection name cannot contain null bytes")
     clean_name = name.strip()
     if clean_name in PROTECTED_COLLECTIONS:
         raise ValueError(
@@ -58,6 +60,8 @@ class VectorPayloadMetadata:
     ) -> VectorPayloadMetadata:
         """Build payload metadata from a validated PR-04A profile."""
         effective_dimensions = profile.effective_dimensions or profile.dimensions
+        if effective_dimensions <= 0:
+            raise ValueError("effective_dimensions must be greater than zero")
         timestamp = indexed_at or datetime.now(tz=timezone.utc)
         return cls(
             model=profile.model,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""OpenClaw test package for static-analysis friendly helper imports."""

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic test fakes used by unit tests."""

--- a/tests/fakes/fake_qwen3_embedder.py
+++ b/tests/fakes/fake_qwen3_embedder.py
@@ -1,0 +1,46 @@
+"""Deterministic fake Qwen3 embedder for unit tests."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+
+from backend.rag.embedder_protocol import DenseEmbedder
+
+
+class FakeQwen3Embedder(DenseEmbedder):
+    """Fake embedder: same input text and mode produce the same unit vector."""
+
+    dimensions: int = 4096
+    model_family: str = "qwen3"
+
+    def embed_query(self, text: str) -> list[float]:
+        """Embed a query using a mode-specific deterministic prefix."""
+        return self._hash_vector(f"query::{text}")
+
+    def embed_document(self, text: str) -> list[float]:
+        """Embed a document using a mode-specific deterministic prefix."""
+        return self._hash_vector(f"document::{text}")
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Embed documents in order."""
+        return [self.embed_document(text) for text in texts]
+
+    def _hash_vector(self, text: str) -> list[float]:
+        seed = int(hashlib.sha256(text.encode("utf-8")).hexdigest(), 16) % (2**32)
+        multiplier = 1_664_525
+        increment = 1_013_904_223
+        modulus = 2**32
+        state = seed
+        values: list[float] = []
+        for _ in range(self.dimensions):
+            state = (multiplier * state + increment) % modulus
+            values.append((float(state) / float(modulus)) * 2.0 - 1.0)
+
+        norm = math.sqrt(sum(value * value for value in values))
+        if norm == 0.0:
+            return values
+        return [value / norm for value in values]
+
+
+__all__ = ["FakeQwen3Embedder"]

--- a/tests/fakes/fake_qwen3_embedder.py
+++ b/tests/fakes/fake_qwen3_embedder.py
@@ -13,6 +13,7 @@ class FakeQwen3Embedder(DenseEmbedder):
 
     dimensions: int = 4096
     model_family: str = "qwen3"
+    profile_fingerprint: str = "fake-qwen3-deterministic-v1"
 
     def embed_query(self, text: str) -> list[float]:
         """Embed a query using a mode-specific deterministic prefix."""

--- a/tests/smoke/test_qwen3_smoke.py
+++ b/tests/smoke/test_qwen3_smoke.py
@@ -1,0 +1,58 @@
+"""Optional smoke tests for the real Qwen3 embedding adapter."""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from backend.rag.qwen3_embedder import Qwen3Embedder
+
+SMOKE_ENABLED = os.getenv("RUN_QWEN3_EMBEDDING_SMOKE") == "1"
+
+
+def _qwen3_profile() -> EmbeddingProfileConfig:
+    return EmbeddingProfileConfig(
+        provider="sentence_transformers",
+        model=os.getenv("QUIMERA_QWEN3_MODEL", "Qwen/Qwen3-Embedding-8B"),
+        model_family="qwen3",
+        version="v1",
+        dimensions=4096,
+        effective_dimensions=None,
+        mrl_supported=True,
+        context_length=32768,
+        distance="cosine",
+        normalized=True,
+        instruction_aware=True,
+        query_instruction=(
+            "Given a financial knowledge retrieval query in Brazilian Portuguese "
+            "or English, retrieve relevant passages that answer the query."
+        ),
+        document_instruction=None,
+        profile_fingerprint=None,
+    )
+
+
+@pytest.mark.skipif(
+    not SMOKE_ENABLED,
+    reason="set RUN_QWEN3_EMBEDDING_SMOKE=1 to run real Qwen3 smoke tests",
+)
+def test_qwen3_real_adapter_returns_normalized_4096_dimensional_vectors() -> None:
+    embedder = Qwen3Embedder(_qwen3_profile())
+    text = "Qual documento sintetico explica duration em renda fixa?"
+
+    query_vector = embedder.embed_query(text)
+    document_vector = embedder.embed_document(text)
+    batch_vectors = embedder.embed_documents(["documento a", "documento b", "documento c"])
+
+    query_norm = math.sqrt(sum(value * value for value in query_vector))
+    dot = sum(q * d for q, d in zip(query_vector, document_vector, strict=True))
+
+    assert len(query_vector) == 4096
+    assert len(document_vector) == 4096
+    assert len(batch_vectors) == 3
+    assert all(len(vector) == 4096 for vector in batch_vectors)
+    assert query_norm == pytest.approx(1.0, abs=1e-3)
+    assert dot < 0.9999

--- a/tests/unit/test_embedder_registry.py
+++ b/tests/unit/test_embedder_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from backend.rag.embedder_registry import get_registry, register
+from backend.rag.embedder_registry import clear_registry_for_tests, get_registry, register
 from backend.rag.embedder_protocol import DenseEmbedder
 from backend.rag.embedding_config import EmbeddingProfileConfig
 from tests.fakes.fake_qwen3_embedder import FakeQwen3Embedder
@@ -17,6 +17,12 @@ def _factory(profile: EmbeddingProfileConfig) -> DenseEmbedder:
 
 class EmbedderRegistryTests(unittest.TestCase):
     """Registry tests that avoid loading real embedding models."""
+
+    def setUp(self) -> None:
+        clear_registry_for_tests()
+
+    def tearDown(self) -> None:
+        clear_registry_for_tests()
 
     def test_get_registry_returns_read_only_snapshot(self) -> None:
         provider = "rc01_snapshot_provider"

--- a/tests/unit/test_embedder_registry.py
+++ b/tests/unit/test_embedder_registry.py
@@ -1,0 +1,55 @@
+"""Unit tests for the dense embedder provider registry contract."""
+
+from __future__ import annotations
+
+import unittest
+
+from backend.rag.embedder_registry import get_registry, register
+from backend.rag.embedder_protocol import DenseEmbedder
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from tests.fakes.fake_qwen3_embedder import FakeQwen3Embedder
+
+
+def _factory(profile: EmbeddingProfileConfig) -> DenseEmbedder:
+    _ = profile
+    return FakeQwen3Embedder()
+
+
+class EmbedderRegistryTests(unittest.TestCase):
+    """Registry tests that avoid loading real embedding models."""
+
+    def test_get_registry_returns_read_only_snapshot(self) -> None:
+        provider = "rc01_snapshot_provider"
+        before = get_registry()
+
+        register(provider, _factory)
+        after = get_registry()
+
+        self.assertNotIn(provider, before)
+        self.assertIn(provider, after)
+        with self.assertRaises(TypeError):
+            after["another_provider"] = _factory  # type: ignore[index]
+        self.assertNotIn("another_provider", get_registry())
+
+    def test_register_rejects_duplicate_provider(self) -> None:
+        provider = "rc01_duplicate_provider"
+
+        register(provider, _factory)
+
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            register(provider, _factory)
+
+    def test_register_normalizes_provider_names(self) -> None:
+        register("  RC01_NORMALIZED_PROVIDER  ", _factory)
+
+        self.assertIn("rc01_normalized_provider", get_registry())
+
+    def test_register_rejects_invalid_provider_names(self) -> None:
+        with self.assertRaisesRegex(ValueError, "empty"):
+            register("   ", _factory)
+        with self.assertRaisesRegex(ValueError, "null bytes"):
+            register("bad\x00provider", _factory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_qwen3_embedder.py
+++ b/tests/unit/test_qwen3_embedder.py
@@ -90,6 +90,11 @@ class Qwen3EmbedderTests(unittest.TestCase):
 
         self.assertEqual(first, second)
 
+    def test_fake_embedder_exposes_stable_profile_fingerprint(self) -> None:
+        fake = FakeQwen3Embedder()
+
+        self.assertEqual(fake.profile_fingerprint, "fake-qwen3-deterministic-v1")
+
     def test_adapter_rejects_wrong_model_family(self) -> None:
         profile = _qwen3_profile().model_copy(update={"model_family": "nomic"})
 

--- a/tests/unit/test_qwen3_embedder.py
+++ b/tests/unit/test_qwen3_embedder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import unittest
 from collections.abc import Sequence
+from pathlib import Path
 from unittest.mock import patch
 
 from backend.rag.embedder_protocol import DenseEmbedder
@@ -81,6 +82,14 @@ class Qwen3EmbedderTests(unittest.TestCase):
 
         self.assertNotEqual(fake.embed_query(text), fake.embed_document(text))
 
+    def test_fake_embedder_is_deterministic_for_same_query(self) -> None:
+        fake = FakeQwen3Embedder()
+
+        first = fake.embed_query("criterio sintetico")
+        second = fake.embed_query("criterio sintetico")
+
+        self.assertEqual(first, second)
+
     def test_adapter_rejects_wrong_model_family(self) -> None:
         profile = _qwen3_profile().model_copy(update={"model_family": "nomic"})
 
@@ -144,6 +153,7 @@ class Qwen3EmbedderTests(unittest.TestCase):
         norm = math.sqrt(sum(value * value for value in vector))
 
         self.assertEqual(len(vector), 2)
+        # MRL proof: truncation keeps 2 dims, then L2 normalization restores norm 1.
         self.assertAlmostEqual(norm, 1.0, places=6)
 
     def test_adapter_validates_vector_dimensions(self) -> None:
@@ -167,6 +177,26 @@ class Qwen3EmbedderTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(ImportError, "openclaw\\[qwen3\\]"):
                 Qwen3Embedder(_qwen3_profile())
+
+    def test_qwen3_adapter_is_not_imported_by_existing_rag_runtime_modules(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        rag_files = sorted((repo_root / "backend" / "rag").glob("*.py"))
+        scanned = [
+            path
+            for path in rag_files
+            if path.name
+            not in {
+                "qwen3_embedder.py",
+            }
+        ]
+
+        offenders = [
+            path.name
+            for path in scanned
+            if "qwen3_embedder" in path.read_text(encoding="utf-8")
+        ]
+
+        self.assertEqual(offenders, [])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_qwen3_embedder.py
+++ b/tests/unit/test_qwen3_embedder.py
@@ -1,0 +1,173 @@
+"""Unit tests for the Qwen3 dense embedder adapter."""
+
+from __future__ import annotations
+
+import math
+import unittest
+from collections.abc import Sequence
+from unittest.mock import patch
+
+from backend.rag.embedder_protocol import DenseEmbedder
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from backend.rag.qwen3_embedder import Qwen3Embedder
+from tests.fakes.fake_qwen3_embedder import FakeQwen3Embedder
+
+
+def _qwen3_profile() -> EmbeddingProfileConfig:
+    return EmbeddingProfileConfig(
+        provider="sentence_transformers",
+        model="Qwen/Qwen3-Embedding-8B",
+        model_family="qwen3",
+        version="v1",
+        dimensions=4096,
+        effective_dimensions=None,
+        mrl_supported=True,
+        context_length=32768,
+        distance="cosine",
+        normalized=True,
+        instruction_aware=True,
+        query_instruction=(
+            "Given a financial knowledge retrieval query in Brazilian Portuguese "
+            "or English, retrieve relevant passages that answer the query."
+        ),
+        document_instruction=None,
+        profile_fingerprint=None,
+    )
+
+
+class RecordingEncoder:
+    """Small encoder spy with deterministic vector output."""
+
+    def __init__(self, dimensions: int = 4096) -> None:
+        self.dimensions = dimensions
+        self.calls: list[tuple[list[str], int, bool, bool]] = []
+
+    def encode(
+        self,
+        sentences: Sequence[str],
+        *,
+        batch_size: int,
+        normalize_embeddings: bool,
+        show_progress_bar: bool,
+    ) -> list[list[float]]:
+        texts = list(sentences)
+        self.calls.append(
+            (texts, batch_size, normalize_embeddings, show_progress_bar)
+        )
+        return [self._vector_for_text(text) for text in texts]
+
+    def _vector_for_text(self, text: str) -> list[float]:
+        first = float((sum(ord(char) for char in text) % 97) + 1)
+        second = float((len(text) % 31) + 1)
+        return [first, second] + [0.0] * (self.dimensions - 2)
+
+
+class Qwen3EmbedderTests(unittest.TestCase):
+    """Adapter tests without loading the real 8B model."""
+
+    def test_fake_embedder_dimensions_and_norm(self) -> None:
+        fake = FakeQwen3Embedder()
+
+        vector = fake.embed_query("duration sintetica")
+        norm = math.sqrt(sum(value * value for value in vector))
+
+        self.assertIsInstance(fake, DenseEmbedder)
+        self.assertEqual(len(vector), 4096)
+        self.assertAlmostEqual(norm, 1.0, places=6)
+
+    def test_fake_embedder_query_vs_document_differs(self) -> None:
+        fake = FakeQwen3Embedder()
+        text = "mesmo texto"
+
+        self.assertNotEqual(fake.embed_query(text), fake.embed_document(text))
+
+    def test_adapter_rejects_wrong_model_family(self) -> None:
+        profile = _qwen3_profile().model_copy(update={"model_family": "nomic"})
+
+        with self.assertRaisesRegex(ValueError, "model_family 'qwen3'"):
+            Qwen3Embedder(profile, encoder=RecordingEncoder())
+
+    def test_adapter_rejects_missing_instruction(self) -> None:
+        profile = _qwen3_profile().model_copy(update={"query_instruction": None})
+
+        with self.assertRaisesRegex(ValueError, "query_instruction"):
+            Qwen3Embedder(profile, encoder=RecordingEncoder())
+
+    def test_embed_query_applies_instruction_and_document_does_not(self) -> None:
+        encoder = RecordingEncoder()
+        profile = _qwen3_profile()
+        embedder = Qwen3Embedder(profile, encoder=encoder)
+
+        embedder.embed_query("qual o criterio sintetico?")
+        embedder.embed_document("qual o criterio sintetico?")
+
+        query_text = encoder.calls[0][0][0]
+        document_text = encoder.calls[1][0][0]
+        self.assertTrue(query_text.startswith(profile.query_instruction or ""))
+        self.assertTrue(query_text.endswith("qual o criterio sintetico?"))
+        self.assertEqual(document_text, "qual o criterio sintetico?")
+        self.assertTrue(encoder.calls[0][2])
+        self.assertFalse(encoder.calls[0][3])
+
+    def test_document_instruction_is_applied_when_explicitly_configured(self) -> None:
+        encoder = RecordingEncoder()
+        profile = _qwen3_profile().model_copy(
+            update={"document_instruction": "Represent this passage for retrieval."}
+        )
+        embedder = Qwen3Embedder(profile, encoder=encoder)
+
+        embedder.embed_document("documento sintetico")
+
+        document_text = encoder.calls[0][0][0]
+        self.assertEqual(
+            document_text,
+            "Represent this passage for retrieval.\ndocumento sintetico",
+        )
+
+    def test_embed_documents_preserves_order_and_length(self) -> None:
+        encoder = RecordingEncoder()
+        embedder = Qwen3Embedder(_qwen3_profile(), encoder=encoder)
+        texts = ["doc a", "doc b", "doc c"]
+
+        vectors = embedder.embed_documents(texts, batch_size=2)
+
+        self.assertEqual(len(vectors), 3)
+        self.assertTrue(all(len(vector) == 4096 for vector in vectors))
+        self.assertEqual(encoder.calls[0][0], ["doc a", "doc b"])
+        self.assertEqual(encoder.calls[1][0], ["doc c"])
+
+    def test_effective_dimensions_truncate_and_renormalize(self) -> None:
+        profile = _qwen3_profile().model_copy(update={"effective_dimensions": 2})
+        embedder = Qwen3Embedder(profile, encoder=RecordingEncoder())
+
+        vector = embedder.embed_document("texto valido")
+        norm = math.sqrt(sum(value * value for value in vector))
+
+        self.assertEqual(len(vector), 2)
+        self.assertAlmostEqual(norm, 1.0, places=6)
+
+    def test_adapter_validates_vector_dimensions(self) -> None:
+        embedder = Qwen3Embedder(_qwen3_profile(), encoder=RecordingEncoder(10))
+
+        with self.assertRaisesRegex(RuntimeError, "expected 4096 dims"):
+            embedder.embed_query("texto valido")
+
+    def test_empty_inputs_are_rejected(self) -> None:
+        embedder = Qwen3Embedder(_qwen3_profile(), encoder=RecordingEncoder())
+
+        with self.assertRaisesRegex(ValueError, "query text cannot be empty"):
+            embedder.embed_query("  ")
+        with self.assertRaisesRegex(ValueError, "texts cannot be empty"):
+            embedder.embed_documents([])
+
+    def test_missing_optional_dependency_has_clear_error(self) -> None:
+        with patch(
+            "backend.rag.qwen3_embedder.import_module",
+            side_effect=ImportError("missing"),
+        ):
+            with self.assertRaisesRegex(ImportError, "openclaw\\[qwen3\\]"):
+                Qwen3Embedder(_qwen3_profile())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_shadow_collection_contract.py
+++ b/tests/unit/test_shadow_collection_contract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import unittest
 from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
 
 from backend.rag.embedding_config import EmbeddingProfileConfig
 from backend.rag.embedding_metadata import compute_profile_fingerprint
@@ -51,6 +53,10 @@ class ShadowCollectionContractTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not a declared shadow collection"):
             assert_collection_is_shadow("custom_qwen3_collection")
 
+    def test_collection_name_rejects_null_bytes(self) -> None:
+        with self.assertRaisesRegex(ValueError, "null bytes"):
+            assert_collection_is_shadow(f"{QWEN3_SHADOW_COLLECTION}\x00")
+
     def test_shadow_collection_namespace_is_exact(self) -> None:
         self.assertEqual(
             SHADOW_COLLECTIONS,
@@ -84,6 +90,15 @@ class ShadowCollectionContractTests(unittest.TestCase):
 
         self.assertEqual(metadata.dimensions, 4096)
         self.assertEqual(metadata.effective_dimensions, 1024)
+
+    def test_payload_metadata_rejects_non_positive_effective_dimensions(self) -> None:
+        invalid_profile = cast(
+            EmbeddingProfileConfig,
+            SimpleNamespace(dimensions=0, effective_dimensions=None),
+        )
+
+        with self.assertRaisesRegex(ValueError, "greater than zero"):
+            VectorPayloadMetadata.from_profile(invalid_profile)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_shadow_collection_contract.py
+++ b/tests/unit/test_shadow_collection_contract.py
@@ -1,0 +1,90 @@
+"""Tests for the PR-04B Qwen3 shadow collection contract."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from backend.rag.embedding_config import EmbeddingProfileConfig
+from backend.rag.embedding_metadata import compute_profile_fingerprint
+from backend.rag.shadow_collection import (
+    PROTECTED_COLLECTIONS,
+    QWEN3_SHADOW_COLLECTION,
+    SHADOW_COLLECTIONS,
+    VectorPayloadMetadata,
+    assert_collection_is_shadow,
+)
+
+
+def _qwen3_profile() -> EmbeddingProfileConfig:
+    return EmbeddingProfileConfig(
+        provider="sentence_transformers",
+        model="Qwen/Qwen3-Embedding-8B",
+        model_family="qwen3",
+        version="v1",
+        dimensions=4096,
+        effective_dimensions=None,
+        mrl_supported=True,
+        context_length=32768,
+        distance="cosine",
+        normalized=True,
+        instruction_aware=True,
+        query_instruction="Given a financial query, retrieve relevant passages.",
+        document_instruction=None,
+        profile_fingerprint=None,
+    )
+
+
+class ShadowCollectionContractTests(unittest.TestCase):
+    """Shadow collection and payload metadata tests."""
+
+    def test_protected_collections_cannot_be_shadow(self) -> None:
+        for collection_name in sorted(PROTECTED_COLLECTIONS):
+            with self.subTest(collection_name=collection_name):
+                with self.assertRaisesRegex(ValueError, "protected"):
+                    assert_collection_is_shadow(collection_name)
+
+    def test_shadow_collection_is_accepted(self) -> None:
+        assert_collection_is_shadow(QWEN3_SHADOW_COLLECTION)
+
+    def test_unknown_collection_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not a declared shadow collection"):
+            assert_collection_is_shadow("custom_qwen3_collection")
+
+    def test_shadow_collection_namespace_is_exact(self) -> None:
+        self.assertEqual(
+            SHADOW_COLLECTIONS,
+            frozenset({"quimera_knowledge_qwen3_dense_v1"}),
+        )
+
+    def test_payload_metadata_from_profile(self) -> None:
+        profile = _qwen3_profile()
+        timestamp = datetime(2026, 5, 17, 12, 0, tzinfo=timezone.utc)
+
+        metadata = VectorPayloadMetadata.from_profile(profile, indexed_at=timestamp)
+        payload = metadata.to_payload()
+
+        self.assertEqual(metadata.model, "Qwen/Qwen3-Embedding-8B")
+        self.assertEqual(metadata.model_family, "qwen3")
+        self.assertEqual(metadata.dimensions, 4096)
+        self.assertEqual(metadata.effective_dimensions, 4096)
+        self.assertEqual(metadata.distance, "cosine")
+        self.assertTrue(metadata.normalized)
+        self.assertEqual(metadata.provider, "sentence_transformers")
+        self.assertEqual(
+            metadata.profile_fingerprint,
+            compute_profile_fingerprint(profile),
+        )
+        self.assertEqual(payload["indexed_at"], "2026-05-17T12:00:00+00:00")
+
+    def test_payload_metadata_uses_effective_dimensions_when_present(self) -> None:
+        profile = _qwen3_profile().model_copy(update={"effective_dimensions": 1024})
+
+        metadata = VectorPayloadMetadata.from_profile(profile)
+
+        self.assertEqual(metadata.dimensions, 4096)
+        self.assertEqual(metadata.effective_dimensions, 1024)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objetivo
Adicionar um adapter para Qwen3-Embedding-8B e definir o contrato de shadow collection dense (4096d) para geração paralela de embeddings, sem alterar o retriever ou as collections atuais.

Closes #93

## Escopo
- Cria backend/rag/embedder_protocol.py com DenseEmbedder síncrono.
- Cria backend/rag/qwen3_embedder.py com adapter Qwen3 isolado, import lazy e encoder injetável para testes.
- Cria backend/rag/shadow_collection.py com allowlist de shadow collection e proteção das collections atuais.
- Cria tests/fakes/fake_qwen3_embedder.py com fake determinístico sem download.
- Cria unit tests e smoke opcional guardado por RUN_QWEN3_EMBEDDING_SMOKE=1.

## Fora de escopo preservado
- Sem troca de modelo em produção.
- Sem criação/migração real de Qdrant collections.
- Sem alteração de retriever, ingest, hybrid, reranker ou Agentic RAG.
- Sem download de modelo nos testes unitários.

## Validação
- uv run pytest tests/unit/test_qwen3_embedder.py tests/unit/test_shadow_collection_contract.py -v
- uv run mypy --strict backend/rag/qwen3_embedder.py backend/rag/shadow_collection.py tests/unit/test_qwen3_embedder.py
- uv run pyright backend/rag/qwen3_embedder.py backend/rag/shadow_collection.py tests/unit/test_qwen3_embedder.py
- uv run pytest tests/smoke/test_qwen3_smoke.py -v (skipped sem env)
- uv run pytest tests/unit/test_embedding_config.py tests/unit/test_rag_embedder_factory.py tests/unit/test_embedding_contract_config.py tests/unit/test_collection_guard.py tests/unit/test_qwen3_embedder.py tests/unit/test_shadow_collection_contract.py -v
- git diff --check
