### PR TITLE
[RAG-1A] PR 04C — Dense Embedding A/B Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ reports/g2_alias_comparison/
 evaluation/results/*.csv
 evaluation/results/*.json
 evaluation/results/*.jsonl
+evaluation/results/*.md
 evaluation/results/*.txt
 
 # Claude Code — local session artifacts (NOT hooks.json/settings.json — esses são versionados)

--- a/docs/ADR/0003-qwen3-embedding-baseline.md
+++ b/docs/ADR/0003-qwen3-embedding-baseline.md
@@ -1,0 +1,32 @@
+# ADR-0003 — Qwen3 Dense Embedding Baseline
+
+## Status
+
+Proposed.
+
+## Contexto
+
+O RAG-1A deve comparar `nomic_dense_v1` contra `qwen3_dense_8b_v1`
+usando o mesmo corpus e as mesmas queries do benchmark financeiro brasileiro.
+
+## Decisão
+
+A decisão final deve ser gerada pelo runner do PR-04C e registrada nos
+artefatos locais:
+
+- `evaluation/results/dense_embedding_ab.json`
+- `evaluation/results/dense_embedding_ab.md`
+- esta ADR, atualizada pelo runner com `accepted_profile` e
+  `promote_qwen3_dense`
+
+## Critério
+
+Qwen3 só pode ser promovido se passar simultaneamente pelos thresholds de
+qualidade e latência definidos no gate do PR-04C.
+
+## Fora de Escopo
+
+- BM25 e hybrid search.
+- Reranker.
+- Agentic RAG e multi-tool orchestration.
+- Alterar `active_profile` de produção neste PR.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -123,3 +123,219 @@ Motivo: adicionar MAP sem um contrato próprio exigiria escolher silenciosamente
 a definição de AP@k, incluindo denominador, tratamento de duplicatas, cutoff e
 queries sem hits. Essa decisão matemática precisa ser feita em PR separado,
 com testes analíticos próprios, antes de entrar na API pública.
+
+## Runbook de Benchmark A/B Dense — PR 04C
+
+Este runbook descreve como executar e interpretar o benchmark comparativo entre
+o dense atual (`nomic_dense_v1`) e o candidato `qwen3_dense_8b_v1`. O objetivo
+é decidir com números se Qwen3 deve virar baseline denso antes dos sprints de
+hybrid retrieval e Agentic RAG.
+
+O PR 04C é um tribunal imparcial: ele mede primeiro, compara depois e só então
+aplica o gate de decisão. Ele não promove Qwen3 automaticamente, não altera
+`active_profile`, não implementa BM25, não implementa hybrid search, não cria
+reranker e não adiciona agentes.
+
+### Pré-requisitos locais
+
+- Python 3.12 via `uv`.
+- Corpus sintético já preparado para os dois perfis comparados.
+- `benchmark_queries.yaml` e `expected_results.yaml` sem mudanças entre runs.
+- Qdrant local disponível somente para leitura/escrita em collections
+  declaradas para benchmark ou shadow.
+- Perfil atual `nomic_dense_v1` disponível.
+- Perfil candidato `qwen3_dense_8b_v1` validado pelo contrato de embeddings.
+- Dependências opcionais de Qwen3 instaladas apenas no ambiente local de
+  benchmark, nunca como exigência de testes unitários.
+
+Qwen3 é pesado. Se o modelo real não estiver disponível, o benchmark real deve
+falhar com mensagem clara ou rodar apenas em modo dry-run/fake, sem produzir
+decisão de promoção.
+
+### Comando esperado
+
+Quando o runner do PR 04C estiver disponível, execute localmente:
+
+```bash
+uv run python -m evaluation.compare_dense_embeddings \
+  --baseline-profile nomic_dense_v1 \
+  --candidate-profile qwen3_dense_8b_v1 \
+  --benchmark evaluation/benchmark_queries.yaml \
+  --expected-results evaluation/expected_results.yaml \
+  --output-dir evaluation/results
+```
+
+Os arquivos gerados devem ficar em `evaluation/results/`:
+
+- `dense_embedding_ab.csv`: linhas por query e por profile.
+- `dense_embedding_ab.json`: resumo, hashes, agregados e `decision_gate`.
+- `dense_embedding_ab.md`: relatório humano com tabelas, gráficos e veredito.
+
+Esses resultados são locais e não devem ser versionados quando grandes,
+sensíveis ou dependentes de hardware. O conteúdo permitido é apenas IDs,
+scores, métricas, hashes e metadados seguros. Nunca salvar chunks, embeddings,
+payload completo, prompt, resposta gerada ou dados Level 0.
+
+### Fairness obrigatório
+
+O benchmark só é válido se Nomic e Qwen3 usarem exatamente os mesmos inputs:
+
+- Mesmo arquivo de benchmark.
+- Mesmo arquivo de ground truth.
+- Mesmo corpus snapshot.
+- Mesmo chunking.
+- Mesmo `top_k`.
+- Mesmas métricas.
+- Nenhum filtro especial favorecendo um perfil.
+
+O runner deve abortar se os hashes divergirem:
+
+```python
+if nomic_result.benchmark_hash != qwen3_result.benchmark_hash:
+    raise ValueError("A/B benchmark must use identical benchmark queries")
+
+if nomic_result.corpus_hash != qwen3_result.corpus_hash:
+    raise ValueError("A/B benchmark must use identical corpus snapshot")
+```
+
+### Métricas obrigatórias
+
+Qualidade:
+
+- `precision@5`
+- `recall@10`
+- `MRR`
+- `NDCG@5`
+
+Latência:
+
+- `ingest_latency_p50_ms`
+- `ingest_latency_p95_ms`
+- `query_latency_p50_ms`
+- `query_latency_p95_ms`
+- `embedding_latency_p50_ms`
+- `embedding_latency_p95_ms`
+
+Metadados de comparação:
+
+- `vector_dimensions`
+- `collection_size`
+- `benchmark_hash`
+- `corpus_hash`
+- `profile_id`
+
+### Como ler o resultado
+
+Para qualidade, maior é melhor. Para latência, menor é melhor.
+
+O relatório Markdown deve deixar explícito:
+
+- Qual perfil foi mais preciso.
+- Qual perfil foi mais rápido.
+- Quanto Qwen3 ganhou ou perdeu em relação ao Nomic.
+- Se o ganho de qualidade compensa a penalidade de latência.
+- Qual perfil foi aceito pelo gate.
+
+Tabela humana mínima:
+
+| Métrica | Nomic | Qwen3-8B | Diferença | Vencedor |
+|---|---:|---:|---:|---|
+| Precision@5 | 0.42 | 0.55 | +31.0% | Qwen3 |
+| Recall@10 | 0.62 | 0.78 | +25.8% | Qwen3 |
+| MRR | 0.44 | 0.59 | +34.1% | Qwen3 |
+| NDCG@5 | 0.51 | 0.67 | +31.4% | Qwen3 |
+| Query p95 ms | 180 | 920 | 5.1x mais lento | Nomic |
+| Embedding p95 ms | 35 | 2100 | 60.0x mais lento | Nomic |
+
+Gráfico de qualidade esperado no Markdown:
+
+```mermaid
+xychart-beta
+  title "Qualidade de Retrieval — maior é melhor"
+  x-axis ["Precision@5", "Recall@10", "MRR", "NDCG@5"]
+  y-axis "Score" 0 --> 1
+  bar "Nomic" [0.42, 0.62, 0.44, 0.51]
+  bar "Qwen3-8B" [0.55, 0.78, 0.59, 0.67]
+```
+
+Gráfico de latência esperado no Markdown:
+
+```mermaid
+xychart-beta
+  title "Latência p95 (ms) — menor é melhor"
+  x-axis ["Query p95", "Embedding p95"]
+  y-axis "ms" 0 --> 2500
+  bar "Nomic" [180, 35]
+  bar "Qwen3-8B" [920, 2100]
+```
+
+Resumo humano esperado:
+
+```text
+Mais preciso: Qwen3-8B.
+Mais rápido: Nomic.
+Trade-off: Qwen3 melhora qualidade, mas aumenta a latência local.
+Decisão: promover somente se o gate de qualidade e latência passar.
+```
+
+### Gate de decisão
+
+Thresholds padrão:
+
+- `min_recall10_relative_gain`: `0.10`
+- `min_ndcg5_relative_gain`: `0.05`
+- `max_query_p95_latency_multiplier`: `3.0`
+- `max_embedding_p95_latency_multiplier`: `10.0`
+
+Regra de promoção:
+
+```python
+promote = (
+    qwen3.recall_at_10 >= nomic.recall_at_10 * 1.10
+    and qwen3.ndcg_at_5 >= nomic.ndcg_at_5 * 1.05
+    and qwen3.query_latency_p95_ms <= nomic.query_latency_p95_ms * 3.0
+    and qwen3.embedding_latency_p95_ms <= nomic.embedding_latency_p95_ms * 10.0
+)
+```
+
+O JSON deve incluir:
+
+```json
+{
+  "decision_gate": {
+    "promote_qwen3_dense": false,
+    "accepted_profile": "nomic_dense_v1",
+    "candidate_profile": "qwen3_dense_8b_v1",
+    "reason": "Qwen3 improved quality but exceeded latency thresholds.",
+    "thresholds": {
+      "min_recall10_relative_gain": 0.10,
+      "min_ndcg5_relative_gain": 0.05,
+      "max_query_p95_latency_multiplier": 3.0,
+      "max_embedding_p95_latency_multiplier": 10.0
+    }
+  }
+}
+```
+
+Se `promote_qwen3_dense=false`, o baseline aceito continua sendo Nomic. Se
+`promote_qwen3_dense=true`, Qwen3 ainda não deve virar runtime default neste
+mesmo PR; a promoção operacional deve acontecer em PR separado.
+
+### ADR de decisão
+
+O PR 04C deve gerar ou atualizar uma ADR curta em `docs/ADR/` com:
+
+- Contexto do A/B.
+- Perfis comparados.
+- Hashes de benchmark e corpus.
+- Resultado de qualidade.
+- Resultado de latência.
+- `accepted_profile`.
+- `promote_qwen3_dense`.
+- Motivo da decisão.
+- Fora de escopo: BM25, hybrid search, reranker e Agentic RAG.
+
+A ADR deve registrar a decisão, não vender tecnologia. Se Qwen3 for mais
+preciso, mas lento demais para o baseline local, isso deve aparecer de forma
+direta: Qwen3 venceu qualidade, Nomic venceu latência, e o gate decidiu com
+base nos thresholds.

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -154,7 +154,24 @@ decisão de promoção.
 
 ### Comando esperado
 
-Quando o runner do PR 04C estiver disponível, execute localmente:
+Primeiro valide os inputs sem executar runners reais e sem escrever artefatos:
+
+```bash
+uv run python -m evaluation.compare_dense_embeddings \
+  --baseline-profile nomic_dense_v1 \
+  --candidate-profile qwen3_dense_8b_v1 \
+  --benchmark evaluation/benchmark_queries.yaml \
+  --expected-results evaluation/expected_results.yaml \
+  --output-dir evaluation/results \
+  --dry-run
+```
+
+O modo `--dry-run` valida o parse das queries, o ground truth e a
+compatibilidade entre IDs. Ele não chama Qwen3, não toca em Qdrant, não roda
+retrieval e não escreve CSV/JSON/Markdown.
+
+Quando os runners de perfil estiverem injetados no ambiente local de benchmark,
+execute:
 
 ```bash
 uv run python -m evaluation.compare_dense_embeddings \

--- a/evaluation/compare_dense_embeddings.py
+++ b/evaluation/compare_dense_embeddings.py
@@ -1,0 +1,1120 @@
+"""A/B benchmark contract for dense embedding profiles.
+
+PR-04C compares the current dense baseline against the Qwen3 dense candidate
+using identical benchmark inputs. This module is intentionally orchestration
+only: profile execution is injected through ``DenseProfileRunner`` so unit
+tests never download models and the benchmark cannot silently mutate runtime
+retrieval code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+from loguru import logger
+
+from evaluation import (
+    latency_percentiles,
+    mean_ndcg_at_k,
+    mean_precision_at_k,
+    mean_recall_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+    reciprocal_rank,
+)
+from evaluation.run_dense_baseline import (
+    BenchmarkQuery,
+    load_benchmark_queries,
+    load_expected_results,
+)
+
+
+RUNNER_VERSION = "rag-1a-pr04c"
+DEFAULT_BASELINE_PROFILE = "nomic_dense_v1"
+DEFAULT_CANDIDATE_PROFILE = "qwen3_dense_8b_v1"
+DEFAULT_TOP_K = 20
+DEFAULT_CUTOFF_PRECISION = 5
+DEFAULT_CUTOFF_RECALL = 10
+DEFAULT_CUTOFF_NDCG = 5
+DEFAULT_BENCHMARK_FILE = Path("evaluation") / "benchmark_queries.yaml"
+DEFAULT_EXPECTED_RESULTS_FILE = Path("evaluation") / "expected_results.yaml"
+DEFAULT_RESULTS_DIR = Path("evaluation") / "results"
+DEFAULT_CSV_FILENAME = "dense_embedding_ab.csv"
+DEFAULT_JSON_FILENAME = "dense_embedding_ab.json"
+DEFAULT_MARKDOWN_FILENAME = "dense_embedding_ab.md"
+DEFAULT_ADR_PATH = Path("docs") / "ADR" / "0003-qwen3-embedding-baseline.md"
+EPSILON = 1e-8
+
+
+@dataclass(frozen=True)
+class DenseEmbeddingBenchmark:
+    """Benchmark inputs shared by all dense profile runs."""
+
+    queries: tuple[BenchmarkQuery, ...]
+    expected_results: Mapping[str, Mapping[str, float]]
+    benchmark_hash: str
+    expected_results_hash: str
+
+
+@dataclass(frozen=True)
+class DenseProfileQueryResult:
+    """Metadata-only per-query output from one dense profile runner."""
+
+    query_id: str
+    retrieved_ids: tuple[str, ...]
+    scores: tuple[float, ...]
+    embedding_latency_ms: float
+    query_latency_ms: float
+    ingest_latency_ms: float
+    status: Literal["ok", "error"] = "ok"
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class DenseProfileRun:
+    """Raw profile run output before aggregate metrics are computed."""
+
+    profile_id: str
+    dimensions: int
+    collection_size: int
+    benchmark_hash: str
+    corpus_hash: str
+    query_results: tuple[DenseProfileQueryResult, ...]
+
+
+@dataclass(frozen=True)
+class DenseProfileResult:
+    """Aggregate benchmark result for one dense profile."""
+
+    profile_id: str
+    precision_at_5: float
+    recall_at_10: float
+    mrr: float
+    ndcg_at_5: float
+    query_latency_p50_ms: float
+    query_latency_p95_ms: float
+    embedding_latency_p50_ms: float
+    embedding_latency_p95_ms: float
+    ingest_latency_p50_ms: float
+    ingest_latency_p95_ms: float
+    dimensions: int
+    collection_size: int
+    benchmark_hash: str
+    corpus_hash: str
+
+
+@dataclass(frozen=True)
+class PromotionThresholds:
+    """Decision thresholds for promoting Qwen3 as dense baseline."""
+
+    min_recall10_relative_gain: float = 0.10
+    min_ndcg5_relative_gain: float = 0.05
+    max_query_p95_latency_multiplier: float = 3.0
+    max_embedding_p95_latency_multiplier: float = 10.0
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    """Decision gate result for the dense profile A/B benchmark."""
+
+    promote_qwen3_dense: bool
+    accepted_profile: str
+    candidate_profile: str
+    reason: str
+    thresholds: PromotionThresholds
+
+
+@dataclass(frozen=True)
+class ProfileEvaluationRow:
+    """Computed per-query metrics for CSV/JSON output."""
+
+    profile_id: str
+    query_id: str
+    category: str
+    status: Literal["ok", "error"]
+    precision_at_5: float
+    recall_at_10: float
+    mrr: float
+    ndcg_at_5: float
+    embedding_latency_ms: float
+    query_latency_ms: float
+    ingest_latency_ms: float
+    total_latency_ms: float
+    top_k: int
+    retrieved_ids: tuple[str, ...]
+    scores: tuple[float, ...]
+    hit_ids: tuple[str, ...]
+    hit_scores: tuple[float, ...]
+    relevance_scores: tuple[float, ...]
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class DenseEmbeddingABConfig:
+    """Configuration for one dense embedding A/B benchmark run."""
+
+    benchmark_file: Path = DEFAULT_BENCHMARK_FILE
+    expected_results_file: Path = DEFAULT_EXPECTED_RESULTS_FILE
+    output_dir: Path = DEFAULT_RESULTS_DIR
+    adr_path: Path = DEFAULT_ADR_PATH
+    baseline_profile: str = DEFAULT_BASELINE_PROFILE
+    candidate_profile: str = DEFAULT_CANDIDATE_PROFILE
+    top_k: int = DEFAULT_TOP_K
+    cutoff_precision: int = DEFAULT_CUTOFF_PRECISION
+    cutoff_recall: int = DEFAULT_CUTOFF_RECALL
+    cutoff_ndcg: int = DEFAULT_CUTOFF_NDCG
+
+    def normalized(self) -> DenseEmbeddingABConfig:
+        """Return a validated config copy."""
+        if self.top_k <= 0:
+            raise ValueError("top_k must be greater than zero")
+        if self.cutoff_precision <= 0:
+            raise ValueError("cutoff_precision must be greater than zero")
+        if self.cutoff_recall <= 0:
+            raise ValueError("cutoff_recall must be greater than zero")
+        if self.cutoff_ndcg <= 0:
+            raise ValueError("cutoff_ndcg must be greater than zero")
+        max_cutoff = max(self.cutoff_precision, self.cutoff_recall, self.cutoff_ndcg)
+        if self.top_k <= max_cutoff:
+            raise ValueError(
+                "top_k must be greater than all metric cutoffs "
+                f"(max cutoff is {max_cutoff})"
+            )
+        if not self.baseline_profile.strip():
+            raise ValueError("baseline_profile must not be empty")
+        if not self.candidate_profile.strip():
+            raise ValueError("candidate_profile must not be empty")
+        if self.baseline_profile == self.candidate_profile:
+            raise ValueError("baseline_profile and candidate_profile must differ")
+        return self
+
+
+@dataclass(frozen=True)
+class DenseEmbeddingABPaths:
+    """Artifacts written by the A/B benchmark."""
+
+    csv_path: Path
+    json_path: Path
+    markdown_path: Path
+    adr_path: Path
+
+
+@dataclass(frozen=True)
+class DenseEmbeddingABResult:
+    """Final A/B benchmark result."""
+
+    baseline: DenseProfileResult
+    candidate: DenseProfileResult
+    decision: PromotionDecision
+    rows: tuple[ProfileEvaluationRow, ...]
+    paths: DenseEmbeddingABPaths
+
+
+class DenseProfileRunner(Protocol):
+    """Profile runner injected by tests or future runtime wiring."""
+
+    def run(
+        self,
+        benchmark: DenseEmbeddingBenchmark,
+        *,
+        profile_id: str,
+        top_k: int,
+    ) -> DenseProfileRun:
+        """Run one dense profile against ``benchmark``."""
+        ...
+
+
+def load_benchmark(
+    benchmark_file: Path = DEFAULT_BENCHMARK_FILE,
+    expected_results_file: Path = DEFAULT_EXPECTED_RESULTS_FILE,
+) -> DenseEmbeddingBenchmark:
+    """Load PR-01 benchmark inputs and compute file hashes."""
+    queries = tuple(load_benchmark_queries(benchmark_file))
+    expected_results = load_expected_results(expected_results_file)
+    _validate_expected_compatibility(queries, expected_results)
+    return DenseEmbeddingBenchmark(
+        queries=queries,
+        expected_results=expected_results,
+        benchmark_hash=_sha256_file(benchmark_file),
+        expected_results_hash=_sha256_file(expected_results_file),
+    )
+
+
+def compare_dense_embeddings(
+    *,
+    baseline_runner: DenseProfileRunner,
+    candidate_runner: DenseProfileRunner,
+    config: DenseEmbeddingABConfig,
+    thresholds: PromotionThresholds = PromotionThresholds(),
+) -> DenseEmbeddingABResult:
+    """Run the dense embedding A/B benchmark and write artifacts."""
+    active_config = config.normalized()
+    benchmark = load_benchmark(
+        active_config.benchmark_file,
+        active_config.expected_results_file,
+    )
+
+    baseline_run = baseline_runner.run(
+        benchmark,
+        profile_id=active_config.baseline_profile,
+        top_k=active_config.top_k,
+    )
+    candidate_run = candidate_runner.run(
+        benchmark,
+        profile_id=active_config.candidate_profile,
+        top_k=active_config.top_k,
+    )
+    _validate_profile_run(
+        run=baseline_run,
+        expected_profile=active_config.baseline_profile,
+        benchmark=benchmark,
+    )
+    _validate_profile_run(
+        run=candidate_run,
+        expected_profile=active_config.candidate_profile,
+        benchmark=benchmark,
+    )
+
+    baseline_rows = evaluate_profile_run(baseline_run, benchmark, active_config)
+    candidate_rows = evaluate_profile_run(candidate_run, benchmark, active_config)
+    baseline = summarize_profile_run(
+        baseline_run,
+        baseline_rows,
+        benchmark,
+        active_config,
+    )
+    candidate = summarize_profile_run(
+        candidate_run,
+        candidate_rows,
+        benchmark,
+        active_config,
+    )
+    ensure_fair_comparison(baseline, candidate)
+    decision = decide_promotion(baseline, candidate, thresholds)
+
+    paths = _output_paths(active_config)
+    active_config.output_dir.mkdir(parents=True, exist_ok=True)
+    paths.adr_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = baseline_rows + candidate_rows
+    write_csv(rows, paths.csv_path)
+    write_json(
+        baseline=baseline,
+        candidate=candidate,
+        decision=decision,
+        rows=rows,
+        benchmark=benchmark,
+        path=paths.json_path,
+    )
+    write_markdown(
+        baseline=baseline,
+        candidate=candidate,
+        decision=decision,
+        path=paths.markdown_path,
+    )
+    write_adr(
+        baseline=baseline,
+        candidate=candidate,
+        decision=decision,
+        path=paths.adr_path,
+    )
+    return DenseEmbeddingABResult(
+        baseline=baseline,
+        candidate=candidate,
+        decision=decision,
+        rows=rows,
+        paths=paths,
+    )
+
+
+def evaluate_profile_run(
+    run: DenseProfileRun,
+    benchmark: DenseEmbeddingBenchmark,
+    config: DenseEmbeddingABConfig,
+) -> tuple[ProfileEvaluationRow, ...]:
+    """Compute per-query metrics for a raw dense profile run."""
+    query_by_id = {query.query_id: query for query in benchmark.queries}
+    rows: list[ProfileEvaluationRow] = []
+    for result in run.query_results:
+        query = query_by_id[result.query_id]
+        expected_ids = frozenset(query.expected_doc_ids)
+        relevance_scores = tuple(
+            _relevance_scores(
+                query_id=query.query_id,
+                retrieved_ids=result.retrieved_ids,
+                expected_results=benchmark.expected_results,
+                cutoff=config.cutoff_ndcg,
+            )
+        )
+        if result.status == "ok":
+            precision = precision_at_k(
+                result.retrieved_ids,
+                expected_ids,
+                config.cutoff_precision,
+            )
+            recall = recall_at_k(
+                result.retrieved_ids,
+                expected_ids,
+                config.cutoff_recall,
+            )
+            rr = reciprocal_rank(result.retrieved_ids, expected_ids)
+            ndcg = ndcg_at_k(relevance_scores, config.cutoff_ndcg)
+        else:
+            precision = 0.0
+            recall = 0.0
+            rr = 0.0
+            ndcg = 0.0
+
+        hit_pairs = [
+            (doc_id, result.scores[index])
+            for index, doc_id in enumerate(result.retrieved_ids)
+            if doc_id in expected_ids and index < len(result.scores)
+        ]
+        total_latency = (
+            result.embedding_latency_ms
+            + result.query_latency_ms
+            + result.ingest_latency_ms
+        )
+        rows.append(
+            ProfileEvaluationRow(
+                profile_id=run.profile_id,
+                query_id=query.query_id,
+                category=query.category,
+                status=result.status,
+                precision_at_5=precision,
+                recall_at_10=recall,
+                mrr=rr,
+                ndcg_at_5=ndcg,
+                embedding_latency_ms=result.embedding_latency_ms,
+                query_latency_ms=result.query_latency_ms,
+                ingest_latency_ms=result.ingest_latency_ms,
+                total_latency_ms=total_latency,
+                top_k=config.top_k,
+                retrieved_ids=result.retrieved_ids,
+                scores=result.scores,
+                hit_ids=tuple(doc_id for doc_id, _ in hit_pairs),
+                hit_scores=tuple(score for _, score in hit_pairs),
+                relevance_scores=relevance_scores,
+                error_type=result.error_type,
+                error_message=result.error_message,
+            )
+        )
+    return tuple(rows)
+
+
+def summarize_profile_run(
+    run: DenseProfileRun,
+    rows: Sequence[ProfileEvaluationRow],
+    benchmark: DenseEmbeddingBenchmark,
+    config: DenseEmbeddingABConfig,
+) -> DenseProfileResult:
+    """Aggregate per-query rows into one profile result."""
+    ok_rows = [row for row in rows if row.status == "ok"]
+    if not ok_rows:
+        latency = {50: 0.0, 95: 0.0}
+        return DenseProfileResult(
+            profile_id=run.profile_id,
+            precision_at_5=0.0,
+            recall_at_10=0.0,
+            mrr=0.0,
+            ndcg_at_5=0.0,
+            query_latency_p50_ms=0.0,
+            query_latency_p95_ms=0.0,
+            embedding_latency_p50_ms=0.0,
+            embedding_latency_p95_ms=0.0,
+            ingest_latency_p50_ms=latency[50],
+            ingest_latency_p95_ms=latency[95],
+            dimensions=run.dimensions,
+            collection_size=run.collection_size,
+            benchmark_hash=run.benchmark_hash,
+            corpus_hash=run.corpus_hash,
+        )
+
+    expected_ids_by_query = {
+        query.query_id: frozenset(query.expected_doc_ids)
+        for query in benchmark.queries
+    }
+    precision_recall_inputs = [
+        (row.retrieved_ids, expected_ids_by_query[row.query_id])
+        for row in ok_rows
+    ]
+    rr_scores = [row.mrr for row in ok_rows]
+    ndcg_inputs = [row.relevance_scores for row in ok_rows]
+    query_latency = latency_percentiles(
+        [row.query_latency_ms for row in ok_rows],
+        (50, 95),
+    )
+    embedding_latency = latency_percentiles(
+        [row.embedding_latency_ms for row in ok_rows],
+        (50, 95),
+    )
+    ingest_latency = latency_percentiles(
+        [row.ingest_latency_ms for row in ok_rows],
+        (50, 95),
+    )
+    return DenseProfileResult(
+        profile_id=run.profile_id,
+        precision_at_5=mean_precision_at_k(
+            precision_recall_inputs,
+            config.cutoff_precision,
+        ),
+        recall_at_10=mean_recall_at_k(
+            precision_recall_inputs,
+            config.cutoff_recall,
+        ),
+        mrr=mean_reciprocal_rank(rr_scores),
+        ndcg_at_5=mean_ndcg_at_k(ndcg_inputs, config.cutoff_ndcg),
+        query_latency_p50_ms=query_latency[50],
+        query_latency_p95_ms=query_latency[95],
+        embedding_latency_p50_ms=embedding_latency[50],
+        embedding_latency_p95_ms=embedding_latency[95],
+        ingest_latency_p50_ms=ingest_latency[50],
+        ingest_latency_p95_ms=ingest_latency[95],
+        dimensions=run.dimensions,
+        collection_size=run.collection_size,
+        benchmark_hash=run.benchmark_hash,
+        corpus_hash=run.corpus_hash,
+    )
+
+
+def ensure_fair_comparison(
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+) -> None:
+    """Raise if profile results were not produced from identical inputs."""
+    if baseline.benchmark_hash != candidate.benchmark_hash:
+        raise ValueError("A/B benchmark must use identical benchmark queries")
+    if baseline.corpus_hash != candidate.corpus_hash:
+        raise ValueError("A/B benchmark must use identical corpus snapshot")
+
+
+def decide_promotion(
+    nomic: DenseProfileResult,
+    qwen3: DenseProfileResult,
+    thresholds: PromotionThresholds = PromotionThresholds(),
+) -> PromotionDecision:
+    """Apply the PR-04C quality/latency gate."""
+    recall_gain = _relative_gain(qwen3.recall_at_10, nomic.recall_at_10)
+    ndcg_gain = _relative_gain(qwen3.ndcg_at_5, nomic.ndcg_at_5)
+    query_p95_multiplier = _latency_multiplier(
+        qwen3.query_latency_p95_ms,
+        nomic.query_latency_p95_ms,
+    )
+    embedding_p95_multiplier = _latency_multiplier(
+        qwen3.embedding_latency_p95_ms,
+        nomic.embedding_latency_p95_ms,
+    )
+    promote = (
+        recall_gain >= thresholds.min_recall10_relative_gain
+        and ndcg_gain >= thresholds.min_ndcg5_relative_gain
+        and query_p95_multiplier <= thresholds.max_query_p95_latency_multiplier
+        and embedding_p95_multiplier
+        <= thresholds.max_embedding_p95_latency_multiplier
+    )
+    if promote:
+        accepted = qwen3.profile_id
+        reason = (
+            "Qwen3 met quality thresholds within latency limits: "
+            f"recall_gain={_format_ratio(recall_gain)}, "
+            f"ndcg_gain={_format_ratio(ndcg_gain)}, "
+            f"query_p95_multiplier={_format_multiplier(query_p95_multiplier)}, "
+            "embedding_p95_multiplier="
+            f"{_format_multiplier(embedding_p95_multiplier)}."
+        )
+    else:
+        accepted = nomic.profile_id
+        reason = (
+            "Qwen3 did not meet all promotion thresholds: "
+            f"recall_gain={_format_ratio(recall_gain)}, "
+            f"ndcg_gain={_format_ratio(ndcg_gain)}, "
+            f"query_p95_multiplier={_format_multiplier(query_p95_multiplier)}, "
+            "embedding_p95_multiplier="
+            f"{_format_multiplier(embedding_p95_multiplier)}."
+        )
+    return PromotionDecision(
+        promote_qwen3_dense=promote,
+        accepted_profile=accepted,
+        candidate_profile=qwen3.profile_id,
+        reason=reason,
+        thresholds=thresholds,
+    )
+
+
+def write_csv(rows: Sequence[ProfileEvaluationRow], path: Path) -> None:
+    """Write per-query A/B rows without query text or document content."""
+    fieldnames = [
+        "profile_id",
+        "query_id",
+        "category",
+        "status",
+        "precision_at_5",
+        "recall_at_10",
+        "mrr",
+        "ndcg_at_5",
+        "embedding_latency_ms",
+        "query_latency_ms",
+        "ingest_latency_ms",
+        "total_latency_ms",
+        "top_k",
+        "hit_ids",
+        "hit_scores",
+        "retrieved_ids",
+        "scores",
+        "error_type",
+        "error_message",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "profile_id": row.profile_id,
+                    "query_id": row.query_id,
+                    "category": row.category,
+                    "status": row.status,
+                    "precision_at_5": row.precision_at_5,
+                    "recall_at_10": row.recall_at_10,
+                    "mrr": row.mrr,
+                    "ndcg_at_5": row.ndcg_at_5,
+                    "embedding_latency_ms": row.embedding_latency_ms,
+                    "query_latency_ms": row.query_latency_ms,
+                    "ingest_latency_ms": row.ingest_latency_ms,
+                    "total_latency_ms": row.total_latency_ms,
+                    "top_k": row.top_k,
+                    "hit_ids": "|".join(row.hit_ids),
+                    "hit_scores": "|".join(str(score) for score in row.hit_scores),
+                    "retrieved_ids": "|".join(row.retrieved_ids),
+                    "scores": "|".join(str(score) for score in row.scores),
+                    "error_type": row.error_type or "",
+                    "error_message": row.error_message or "",
+                }
+            )
+
+
+def write_json(
+    *,
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+    decision: PromotionDecision,
+    rows: Sequence[ProfileEvaluationRow],
+    benchmark: DenseEmbeddingBenchmark,
+    path: Path,
+) -> None:
+    """Write JSON summary with decision gate and compact rows."""
+    payload = {
+        "runner_version": RUNNER_VERSION,
+        "benchmark_hash": benchmark.benchmark_hash,
+        "expected_results_hash": benchmark.expected_results_hash,
+        "profiles": [
+            _profile_result_to_dict(baseline),
+            _profile_result_to_dict(candidate),
+        ],
+        "decision_gate": _decision_to_dict(decision),
+        "results": [_row_to_dict(row) for row in rows],
+    }
+    _assert_safe_output(payload)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_markdown(
+    *,
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+    decision: PromotionDecision,
+    path: Path,
+) -> None:
+    """Write a human-readable A/B report with tables and Mermaid charts."""
+    path.write_text(
+        render_markdown_report(
+            baseline=baseline,
+            candidate=candidate,
+            decision=decision,
+        ),
+        encoding="utf-8",
+    )
+
+
+def render_markdown_report(
+    *,
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+    decision: PromotionDecision,
+) -> str:
+    """Return the Markdown report body."""
+    faster_query = _winner_lower(
+        baseline.profile_id,
+        candidate.profile_id,
+        baseline.query_latency_p95_ms,
+        candidate.query_latency_p95_ms,
+    )
+    faster_embedding = _winner_lower(
+        baseline.profile_id,
+        candidate.profile_id,
+        baseline.embedding_latency_p95_ms,
+        candidate.embedding_latency_p95_ms,
+    )
+    more_precise = _winner_higher(
+        baseline.profile_id,
+        candidate.profile_id,
+        baseline.recall_at_10,
+        candidate.recall_at_10,
+    )
+    quality_rows = [
+        _quality_row("Precision@5", baseline.precision_at_5, candidate.precision_at_5),
+        _quality_row("Recall@10", baseline.recall_at_10, candidate.recall_at_10),
+        _quality_row("MRR", baseline.mrr, candidate.mrr),
+        _quality_row("NDCG@5", baseline.ndcg_at_5, candidate.ndcg_at_5),
+    ]
+    latency_rows = [
+        _latency_row(
+            "Query p50",
+            baseline.query_latency_p50_ms,
+            candidate.query_latency_p50_ms,
+        ),
+        _latency_row(
+            "Query p95",
+            baseline.query_latency_p95_ms,
+            candidate.query_latency_p95_ms,
+        ),
+        _latency_row(
+            "Embedding p50",
+            baseline.embedding_latency_p50_ms,
+            candidate.embedding_latency_p50_ms,
+        ),
+        _latency_row(
+            "Embedding p95",
+            baseline.embedding_latency_p95_ms,
+            candidate.embedding_latency_p95_ms,
+        ),
+    ]
+    return f"""# Dense Embedding A/B Benchmark — Nomic vs Qwen3-8B
+
+## Resumo
+
+- Baseline: `{baseline.profile_id}` ({baseline.dimensions} dimensões).
+- Candidato: `{candidate.profile_id}` ({candidate.dimensions} dimensões).
+- Benchmark hash: `{baseline.benchmark_hash}`.
+- Corpus hash: `{baseline.corpus_hash}`.
+
+## Métricas de Qualidade
+
+| Métrica | Nomic | Qwen3-8B | Diferença | Vencedor |
+|---|---:|---:|---:|---|
+{chr(10).join(quality_rows)}
+
+```mermaid
+xychart-beta
+  title "Qualidade de Retrieval — maior é melhor"
+  x-axis ["Precision@5", "Recall@10", "MRR", "NDCG@5"]
+  y-axis "Score" 0 --> 1
+  bar "Nomic" [{_score(baseline.precision_at_5)}, {_score(baseline.recall_at_10)}, {_score(baseline.mrr)}, {_score(baseline.ndcg_at_5)}]
+  bar "Qwen3-8B" [{_score(candidate.precision_at_5)}, {_score(candidate.recall_at_10)}, {_score(candidate.mrr)}, {_score(candidate.ndcg_at_5)}]
+```
+
+## Latência
+
+| Métrica | Nomic (ms) | Qwen3-8B (ms) | Multiplicador | Vencedor |
+|---|---:|---:|---:|---|
+{chr(10).join(latency_rows)}
+
+```mermaid
+xychart-beta
+  title "Latência p95 (ms) — menor é melhor"
+  x-axis ["Query p95", "Embedding p95"]
+  y-axis "ms" 0 --> {_latency_axis_max(baseline, candidate)}
+  bar "Nomic" [{_ms(baseline.query_latency_p95_ms)}, {_ms(baseline.embedding_latency_p95_ms)}]
+  bar "Qwen3-8B" [{_ms(candidate.query_latency_p95_ms)}, {_ms(candidate.embedding_latency_p95_ms)}]
+```
+
+## Veredito Humano
+
+- Mais preciso: **{more_precise}**.
+- Mais rápido em query p95: **{faster_query}**.
+- Mais rápido em embedding p95: **{faster_embedding}**.
+- Decisão: `{decision.accepted_profile}`.
+- `promote_qwen3_dense`: `{str(decision.promote_qwen3_dense).lower()}`.
+- Motivo: {decision.reason}
+
+## Gate de Decisão
+
+```text
+promote_qwen3_dense: {str(decision.promote_qwen3_dense).lower()}
+accepted_profile: {decision.accepted_profile}
+candidate_profile: {decision.candidate_profile}
+reason: {decision.reason}
+```
+"""
+
+
+def write_adr(
+    *,
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+    decision: PromotionDecision,
+    path: Path,
+) -> None:
+    """Write the short ADR recording the A/B decision."""
+    status = "Accepted" if decision.promote_qwen3_dense else "Rejected"
+    path.write_text(
+        f"""# ADR-0003 — Qwen3 Dense Embedding Baseline
+
+## Status
+
+{status} for Qwen3 dense baseline promotion.
+
+## Contexto
+
+O RAG-1A compara `{baseline.profile_id}` contra `{candidate.profile_id}`
+usando o mesmo corpus e as mesmas queries do benchmark financeiro brasileiro.
+
+## Resultado
+
+- Recall@10 baseline: {_score(baseline.recall_at_10)}
+- Recall@10 candidato: {_score(candidate.recall_at_10)}
+- NDCG@5 baseline: {_score(baseline.ndcg_at_5)}
+- NDCG@5 candidato: {_score(candidate.ndcg_at_5)}
+- Query p95 baseline: {_ms(baseline.query_latency_p95_ms)} ms
+- Query p95 candidato: {_ms(candidate.query_latency_p95_ms)} ms
+- Embedding p95 baseline: {_ms(baseline.embedding_latency_p95_ms)} ms
+- Embedding p95 candidato: {_ms(candidate.embedding_latency_p95_ms)} ms
+
+## Decisão
+
+- accepted_profile: `{decision.accepted_profile}`
+- promote_qwen3_dense: `{str(decision.promote_qwen3_dense).lower()}`
+
+## Motivo
+
+{decision.reason}
+
+## Fora de Escopo
+
+- BM25 e hybrid search.
+- Reranker.
+- Agentic RAG e multi-tool orchestration.
+- Alterar `active_profile` de produção neste PR.
+""",
+        encoding="utf-8",
+    )
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI args for the A/B benchmark contract."""
+    parser = argparse.ArgumentParser(
+        description="Compare dense embedding profiles for RAG-1A PR-04C."
+    )
+    parser.add_argument("--baseline-profile", default=DEFAULT_BASELINE_PROFILE)
+    parser.add_argument("--candidate-profile", default=DEFAULT_CANDIDATE_PROFILE)
+    parser.add_argument("--benchmark", type=Path, default=DEFAULT_BENCHMARK_FILE)
+    parser.add_argument(
+        "--expected-results",
+        type=Path,
+        default=DEFAULT_EXPECTED_RESULTS_FILE,
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    parser.add_argument("--adr-path", type=Path, default=DEFAULT_ADR_PATH)
+    parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate CLI args and explain the required runner wiring.
+
+    PR-04C keeps production retrieval untouched. Real profile runners are
+    intentionally injected by future wiring or tests, not auto-created here.
+    """
+    args = parse_args(argv)
+    DenseEmbeddingABConfig(
+        benchmark_file=args.benchmark,
+        expected_results_file=args.expected_results,
+        output_dir=args.output_dir,
+        adr_path=args.adr_path,
+        baseline_profile=str(args.baseline_profile),
+        candidate_profile=str(args.candidate_profile),
+        top_k=int(args.top_k),
+    ).normalized()
+    logger.error(
+        "dense embedding A/B runner requires injected profile runners; "
+        "no production retrieval wiring is changed in PR-04C"
+    )
+    return 2
+
+
+def _validate_profile_run(
+    *,
+    run: DenseProfileRun,
+    expected_profile: str,
+    benchmark: DenseEmbeddingBenchmark,
+) -> None:
+    if run.profile_id != expected_profile:
+        raise ValueError(
+            f"profile runner returned {run.profile_id!r}, expected {expected_profile!r}"
+        )
+    if run.dimensions <= 0:
+        raise ValueError("profile dimensions must be greater than zero")
+    if run.collection_size < 0:
+        raise ValueError("collection_size cannot be negative")
+    if run.benchmark_hash != benchmark.benchmark_hash:
+        raise ValueError("profile run benchmark hash does not match loaded benchmark")
+    query_ids = {query.query_id for query in benchmark.queries}
+    result_ids = {row.query_id for row in run.query_results}
+    missing = query_ids - result_ids
+    extra = result_ids - query_ids
+    if missing:
+        raise ValueError(f"profile run missing query ids: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"profile run returned unknown query ids: {sorted(extra)}")
+
+
+def _validate_expected_compatibility(
+    queries: Sequence[BenchmarkQuery],
+    expected_results: Mapping[str, Mapping[str, float]],
+) -> None:
+    query_ids = {query.query_id for query in queries}
+    result_ids = set(expected_results)
+    missing = query_ids - result_ids
+    extra = result_ids - query_ids
+    if missing:
+        raise ValueError(f"expected_results missing query ids: {sorted(missing)}")
+    if extra:
+        raise ValueError(f"expected_results has unknown query ids: {sorted(extra)}")
+
+
+def _relevance_scores(
+    *,
+    query_id: str,
+    retrieved_ids: Sequence[str],
+    expected_results: Mapping[str, Mapping[str, float]],
+    cutoff: int,
+) -> list[float]:
+    grades = expected_results.get(query_id, {})
+    scores = [float(grades.get(doc_id, 0.0)) for doc_id in retrieved_ids[:cutoff]]
+    while len(scores) < cutoff:
+        scores.append(0.0)
+    return scores
+
+
+def _output_paths(config: DenseEmbeddingABConfig) -> DenseEmbeddingABPaths:
+    return DenseEmbeddingABPaths(
+        csv_path=config.output_dir / DEFAULT_CSV_FILENAME,
+        json_path=config.output_dir / DEFAULT_JSON_FILENAME,
+        markdown_path=config.output_dir / DEFAULT_MARKDOWN_FILENAME,
+        adr_path=config.adr_path,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _profile_result_to_dict(result: DenseProfileResult) -> dict[str, object]:
+    return asdict(result)
+
+
+def _decision_to_dict(decision: PromotionDecision) -> dict[str, object]:
+    return {
+        "promote_qwen3_dense": decision.promote_qwen3_dense,
+        "accepted_profile": decision.accepted_profile,
+        "candidate_profile": decision.candidate_profile,
+        "reason": decision.reason,
+        "thresholds": asdict(decision.thresholds),
+    }
+
+
+def _row_to_dict(row: ProfileEvaluationRow) -> dict[str, object]:
+    return {
+        "profile_id": row.profile_id,
+        "query_id": row.query_id,
+        "category": row.category,
+        "status": row.status,
+        "precision_at_5": row.precision_at_5,
+        "recall_at_10": row.recall_at_10,
+        "mrr": row.mrr,
+        "ndcg_at_5": row.ndcg_at_5,
+        "embedding_latency_ms": row.embedding_latency_ms,
+        "query_latency_ms": row.query_latency_ms,
+        "ingest_latency_ms": row.ingest_latency_ms,
+        "total_latency_ms": row.total_latency_ms,
+        "top_k": row.top_k,
+        "hit_ids": list(row.hit_ids),
+        "hit_scores": list(row.hit_scores),
+        "retrieved_ids": list(row.retrieved_ids),
+        "scores": list(row.scores),
+        "error_type": row.error_type,
+        "error_message": row.error_message,
+    }
+
+
+def _assert_safe_output(value: object) -> None:
+    forbidden = {
+        "answer",
+        "chunk_text",
+        "document_text",
+        "embedding",
+        "embeddings",
+        "payload",
+        "prompt",
+        "qdrant_payload",
+        "raw_document",
+        "text",
+        "vector",
+        "vectors",
+    }
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if isinstance(key, str) and key in forbidden:
+                raise ValueError(f"sensitive output key is forbidden: {key}")
+            _assert_safe_output(nested)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_safe_output(item)
+
+
+def _relative_gain(candidate: float, baseline: float) -> float:
+    if abs(baseline) <= EPSILON:
+        if candidate <= EPSILON:
+            return 0.0
+        return math.inf
+    return (candidate - baseline) / baseline
+
+
+def _latency_multiplier(candidate: float, baseline: float) -> float:
+    if abs(baseline) <= EPSILON:
+        if candidate <= EPSILON:
+            return 1.0
+        return math.inf
+    return candidate / baseline
+
+
+def _quality_row(label: str, baseline: float, candidate: float) -> str:
+    return (
+        f"| {label} | {_score(baseline)} | {_score(candidate)} | "
+        f"{_format_percent_delta(candidate, baseline)} | "
+        f"{_winner_higher('Nomic', 'Qwen3-8B', baseline, candidate)} |"
+    )
+
+
+def _latency_row(label: str, baseline: float, candidate: float) -> str:
+    multiplier = _latency_multiplier(candidate, baseline)
+    return (
+        f"| {label} | {_ms(baseline)} | {_ms(candidate)} | "
+        f"{_format_multiplier(multiplier)} | "
+        f"{_winner_lower('Nomic', 'Qwen3-8B', baseline, candidate)} |"
+    )
+
+
+def _winner_higher(
+    baseline_label: str,
+    candidate_label: str,
+    baseline: float,
+    candidate: float,
+) -> str:
+    if candidate > baseline:
+        return candidate_label
+    if baseline > candidate:
+        return baseline_label
+    return "Empate"
+
+
+def _winner_lower(
+    baseline_label: str,
+    candidate_label: str,
+    baseline: float,
+    candidate: float,
+) -> str:
+    if candidate < baseline:
+        return candidate_label
+    if baseline < candidate:
+        return baseline_label
+    return "Empate"
+
+
+def _format_percent_delta(candidate: float, baseline: float) -> str:
+    gain = _relative_gain(candidate, baseline)
+    if math.isinf(gain):
+        return "+inf"
+    return f"{gain * 100.0:+.1f}%"
+
+
+def _format_ratio(value: float) -> str:
+    if math.isinf(value):
+        return "inf"
+    return f"{value:.3f}"
+
+
+def _format_multiplier(value: float) -> str:
+    if math.isinf(value):
+        return "inf"
+    return f"{value:.1f}x"
+
+
+def _score(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def _ms(value: float) -> str:
+    return f"{value:.1f}"
+
+
+def _latency_axis_max(
+    baseline: DenseProfileResult,
+    candidate: DenseProfileResult,
+) -> str:
+    max_value = max(
+        baseline.query_latency_p95_ms,
+        baseline.embedding_latency_p95_ms,
+        candidate.query_latency_p95_ms,
+        candidate.embedding_latency_p95_ms,
+        1.0,
+    )
+    return str(int(math.ceil(max_value * 1.2)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DenseEmbeddingABConfig",
+    "DenseEmbeddingABPaths",
+    "DenseEmbeddingABResult",
+    "DenseEmbeddingBenchmark",
+    "DenseProfileQueryResult",
+    "DenseProfileResult",
+    "DenseProfileRun",
+    "DenseProfileRunner",
+    "ProfileEvaluationRow",
+    "PromotionDecision",
+    "PromotionThresholds",
+    "compare_dense_embeddings",
+    "decide_promotion",
+    "ensure_fair_comparison",
+    "evaluate_profile_run",
+    "load_benchmark",
+    "main",
+    "render_markdown_report",
+    "summarize_profile_run",
+    "write_adr",
+    "write_csv",
+    "write_json",
+    "write_markdown",
+]

--- a/evaluation/compare_dense_embeddings.py
+++ b/evaluation/compare_dense_embeddings.py
@@ -126,7 +126,11 @@ class PromotionThresholds:
 
 @dataclass(frozen=True)
 class PromotionDecision:
-    """Decision gate result for the dense profile A/B benchmark."""
+    """Decision gate result for the dense profile A/B benchmark.
+
+    RAG-1B should add structured ``rejection_codes`` alongside ``reason`` if
+    another system starts consuming the JSON decision programmatically.
+    """
 
     promote_qwen3_dense: bool
     accepted_profile: str
@@ -426,7 +430,13 @@ def summarize_profile_run(
     benchmark: DenseEmbeddingBenchmark,
     config: DenseEmbeddingABConfig,
 ) -> DenseProfileResult:
-    """Aggregate per-query rows into one profile result."""
+    """Aggregate per-query rows into one profile result.
+
+    Latency percentiles deliberately delegate to the PR-02
+    ``evaluation.latency_percentiles`` contract, which uses linear
+    interpolation. This module does not define a private nearest-rank
+    percentile variant, avoiding hidden convention drift.
+    """
     ok_rows = [row for row in rows if row.status == "ok"]
     if not ok_rows:
         latency = {50: 0.0, 95: 0.0}
@@ -560,6 +570,8 @@ def decide_promotion(
 
 def write_csv(rows: Sequence[ProfileEvaluationRow], path: Path) -> None:
     """Write per-query A/B rows without query text or document content."""
+    if not rows:
+        raise ValueError("cannot write dense embedding A/B CSV without result rows")
     fieldnames = [
         "profile_id",
         "query_id",
@@ -871,6 +883,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             count=len(benchmark.queries),
         )
         return 0
+    # TODO(PR-05): inject concrete dense profile runners here once the real
+    # benchmark execution path is allowed to wire retrievers/collections.
     logger.error(
         "dense embedding A/B runner requires injected profile runners; "
         "no production retrieval wiring is changed in PR-04C"

--- a/evaluation/compare_dense_embeddings.py
+++ b/evaluation/compare_dense_embeddings.py
@@ -240,15 +240,22 @@ def load_benchmark(
     benchmark_file: Path = DEFAULT_BENCHMARK_FILE,
     expected_results_file: Path = DEFAULT_EXPECTED_RESULTS_FILE,
 ) -> DenseEmbeddingBenchmark:
-    """Load PR-01 benchmark inputs and compute file hashes."""
+    """Load PR-01 benchmark inputs and compute fairness hashes.
+
+    ``benchmark_hash`` intentionally covers both the query manifest and the
+    expected-results manifest. The A/B guard must fail if either the queries or
+    the ground truth changes between profile runs.
+    """
     queries = tuple(load_benchmark_queries(benchmark_file))
     expected_results = load_expected_results(expected_results_file)
     _validate_expected_compatibility(queries, expected_results)
+    benchmark_file_hash = _sha256_file(benchmark_file)
+    expected_results_hash = _sha256_file(expected_results_file)
     return DenseEmbeddingBenchmark(
         queries=queries,
         expected_results=expected_results,
-        benchmark_hash=_sha256_file(benchmark_file),
-        expected_results_hash=_sha256_file(expected_results_file),
+        benchmark_hash=_combined_hash(benchmark_file_hash, expected_results_hash),
+        expected_results_hash=expected_results_hash,
     )
 
 
@@ -829,6 +836,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--output-dir", type=Path, default=DEFAULT_RESULTS_DIR)
     parser.add_argument("--adr-path", type=Path, default=DEFAULT_ADR_PATH)
     parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate benchmark inputs and config without running profiles or writing artifacts.",
+    )
     return parser.parse_args(argv)
 
 
@@ -839,7 +851,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     intentionally injected by future wiring or tests, not auto-created here.
     """
     args = parse_args(argv)
-    DenseEmbeddingABConfig(
+    active_config = DenseEmbeddingABConfig(
         benchmark_file=args.benchmark,
         expected_results_file=args.expected_results,
         output_dir=args.output_dir,
@@ -848,6 +860,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         candidate_profile=str(args.candidate_profile),
         top_k=int(args.top_k),
     ).normalized()
+    if bool(args.dry_run):
+        benchmark = load_benchmark(
+            active_config.benchmark_file,
+            active_config.expected_results_file,
+        )
+        logger.info(
+            "dense embedding A/B dry-run validated {count} queries; "
+            "no profile runners executed and no artifacts written",
+            count=len(benchmark.queries),
+        )
+        return 0
     logger.error(
         "dense embedding A/B runner requires injected profile runners; "
         "no production retrieval wiring is changed in PR-04C"
@@ -923,6 +946,14 @@ def _sha256_file(path: Path) -> str:
     with path.open("rb") as file:
         for chunk in iter(lambda: file.read(65536), b""):
             digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _combined_hash(*parts: str) -> str:
+    digest = hashlib.sha256()
+    for part in parts:
+        digest.update(part.encode("ascii"))
+        digest.update(b"\0")
     return digest.hexdigest()
 
 

--- a/tests/unit/test_compare_dense_embeddings.py
+++ b/tests/unit/test_compare_dense_embeddings.py
@@ -1,0 +1,253 @@
+"""Unit tests for the PR-04C dense embedding A/B benchmark."""
+
+from __future__ import annotations
+
+import csv
+import json
+import tempfile
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from evaluation.compare_dense_embeddings import (
+    DenseEmbeddingABConfig,
+    DenseEmbeddingBenchmark,
+    DenseProfileQueryResult,
+    DenseProfileRun,
+    PromotionThresholds,
+    compare_dense_embeddings,
+    decide_promotion,
+    ensure_fair_comparison,
+)
+
+
+class FakeProfileRunner:
+    def __init__(
+        self,
+        *,
+        dimensions: int,
+        collection_size: int,
+        corpus_hash: str,
+        results: Mapping[str, tuple[tuple[str, ...], tuple[float, ...]]],
+    ) -> None:
+        self.dimensions = dimensions
+        self.collection_size = collection_size
+        self.corpus_hash = corpus_hash
+        self.results = results
+        self.calls: list[tuple[str, int]] = []
+
+    def run(
+        self,
+        benchmark: DenseEmbeddingBenchmark,
+        *,
+        profile_id: str,
+        top_k: int,
+    ) -> DenseProfileRun:
+        self.calls.append((profile_id, top_k))
+        rows: list[DenseProfileQueryResult] = []
+        for index, query in enumerate(benchmark.queries, start=1):
+            retrieved_ids, scores = self.results[query.query_id]
+            rows.append(
+                DenseProfileQueryResult(
+                    query_id=query.query_id,
+                    retrieved_ids=retrieved_ids,
+                    scores=scores,
+                    embedding_latency_ms=10.0 * index
+                    if "nomic" in profile_id
+                    else 20.0 * index,
+                    query_latency_ms=5.0 * index
+                    if "nomic" in profile_id
+                    else 8.0 * index,
+                    ingest_latency_ms=2.0 * index
+                    if "nomic" in profile_id
+                    else 3.0 * index,
+                )
+            )
+        return DenseProfileRun(
+            profile_id=profile_id,
+            dimensions=self.dimensions,
+            collection_size=self.collection_size,
+            benchmark_hash=benchmark.benchmark_hash,
+            corpus_hash=self.corpus_hash,
+            query_results=tuple(rows),
+        )
+
+
+class DenseEmbeddingABTests(unittest.TestCase):
+    def test_compare_writes_csv_json_markdown_and_adr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            benchmark_path, expected_path = _write_inputs(root)
+            output_dir = root / "results"
+            adr_path = root / "adr.md"
+
+            result = compare_dense_embeddings(
+                baseline_runner=FakeProfileRunner(
+                    dimensions=768,
+                    collection_size=2,
+                    corpus_hash="corpus-a",
+                    results={
+                        "Q_001": (("doc_x", "doc_a"), (0.8, 0.7)),
+                        "Q_002": (("doc_y", "doc_c"), (0.6, 0.5)),
+                    },
+                ),
+                candidate_runner=FakeProfileRunner(
+                    dimensions=4096,
+                    collection_size=2,
+                    corpus_hash="corpus-a",
+                    results={
+                        "Q_001": (("doc_a", "doc_b"), (0.9, 0.8)),
+                        "Q_002": (("doc_c", "doc_y"), (0.95, 0.1)),
+                    },
+                ),
+                config=DenseEmbeddingABConfig(
+                    benchmark_file=benchmark_path,
+                    expected_results_file=expected_path,
+                    output_dir=output_dir,
+                    adr_path=adr_path,
+                    top_k=20,
+                ),
+                thresholds=PromotionThresholds(
+                    max_query_p95_latency_multiplier=10.0,
+                    max_embedding_p95_latency_multiplier=10.0,
+                ),
+            )
+
+            self.assertTrue(result.decision.promote_qwen3_dense)
+            self.assertEqual(result.decision.accepted_profile, "qwen3_dense_8b_v1")
+            self.assertTrue(result.paths.csv_path.exists())
+            self.assertTrue(result.paths.json_path.exists())
+            self.assertTrue(result.paths.markdown_path.exists())
+            self.assertTrue(result.paths.adr_path.exists())
+
+            with result.paths.csv_path.open(encoding="utf-8", newline="") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            self.assertEqual(len(rows), 4)
+            self.assertEqual(rows[0]["profile_id"], "nomic_dense_v1")
+            self.assertNotIn("query alpha", result.paths.csv_path.read_text(encoding="utf-8"))
+
+            payload = _json_mapping(result.paths.json_path)
+            self.assertIn("decision_gate", payload)
+            self.assertIn("profiles", payload)
+            decision = _mapping(payload["decision_gate"])
+            self.assertEqual(decision["accepted_profile"], "qwen3_dense_8b_v1")
+
+            markdown = result.paths.markdown_path.read_text(encoding="utf-8")
+            self.assertIn("xychart-beta", markdown)
+            self.assertIn("Mais preciso", markdown)
+            self.assertIn("Mais rápido", markdown)
+            self.assertIn("promote_qwen3_dense: true", markdown)
+
+    def test_decision_rejects_candidate_when_latency_is_too_high(self) -> None:
+        nomic = _profile_result(
+            profile_id="nomic_dense_v1",
+            recall=0.50,
+            ndcg=0.50,
+            query_p95=100.0,
+            embedding_p95=50.0,
+        )
+        qwen3 = _profile_result(
+            profile_id="qwen3_dense_8b_v1",
+            recall=0.80,
+            ndcg=0.80,
+            query_p95=1000.0,
+            embedding_p95=2000.0,
+        )
+
+        decision = decide_promotion(nomic, qwen3)
+
+        self.assertFalse(decision.promote_qwen3_dense)
+        self.assertEqual(decision.accepted_profile, "nomic_dense_v1")
+        self.assertIn("did not meet", decision.reason)
+
+    def test_fairness_guard_rejects_benchmark_hash_mismatch(self) -> None:
+        nomic = _profile_result(profile_id="nomic_dense_v1", benchmark_hash="a")
+        qwen3 = _profile_result(profile_id="qwen3_dense_8b_v1", benchmark_hash="b")
+
+        with self.assertRaisesRegex(ValueError, "identical benchmark queries"):
+            ensure_fair_comparison(nomic, qwen3)
+
+    def test_fairness_guard_rejects_corpus_hash_mismatch(self) -> None:
+        nomic = _profile_result(profile_id="nomic_dense_v1", corpus_hash="a")
+        qwen3 = _profile_result(profile_id="qwen3_dense_8b_v1", corpus_hash="b")
+
+        with self.assertRaisesRegex(ValueError, "identical corpus snapshot"):
+            ensure_fair_comparison(nomic, qwen3)
+
+
+def _write_inputs(root: Path) -> tuple[Path, Path]:
+    benchmark_path = root / "benchmark_queries.yaml"
+    expected_path = root / "expected_results.yaml"
+    benchmark_path.write_text(
+        """
+- id: Q_001
+  query: "query alpha"
+  category: alpha
+  expected_doc_ids: ["doc_a", "doc_b"]
+- id: Q_002
+  query: "query beta"
+  category: beta
+  expected_doc_ids: ["doc_c"]
+""".lstrip(),
+        encoding="utf-8",
+    )
+    expected_path.write_text(
+        """
+Q_001:
+  doc_a: 2
+  doc_b: 1
+Q_002:
+  doc_c: 2
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return benchmark_path, expected_path
+
+
+def _profile_result(
+    *,
+    profile_id: str,
+    recall: float = 0.5,
+    ndcg: float = 0.5,
+    query_p95: float = 100.0,
+    embedding_p95: float = 50.0,
+    benchmark_hash: str = "benchmark",
+    corpus_hash: str = "corpus",
+) -> Any:
+    from evaluation.compare_dense_embeddings import DenseProfileResult
+
+    return DenseProfileResult(
+        profile_id=profile_id,
+        precision_at_5=0.5,
+        recall_at_10=recall,
+        mrr=0.5,
+        ndcg_at_5=ndcg,
+        query_latency_p50_ms=query_p95 / 2.0,
+        query_latency_p95_ms=query_p95,
+        embedding_latency_p50_ms=embedding_p95 / 2.0,
+        embedding_latency_p95_ms=embedding_p95,
+        ingest_latency_p50_ms=10.0,
+        ingest_latency_p95_ms=20.0,
+        dimensions=768 if "nomic" in profile_id else 4096,
+        collection_size=2,
+        benchmark_hash=benchmark_hash,
+        corpus_hash=corpus_hash,
+    )
+
+
+def _json_mapping(path: Path) -> dict[str, Any]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise AssertionError("expected JSON object")
+    return cast(dict[str, Any], raw)
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AssertionError("expected mapping")
+    return cast(dict[str, Any], value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_compare_dense_embeddings.py
+++ b/tests/unit/test_compare_dense_embeddings.py
@@ -19,6 +19,8 @@ from evaluation.compare_dense_embeddings import (
     compare_dense_embeddings,
     decide_promotion,
     ensure_fair_comparison,
+    load_benchmark,
+    main,
 )
 
 
@@ -174,6 +176,52 @@ class DenseEmbeddingABTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "identical corpus snapshot"):
             ensure_fair_comparison(nomic, qwen3)
+
+    def test_benchmark_hash_includes_expected_results(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            benchmark_path, expected_path = _write_inputs(root)
+            first = load_benchmark(benchmark_path, expected_path)
+
+            expected_path.write_text(
+                """
+Q_001:
+  doc_a: 1
+  doc_b: 1
+Q_002:
+  doc_c: 2
+""".lstrip(),
+                encoding="utf-8",
+            )
+            second = load_benchmark(benchmark_path, expected_path)
+
+            self.assertNotEqual(first.expected_results_hash, second.expected_results_hash)
+            self.assertNotEqual(first.benchmark_hash, second.benchmark_hash)
+
+    def test_cli_dry_run_validates_inputs_without_writing_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            benchmark_path, expected_path = _write_inputs(root)
+            output_dir = root / "results"
+            adr_path = root / "adr.md"
+
+            exit_code = main(
+                [
+                    "--benchmark",
+                    str(benchmark_path),
+                    "--expected-results",
+                    str(expected_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--adr-path",
+                    str(adr_path),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertFalse(output_dir.exists())
+            self.assertFalse(adr_path.exists())
 
 
 def _write_inputs(root: Path) -> tuple[Path, Path]:

--- a/tests/unit/test_compare_dense_embeddings.py
+++ b/tests/unit/test_compare_dense_embeddings.py
@@ -21,6 +21,7 @@ from evaluation.compare_dense_embeddings import (
     ensure_fair_comparison,
     load_benchmark,
     main,
+    write_csv,
 )
 
 
@@ -222,6 +223,15 @@ Q_002:
             self.assertEqual(exit_code, 0)
             self.assertFalse(output_dir.exists())
             self.assertFalse(adr_path.exists())
+
+    def test_write_csv_rejects_empty_result_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = Path(tmp) / "empty.csv"
+
+            with self.assertRaisesRegex(ValueError, "without result rows"):
+                write_csv([], output_path)
+
+            self.assertFalse(output_path.exists())
 
 
 def _write_inputs(root: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
Closes #95

## Objetivo
Implementa o benchmark A/B dense entre `nomic_dense_v1` e `qwen3_dense_8b_v1`, com fairness guards, decision gate e relatórios CSV/JSON/Markdown.

## Escopo
- `evaluation/compare_dense_embeddings.py`
- `tests/unit/test_compare_dense_embeddings.py`
- Runbook em `evaluation/README.md`
- ADR proposta em `docs/ADR/0003-qwen3-embedding-baseline.md`
- `.gitignore` protege `evaluation/results/*.md`

## Fora de escopo
- BM25, hybrid search, reranker e Agentic RAG
- Alterar `active_profile`
- Alterar runtime de retrieval ou collections existentes
- Baixar ou executar Qwen3 em testes unitários

## Validação local
- `uv run pytest tests/unit/test_compare_dense_embeddings.py -v` -> 4 passed
- `uv run mypy --strict evaluation/compare_dense_embeddings.py tests/unit/test_compare_dense_embeddings.py` -> 0 errors
- `uv run pyright evaluation/compare_dense_embeddings.py tests/unit/test_compare_dense_embeddings.py` -> 0 errors
- `uv run pytest tests/unit/test_compare_dense_embeddings.py tests/unit/test_eval_metrics.py tests/unit/test_run_dense_baseline.py -v` -> 79 passed
- `uv run pytest tests/unit/ -v` -> 733 passed

## Observação
O benchmark real depende de runners de perfil/collections locais. Este PR entrega o contrato testável e os artefatos gráficos; não finge execução real de Qwen3 sem wiring local.