### PR TITLE
[RAG-1A] PR 05 — SparseVector Dataclass + SparseEmbedder BM25

### DIFF
--- a/backend/rag/sparse_embedder.py
+++ b/backend/rag/sparse_embedder.py
@@ -1,0 +1,181 @@
+"""BM25 sparse embedder adapter.
+
+PR-05 prepares the lexical sparse component only. This module does not import
+Qdrant, does not write collections, and does not implement hybrid retrieval.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from importlib import import_module
+from typing import Any, Protocol, cast
+
+from loguru import logger
+
+from backend.rag.sparse_embedder_protocol import SparseEmbedder
+from backend.rag.sparse_vector import SparseVector
+
+DEFAULT_BM25_MODEL_NAME = "Qdrant/bm25"
+DEFAULT_BM25_BATCH_SIZE = 32
+
+_log = logger.bind(component="sparse_embedder", provider="bm25")
+
+
+class SparseEmbeddingLike(Protocol):
+    """Minimal FastEmbed-like sparse encoder surface used by the adapter."""
+
+    def embed(
+        self,
+        documents: Sequence[str],
+        *,
+        batch_size: int,
+    ) -> Iterable[object]:
+        """Embed documents and yield objects with ``indices`` and ``values``."""
+        ...
+
+
+class BM25SparseEmbedder(SparseEmbedder):
+    """Adapter around ``fastembed.SparseTextEmbedding`` for BM25 vectors."""
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_BM25_MODEL_NAME,
+        *,
+        encoder: SparseEmbeddingLike | None = None,
+    ) -> None:
+        clean_model_name = _clean_sparse_text(model_name, "model_name")
+        self._model_name = clean_model_name
+        self._encoder = (
+            encoder if encoder is not None else self._load_model(clean_model_name)
+        )
+        _log.debug("BM25 sparse embedder initialized", model_name=clean_model_name)
+
+    @staticmethod
+    def _load_model(model_name: str) -> SparseEmbeddingLike:
+        try:
+            fastembed = import_module("fastembed")
+        except ImportError as exc:
+            raise ImportError(
+                "BM25SparseEmbedder requires fastembed. Install optional sparse "
+                "dependencies before running the real BM25 adapter."
+            ) from exc
+        sparse_text_embedding = getattr(fastembed, "SparseTextEmbedding")
+        _log.info("loading BM25 sparse model", model_name=model_name)
+        return cast(
+            SparseEmbeddingLike,
+            sparse_text_embedding(model_name=model_name),
+        )
+
+    @property
+    def model_name(self) -> str:
+        """Return the configured BM25 sparse model name."""
+        return self._model_name
+
+    def embed_sparse(self, text: str) -> SparseVector:
+        """Embed a single text into a BM25 sparse vector."""
+        [vector] = self.embed_sparse_batch([text], batch_size=1)
+        return vector
+
+    def embed_sparse_batch(
+        self,
+        texts: list[str],
+        batch_size: int = DEFAULT_BM25_BATCH_SIZE,
+    ) -> list[SparseVector]:
+        """Embed a batch of texts while preserving input order."""
+        if not texts:
+            return []
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
+        cleaned = [_clean_sparse_text(text, "text") for text in texts]
+        _log.debug(
+            "BM25 sparse batch started",
+            batch_size=batch_size,
+            text_count=len(cleaned),
+        )
+
+        results: list[SparseVector] = []
+        for offset in range(0, len(cleaned), batch_size):
+            chunk = cleaned[offset : offset + batch_size]
+            raw_vectors = self._encoder.embed(chunk, batch_size=batch_size)
+            for raw_vector in raw_vectors:
+                results.append(_coerce_sparse_vector(raw_vector))
+
+        if len(results) != len(cleaned):
+            raise RuntimeError(
+                "BM25SparseEmbedder expected "
+                f"{len(cleaned)} sparse vectors, got {len(results)}"
+            )
+
+        nnz_mean = sum(vector.nnz for vector in results) / float(len(results))
+        _log.debug(
+            "BM25 sparse batch completed",
+            produced=len(results),
+            nnz_mean=nnz_mean,
+        )
+        return results
+
+
+def _clean_sparse_text(value: object, label: str = "text") -> str:
+    """Return stripped text or raise for invalid sparse embedder input."""
+    if not isinstance(value, str):
+        raise TypeError(f"sparse {label} must be str")
+    if "\x00" in value:
+        raise ValueError(f"sparse {label} cannot contain null bytes")
+    clean = value.strip()
+    if not clean:
+        raise ValueError(f"sparse {label} cannot be empty or whitespace-only")
+    return clean
+
+
+def _coerce_sparse_vector(raw_vector: object) -> SparseVector:
+    raw_indices = getattr(raw_vector, "indices", None)
+    raw_values = getattr(raw_vector, "values", None)
+    if raw_indices is None or raw_values is None:
+        raise RuntimeError("sparse encoder returned object without indices/values")
+
+    indices = [int(index) for index in _to_sequence(raw_indices, "indices")]
+    values = [float(value) for value in _to_sequence(raw_values, "values")]
+    sorted_indices, sorted_values = _sort_sparse(indices, values)
+    return SparseVector(indices=sorted_indices, values=sorted_values)
+
+
+def _to_sequence(value: object, label: str) -> Sequence[Any]:
+    materialized = _tolist(value)
+    if not isinstance(materialized, Sequence) or isinstance(
+        materialized,
+        (str, bytes),
+    ):
+        raise RuntimeError(f"sparse encoder returned malformed {label}")
+    return materialized
+
+
+def _tolist(value: object) -> object:
+    method = getattr(value, "tolist", None)
+    if callable(method):
+        return method()
+    return value
+
+
+def _sort_sparse(
+    indices: list[int],
+    values: list[float],
+) -> tuple[list[int], list[float]]:
+    if len(indices) != len(values):
+        raise ValueError(
+            "SparseVector requires len(indices) == len(values), "
+            f"got {len(indices)} vs {len(values)}"
+        )
+    if not indices:
+        return [], []
+    pairs = sorted(zip(indices, values, strict=True), key=lambda pair: pair[0])
+    sorted_indices, sorted_values = zip(*pairs, strict=True)
+    return list(sorted_indices), list(sorted_values)
+
+
+__all__ = [
+    "BM25SparseEmbedder",
+    "DEFAULT_BM25_BATCH_SIZE",
+    "DEFAULT_BM25_MODEL_NAME",
+    "SparseEmbeddingLike",
+]

--- a/backend/rag/sparse_embedder_protocol.py
+++ b/backend/rag/sparse_embedder_protocol.py
@@ -1,0 +1,28 @@
+"""Sparse embedder protocol for lexical retrieval adapters."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from backend.rag.sparse_vector import SparseVector
+
+
+@runtime_checkable
+class SparseEmbedder(Protocol):
+    """Common interface for BM25 and future sparse lexical embedders."""
+
+    @property
+    def model_name(self) -> str:
+        """Return the sparse model name, for example ``Qdrant/bm25``."""
+        ...
+
+    def embed_sparse(self, text: str) -> SparseVector:
+        """Embed one text into a sparse vector."""
+        ...
+
+    def embed_sparse_batch(self, texts: list[str]) -> list[SparseVector]:
+        """Embed texts in order. Empty batches return an empty list."""
+        ...
+
+
+__all__ = ["SparseEmbedder"]

--- a/backend/rag/sparse_embedder_registry.py
+++ b/backend/rag/sparse_embedder_registry.py
@@ -1,0 +1,64 @@
+"""Read-only registry for sparse embedding adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from threading import RLock
+from types import MappingProxyType
+from typing import Protocol
+
+from backend.rag.sparse_embedder import BM25SparseEmbedder
+from backend.rag.sparse_embedder_protocol import SparseEmbedder
+
+
+class SparseEmbedderFactory(Protocol):
+    """Factory that builds a sparse embedder."""
+
+    def __call__(self) -> SparseEmbedder:
+        """Return a sparse embedder instance."""
+        ...
+
+
+_REGISTRY: dict[str, SparseEmbedderFactory] = {}
+_REGISTRY_LOCK = RLock()
+
+
+def get_sparse_registry() -> Mapping[str, SparseEmbedderFactory]:
+    """Return a read-only snapshot of registered sparse factories."""
+    with _REGISTRY_LOCK:
+        return MappingProxyType(dict(_REGISTRY))
+
+
+def register_sparse(provider: str, factory: SparseEmbedderFactory) -> None:
+    """Register a sparse provider factory exactly once."""
+    provider_key = _normalize_provider(provider)
+    with _REGISTRY_LOCK:
+        if provider_key in _REGISTRY:
+            raise ValueError(f"sparse provider {provider_key!r} already registered")
+        _REGISTRY[provider_key] = factory
+
+
+def clear_sparse_registry_for_tests() -> None:
+    """Clear sparse providers for isolated unit tests."""
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+
+
+def _normalize_provider(provider: str) -> str:
+    if "\x00" in provider:
+        raise ValueError("provider cannot contain null bytes")
+    provider_key = provider.strip().casefold()
+    if not provider_key:
+        raise ValueError("provider cannot be empty")
+    return provider_key
+
+
+register_sparse("bm25", lambda: BM25SparseEmbedder())
+
+
+__all__ = [
+    "SparseEmbedderFactory",
+    "clear_sparse_registry_for_tests",
+    "get_sparse_registry",
+    "register_sparse",
+]

--- a/backend/rag/sparse_vector.py
+++ b/backend/rag/sparse_vector.py
@@ -1,0 +1,64 @@
+"""Sparse vector contract for future Qdrant BM25 retrieval.
+
+This module intentionally imports no Qdrant client. It only models the
+metadata shape Qdrant sparse vectors use: ``indices`` plus ``values``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SparseVector:
+    """Sparse embedding vector compatible with the Qdrant sparse contract.
+
+    Args:
+        indices: Non-negative integer indices for non-zero sparse dimensions.
+        values: Sparse weights, aligned one-to-one with ``indices``.
+
+    Raises:
+        ValueError: If lengths differ, indices are negative/duplicated, or
+            values are non-finite.
+    """
+
+    indices: list[int]
+    values: list[float]
+
+    def __post_init__(self) -> None:
+        copied_indices = [int(index) for index in self.indices]
+        copied_values = [float(value) for value in self.values]
+        object.__setattr__(self, "indices", copied_indices)
+        object.__setattr__(self, "values", copied_values)
+
+        if len(copied_indices) != len(copied_values):
+            raise ValueError(
+                "SparseVector requires len(indices) == len(values), "
+                f"got {len(copied_indices)} vs {len(copied_values)}"
+            )
+        if any(index < 0 for index in copied_indices):
+            raise ValueError("SparseVector indices must be non-negative integers")
+        if len(set(copied_indices)) != len(copied_indices):
+            raise ValueError("SparseVector indices must be unique")
+        if any(not math.isfinite(value) for value in copied_values):
+            raise ValueError("SparseVector values must be finite floats")
+
+    @property
+    def nnz(self) -> int:
+        """Return the number of non-zero sparse dimensions."""
+        return len(self.indices)
+
+    def is_empty(self) -> bool:
+        """Return True when the vector has no active sparse dimensions."""
+        return self.nnz == 0
+
+    def to_qdrant_payload(self) -> dict[str, list[int] | list[float]]:
+        """Return a Qdrant-compatible sparse vector payload without Qdrant."""
+        return {
+            "indices": list(self.indices),
+            "values": list(self.values),
+        }
+
+
+__all__ = ["SparseVector"]

--- a/backend/rag/sparse_vector.py
+++ b/backend/rag/sparse_vector.py
@@ -7,6 +7,7 @@ metadata shape Qdrant sparse vectors use: ``indices`` plus ``values``.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 
@@ -23,12 +24,12 @@ class SparseVector:
             values are non-finite.
     """
 
-    indices: list[int]
-    values: list[float]
+    indices: Sequence[int]
+    values: Sequence[float]
 
     def __post_init__(self) -> None:
-        copied_indices = [int(index) for index in self.indices]
-        copied_values = [float(value) for value in self.values]
+        copied_indices = tuple(int(index) for index in self.indices)
+        copied_values = tuple(float(value) for value in self.values)
         object.__setattr__(self, "indices", copied_indices)
         object.__setattr__(self, "values", copied_values)
 

--- a/tests/fakes/fake_bm25_embedder.py
+++ b/tests/fakes/fake_bm25_embedder.py
@@ -1,0 +1,53 @@
+"""Deterministic fake BM25 sparse embedder for unit tests."""
+
+from __future__ import annotations
+
+import hashlib
+
+from backend.rag.sparse_embedder import _clean_sparse_text
+from backend.rag.sparse_embedder_protocol import SparseEmbedder
+from backend.rag.sparse_vector import SparseVector
+
+_FAKE_VOCAB_SIZE = 30_000
+_FAKE_NNZ = 8
+
+
+class FakeBM25Embedder(SparseEmbedder):
+    """Fake sparse embedder: same input text produces the same vector."""
+
+    model_name: str = "fake-bm25"
+
+    def embed_sparse(self, text: str) -> SparseVector:
+        """Embed one text deterministically without external dependencies."""
+        return self._sparse_from_text(_clean_sparse_text(text, "text"))
+
+    def embed_sparse_batch(self, texts: list[str]) -> list[SparseVector]:
+        """Embed texts in order. Empty batches return an empty list."""
+        return [self.embed_sparse(text) for text in texts]
+
+    def _sparse_from_text(self, text: str) -> SparseVector:
+        seed = int(hashlib.sha256(text.encode("utf-8")).hexdigest(), 16)
+        multiplier = 1_664_525
+        increment = 1_013_904_223
+        modulus = 2**32
+        state = seed % modulus
+        seen: set[int] = set()
+        pairs: list[tuple[int, float]] = []
+        rank = 1
+        while len(pairs) < _FAKE_NNZ:
+            state = (multiplier * state + increment) % modulus
+            index = int(state % _FAKE_VOCAB_SIZE)
+            if index in seen:
+                continue
+            seen.add(index)
+            pairs.append((index, round(1.0 / float(rank), 6)))
+            rank += 1
+
+        sorted_pairs = sorted(pairs, key=lambda pair: pair[0])
+        return SparseVector(
+            indices=[index for index, _ in sorted_pairs],
+            values=[value for _, value in sorted_pairs],
+        )
+
+
+__all__ = ["FakeBM25Embedder"]

--- a/tests/smoke/test_bm25_smoke.py
+++ b/tests/smoke/test_bm25_smoke.py
@@ -1,0 +1,38 @@
+"""Optional smoke tests for the real FastEmbed BM25 sparse adapter."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.rag.sparse_embedder import BM25SparseEmbedder
+from backend.rag.sparse_vector import SparseVector
+
+SMOKE_ENABLED = os.getenv("RUN_SPARSE_EMBEDDING_SMOKE") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not SMOKE_ENABLED,
+    reason="set RUN_SPARSE_EMBEDDING_SMOKE=1 to run BM25 sparse smoke tests",
+)
+
+
+def test_bm25_real_adapter_returns_sparse_vector() -> None:
+    embedder = BM25SparseEmbedder()
+
+    vector = embedder.embed_sparse("documento sintetico sobre duration e Selic")
+
+    assert isinstance(vector, SparseVector)
+    assert vector.nnz > 0
+    assert len(vector.indices) == len(vector.values)
+    assert all(index >= 0 for index in vector.indices)
+    assert all(value > 0.0 for value in vector.values)
+
+
+def test_bm25_real_adapter_batch_preserves_length() -> None:
+    embedder = BM25SparseEmbedder()
+
+    vectors = embedder.embed_sparse_batch(["alpha financeiro", "beta macro"])
+
+    assert len(vectors) == 2
+    assert all(vector.nnz > 0 for vector in vectors)

--- a/tests/unit/test_sparse_embedder_contract.py
+++ b/tests/unit/test_sparse_embedder_contract.py
@@ -1,0 +1,174 @@
+"""Unit tests for BM25 sparse embedder contract and registry."""
+
+from __future__ import annotations
+
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend.rag.sparse_embedder import (
+    BM25SparseEmbedder,
+    DEFAULT_BM25_BATCH_SIZE,
+    _clean_sparse_text,
+)
+from backend.rag.sparse_embedder_protocol import SparseEmbedder
+from backend.rag.sparse_embedder_registry import (
+    clear_sparse_registry_for_tests,
+    get_sparse_registry,
+    register_sparse,
+)
+
+
+class RecordingSparseEncoder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], int]] = []
+
+    def embed(
+        self,
+        documents: Sequence[str],
+        *,
+        batch_size: int,
+    ) -> list[SimpleNamespace]:
+        self.calls.append((list(documents), batch_size))
+        return [
+            SimpleNamespace(indices=[5, 1, 3], values=[0.5, 1.0, 0.75])
+            for _ in documents
+        ]
+
+
+class ShortSparseEncoder:
+    def embed(
+        self,
+        documents: Sequence[str],
+        *,
+        batch_size: int,
+    ) -> list[SimpleNamespace]:
+        return [SimpleNamespace(indices=[1], values=[1.0]) for _ in documents[:-1]]
+
+
+class MalformedSparseEncoder:
+    def embed(
+        self,
+        documents: Sequence[str],
+        *,
+        batch_size: int,
+    ) -> list[SimpleNamespace]:
+        return [SimpleNamespace(indices=[1, 2], values=[1.0]) for _ in documents]
+
+
+class BM25SparseEmbedderContractTests(unittest.TestCase):
+    def test_adapter_is_sparse_embedder_and_uses_default_model_name(self) -> None:
+        embedder = BM25SparseEmbedder(encoder=RecordingSparseEncoder())
+
+        self.assertIsInstance(embedder, SparseEmbedder)
+        self.assertEqual(embedder.model_name, "Qdrant/bm25")
+
+    def test_clean_sparse_text_rejects_invalid_inputs(self) -> None:
+        with self.assertRaises(TypeError):
+            _clean_sparse_text(None)
+        with self.assertRaisesRegex(ValueError, "empty"):
+            _clean_sparse_text(" \t\n")
+        with self.assertRaisesRegex(ValueError, "null bytes"):
+            _clean_sparse_text("abc\x00def")
+
+    def test_embed_sparse_sorts_indices_and_preserves_values(self) -> None:
+        encoder = RecordingSparseEncoder()
+        embedder = BM25SparseEmbedder(encoder=encoder)
+
+        vector = embedder.embed_sparse("texto valido")
+
+        self.assertEqual(vector.indices, [1, 3, 5])
+        self.assertEqual(vector.values, [1.0, 0.75, 0.5])
+        self.assertEqual(encoder.calls, [(["texto valido"], 1)])
+
+    def test_batch_empty_returns_empty_without_encoder_call(self) -> None:
+        encoder = RecordingSparseEncoder()
+        embedder = BM25SparseEmbedder(encoder=encoder)
+
+        self.assertEqual(embedder.embed_sparse_batch([]), [])
+        self.assertEqual(encoder.calls, [])
+
+    def test_batch_multiple_preserves_order_and_uses_batches(self) -> None:
+        encoder = RecordingSparseEncoder()
+        embedder = BM25SparseEmbedder(encoder=encoder)
+
+        vectors = embedder.embed_sparse_batch(["a", "b", "c"], batch_size=2)
+
+        self.assertEqual(len(vectors), 3)
+        self.assertEqual(encoder.calls, [(["a", "b"], 2), (["c"], 2)])
+
+    def test_batch_rejects_invalid_batch_size(self) -> None:
+        embedder = BM25SparseEmbedder(encoder=RecordingSparseEncoder())
+
+        with self.assertRaisesRegex(ValueError, "batch_size"):
+            embedder.embed_sparse_batch(["a"], batch_size=0)
+
+    def test_result_count_mismatch_raises_runtime_error(self) -> None:
+        embedder = BM25SparseEmbedder(encoder=ShortSparseEncoder())
+
+        with self.assertRaisesRegex(RuntimeError, "expected 2 sparse vectors"):
+            embedder.embed_sparse_batch(["a", "b"])
+
+    def test_malformed_encoder_output_raises_value_error(self) -> None:
+        embedder = BM25SparseEmbedder(encoder=MalformedSparseEncoder())
+
+        with self.assertRaisesRegex(ValueError, "len\\(indices\\)"):
+            embedder.embed_sparse("a")
+
+    def test_missing_fastembed_dependency_has_clear_error(self) -> None:
+        with patch(
+            "backend.rag.sparse_embedder.import_module",
+            side_effect=ImportError("missing"),
+        ):
+            with self.assertRaisesRegex(ImportError, "fastembed"):
+                BM25SparseEmbedder()
+
+    def test_module_has_no_top_level_fastembed_or_print(self) -> None:
+        source = Path("backend/rag/sparse_embedder.py").read_text(encoding="utf-8")
+
+        self.assertNotIn("from fastembed import", source)
+        self.assertNotIn("import fastembed", source)
+        self.assertNotIn("print(", source)
+
+    def test_default_batch_size_is_exposed(self) -> None:
+        self.assertEqual(DEFAULT_BM25_BATCH_SIZE, 32)
+
+
+class SparseEmbedderRegistryTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        clear_sparse_registry_for_tests()
+        register_sparse("bm25", lambda: BM25SparseEmbedder())
+
+    def test_default_bm25_provider_is_registered(self) -> None:
+        registry = get_sparse_registry()
+
+        self.assertIn("bm25", registry)
+
+    def test_registry_returns_read_only_snapshot(self) -> None:
+        before = get_sparse_registry()
+        register_sparse("test_provider_snapshot", lambda: BM25SparseEmbedder())
+        after = get_sparse_registry()
+
+        self.assertNotIn("test_provider_snapshot", before)
+        self.assertIn("test_provider_snapshot", after)
+        with self.assertRaises(TypeError):
+            before["x"] = lambda: BM25SparseEmbedder()  # type: ignore[index]
+
+    def test_register_rejects_duplicate_provider(self) -> None:
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            register_sparse("bm25", lambda: BM25SparseEmbedder())
+
+    def test_register_normalizes_and_rejects_invalid_provider(self) -> None:
+        register_sparse("  RC05_PROVIDER  ", lambda: BM25SparseEmbedder())
+
+        self.assertIn("rc05_provider", get_sparse_registry())
+        with self.assertRaisesRegex(ValueError, "empty"):
+            register_sparse("   ", lambda: BM25SparseEmbedder())
+        with self.assertRaisesRegex(ValueError, "null bytes"):
+            register_sparse("bad\x00provider", lambda: BM25SparseEmbedder())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sparse_embedder_contract.py
+++ b/tests/unit/test_sparse_embedder_contract.py
@@ -79,8 +79,8 @@ class BM25SparseEmbedderContractTests(unittest.TestCase):
 
         vector = embedder.embed_sparse("texto valido")
 
-        self.assertEqual(vector.indices, [1, 3, 5])
-        self.assertEqual(vector.values, [1.0, 0.75, 0.5])
+        self.assertEqual(vector.indices, (1, 3, 5))
+        self.assertEqual(vector.values, (1.0, 0.75, 0.5))
         self.assertEqual(encoder.calls, [(["texto valido"], 1)])
 
     def test_batch_empty_returns_empty_without_encoder_call(self) -> None:

--- a/tests/unit/test_sparse_embedder_fake.py
+++ b/tests/unit/test_sparse_embedder_fake.py
@@ -1,0 +1,42 @@
+"""Unit tests for the deterministic fake BM25 sparse embedder."""
+
+from __future__ import annotations
+
+import unittest
+
+from backend.rag.sparse_embedder_protocol import SparseEmbedder
+from tests.fakes.fake_bm25_embedder import FakeBM25Embedder
+
+
+class FakeBM25EmbedderTests(unittest.TestCase):
+    def test_fake_embedder_is_sparse_embedder(self) -> None:
+        self.assertIsInstance(FakeBM25Embedder(), SparseEmbedder)
+
+    def test_same_text_produces_same_sparse_vector(self) -> None:
+        embedder = FakeBM25Embedder()
+
+        first = embedder.embed_sparse("duration sintetica")
+        second = embedder.embed_sparse("duration sintetica")
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.nnz, 8)
+
+    def test_batch_empty_returns_empty_list(self) -> None:
+        self.assertEqual(FakeBM25Embedder().embed_sparse_batch([]), [])
+
+    def test_batch_multiple_preserves_order(self) -> None:
+        embedder = FakeBM25Embedder()
+        texts = ["alpha", "beta", "gamma"]
+
+        vectors = embedder.embed_sparse_batch(texts)
+
+        self.assertEqual(vectors, [embedder.embed_sparse(text) for text in texts])
+        self.assertNotEqual(vectors[0], vectors[1])
+
+    def test_empty_text_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "empty"):
+            FakeBM25Embedder().embed_sparse("  ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_sparse_vector.py
+++ b/tests/unit/test_sparse_vector.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import math
 import unittest
+from dataclasses import FrozenInstanceError
+from typing import cast
 
 from backend.rag.sparse_vector import SparseVector
 
@@ -49,8 +51,58 @@ class SparseVectorTests(unittest.TestCase):
         indices.append(2)
         values.append(2.0)
 
-        self.assertEqual(vector.indices, [1])
-        self.assertEqual(vector.values, [1.0])
+        self.assertEqual(vector.indices, (1,))
+        self.assertEqual(vector.values, (1.0,))
+
+    def test_sparse_vector_payload_returns_defensive_lists(self) -> None:
+        vector = SparseVector(indices=[1], values=[1.0])
+        payload = vector.to_qdrant_payload()
+
+        cast(list[int], payload["indices"]).append(2)
+        cast(list[float], payload["values"]).append(2.0)
+
+        self.assertEqual(vector.indices, (1,))
+        self.assertEqual(vector.values, (1.0,))
+
+
+class SparseVectorFrozenTests(unittest.TestCase):
+    def test_sparse_vector_is_frozen(self) -> None:
+        vector = SparseVector(indices=[1], values=[1.0])
+
+        with self.assertRaises(FrozenInstanceError):
+            vector.indices = [2]  # type: ignore[misc]
+
+    def test_sparse_vector_equality_matches_same_payload(self) -> None:
+        first = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+        second = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+
+        self.assertEqual(first, second)
+
+    def test_sparse_vector_inequality_detects_different_indices(self) -> None:
+        first = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+        second = SparseVector(indices=[1, 3], values=[1.0, 2.0])
+
+        self.assertNotEqual(first, second)
+
+    def test_sparse_vector_inequality_detects_different_values(self) -> None:
+        first = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+        second = SparseVector(indices=[1, 2], values=[1.0, 3.0])
+
+        self.assertNotEqual(first, second)
+
+    def test_sparse_vector_is_hashable(self) -> None:
+        vector = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+
+        self.assertEqual({vector}, {SparseVector(indices=[1, 2], values=[1.0, 2.0])})
+
+    def test_sparse_vector_can_be_used_as_dict_key(self) -> None:
+        vector = SparseVector(indices=[1, 2], values=[1.0, 2.0])
+        lookup = {vector: "ok"}
+
+        self.assertEqual(
+            lookup[SparseVector(indices=[1, 2], values=[1.0, 2.0])],
+            "ok",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_sparse_vector.py
+++ b/tests/unit/test_sparse_vector.py
@@ -1,0 +1,57 @@
+"""Unit tests for the sparse vector contract."""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from backend.rag.sparse_vector import SparseVector
+
+
+class SparseVectorTests(unittest.TestCase):
+    def test_sparse_vector_accepts_valid_indices_and_values(self) -> None:
+        vector = SparseVector(indices=[3, 7], values=[1.5, 2.5])
+
+        self.assertEqual(vector.nnz, 2)
+        self.assertFalse(vector.is_empty())
+        self.assertEqual(
+            vector.to_qdrant_payload(),
+            {"indices": [3, 7], "values": [1.5, 2.5]},
+        )
+
+    def test_sparse_vector_allows_empty_vector(self) -> None:
+        vector = SparseVector(indices=[], values=[])
+
+        self.assertEqual(vector.nnz, 0)
+        self.assertTrue(vector.is_empty())
+
+    def test_sparse_vector_rejects_mismatched_lengths(self) -> None:
+        with self.assertRaisesRegex(ValueError, "len\\(indices\\) == len\\(values\\)"):
+            SparseVector(indices=[1], values=[1.0, 2.0])
+
+    def test_sparse_vector_rejects_negative_indices(self) -> None:
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            SparseVector(indices=[1, -2], values=[1.0, 2.0])
+
+    def test_sparse_vector_rejects_duplicate_indices(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unique"):
+            SparseVector(indices=[1, 1], values=[1.0, 2.0])
+
+    def test_sparse_vector_rejects_non_finite_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "finite"):
+            SparseVector(indices=[1], values=[math.inf])
+
+    def test_sparse_vector_copies_input_lists(self) -> None:
+        indices = [1]
+        values = [1.0]
+
+        vector = SparseVector(indices=indices, values=values)
+        indices.append(2)
+        values.append(2.0)
+
+        self.assertEqual(vector.indices, [1])
+        self.assertEqual(vector.values, [1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #97

## Objetivo
Criar o componente sparse lexical BM25 isolado para RAG-1A, pronto para ser conectado a Qdrant e Hybrid/Agentic RAG em PRs futuros, sem conversar com Qdrant agora.

## Escopo implementado
- `backend/rag/sparse_vector.py`: contrato `SparseVector` com `indices` + `values`, validação de comprimento, índices não negativos/únicos, valores finitos, `nnz`, `is_empty()` e payload compatível.
- `backend/rag/sparse_embedder_protocol.py`: `SparseEmbedder` Protocol runtime-checkable.
- `backend/rag/sparse_embedder.py`: `BM25SparseEmbedder` com import lazy de FastEmbed, encoder injetável, limpeza de texto, batch vazio explícito, ordenação de índices e validação de contagem de resultados.
- `backend/rag/sparse_embedder_registry.py`: registry sparse separado e read-only, com provider BM25 padrão.
- `tests/fakes/fake_bm25_embedder.py`: fake determinístico sem dependências pesadas.
- Unit tests para vetor, fake, adapter/registry; smoke FastEmbed real opt-in via `RUN_SPARSE_EMBEDDING_SMOKE=1`.

## Fora de escopo mantido
- Sem Qdrant client, upsert, schema ou collections.
- Sem hybrid retrieval, RRF, DBSF, ColBERT ou reranker.
- Sem alterações em Qwen3 ou retriever dense atual.
- Sem Agentic loops/runtime.

## Validação local
- `uv run pytest tests/unit/test_sparse_vector.py tests/unit/test_sparse_embedder_fake.py tests/unit/test_sparse_embedder_contract.py -v` -> 27 passed
- `uv run pytest tests/unit/test_sparse_vector.py tests/unit/test_sparse_embedder_fake.py tests/unit/test_sparse_embedder_contract.py tests/smoke/test_bm25_smoke.py -v` -> 27 passed, 2 skipped
- `uv run mypy --strict backend/rag/sparse_vector.py backend/rag/sparse_embedder_protocol.py backend/rag/sparse_embedder.py backend/rag/sparse_embedder_registry.py tests/fakes/fake_bm25_embedder.py tests/unit/test_sparse_vector.py tests/unit/test_sparse_embedder_fake.py tests/unit/test_sparse_embedder_contract.py tests/smoke/test_bm25_smoke.py` -> 0 errors
- `uv run pyright backend/rag/sparse_vector.py backend/rag/sparse_embedder_protocol.py backend/rag/sparse_embedder.py backend/rag/sparse_embedder_registry.py tests/fakes/fake_bm25_embedder.py tests/unit/test_sparse_vector.py tests/unit/test_sparse_embedder_fake.py tests/unit/test_sparse_embedder_contract.py tests/smoke/test_bm25_smoke.py` -> 0 errors
- `uv run pytest tests/unit/ -v` -> 763 passed, 253 subtests passed
- `git diff --check` -> clean

## Observação
`RUN_SPARSE_EMBEDDING_SMOKE=1` exige FastEmbed instalado localmente; por padrão o smoke é skipado para CI/unit tests não baixarem modelo.
