### PR TITLE
[RAG-1A] PR 06 — Qdrant Hybrid Collection Schema

### DIFF
--- a/backend/rag/qdrant_store.py
+++ b/backend/rag/qdrant_store.py
@@ -51,6 +51,7 @@ SCHEMA_VERSION: str = "qdrant-hybrid-v2"
 # Do NOT use modifier=models.Modifier.IDF here. That would apply server-side
 # IDF a second time, silently degrading recall without raising an exception.
 SPARSE_VECTOR_PARAMS: models.SparseVectorParams = models.SparseVectorParams()
+# modifier=None is mandatory for FastEmbed BM25 sparse vectors.
 
 
 class HybridPointPayload(TypedDict):
@@ -520,6 +521,7 @@ def build_hybrid_point(
 
     resolved_config = config or HybridCollectionConfig()
     clean_payload = validate_hybrid_payload(payload, resolved_config)
+    _validate_dense_vector_dimension(dense_vector, resolved_config)
     dense = _validate_vector(dense_vector, resolved_config.dense_dimensions)
     sparse = models.SparseVector(
         indices=list(sparse_vector.indices),
@@ -602,6 +604,18 @@ def _validate_vector(vector: Sequence[float], vector_size: int) -> list[float]:
             raise ValueError("vector values must be finite")
         values.append(float(value))
     return values
+
+
+def _validate_dense_vector_dimension(
+    dense_vector: Sequence[float],
+    config: HybridCollectionConfig,
+) -> None:
+    actual_dimensions = len(dense_vector)
+    if actual_dimensions != config.dense_dimensions:
+        raise ValueError(
+            f"dense_vector has {actual_dimensions}d, "
+            f"spec expects {config.dense_dimensions}d"
+        )
 
 
 def _validate_non_empty(value: str, field_name: str) -> str:

--- a/backend/rag/qdrant_store.py
+++ b/backend/rag/qdrant_store.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Protocol, TypedDict, cast
 from uuid import uuid5, NAMESPACE_URL
 
-from qdrant_client import QdrantClient
+from qdrant_client import AsyncQdrantClient, QdrantClient
 from qdrant_client.http import models
+
+from backend.rag.sparse_vector import SparseVector
 
 
 DEFAULT_QDRANT_HOST = "localhost"
@@ -25,6 +31,83 @@ RESERVED_PAYLOAD_KEYS = {
     "ingested_at",
     "security_level",
 }
+
+DENSE_VECTOR_NAME: str = "dense"
+SPARSE_VECTOR_NAME: str = "sparse"
+LEGACY_COLLECTION_NAME: str = "quimera_knowledge"
+HYBRID_COLLECTION_NAME: str = "quimera_knowledge_v2"
+
+# Qwen3 0.6B is the efficient local default for the v2 hybrid collection.
+# Do not change these values without bumping SCHEMA_VERSION and revalidating
+# collection compatibility.
+QWEN3_EMBEDDING_MODEL: str = "Qwen/Qwen3-Embedding-0.6B"
+QWEN3_EMBEDDING_PROVIDER: str = "local"
+QWEN3_EMBEDDING_DIMENSIONS: int = 1024
+QWEN3_EMBEDDING_VERSION: str = "qwen3-embedding-0.6b@pinned"
+SCHEMA_VERSION: str = "qdrant-hybrid-v2"
+
+# ⚠️ ATENÇÃO — DOUBLE-IDF TRAP
+# fastembed BM25 already applies TF-IDF weights internally.
+# Do NOT use modifier=models.Modifier.IDF here. That would apply server-side
+# IDF a second time, silently degrading recall without raising an exception.
+SPARSE_VECTOR_PARAMS: models.SparseVectorParams = models.SparseVectorParams()
+
+
+class HybridPointPayload(TypedDict):
+    """Required payload metadata for points in the v2 hybrid collection."""
+
+    doc_id: str
+    chunk_index: int
+    security_level: str
+    embedding_model: str
+    embedding_provider: str
+    embedding_dimensions: int
+    embedding_version: str
+    schema_version: str
+
+
+class HybridQdrantClient(Protocol):
+    """Synchronous Qdrant client surface used by the hybrid schema helpers."""
+
+    def collection_exists(self, collection_name: str) -> bool: ...
+
+    def create_collection(
+        self,
+        *,
+        collection_name: str,
+        vectors_config: Mapping[str, models.VectorParams],
+        sparse_vectors_config: Mapping[str, models.SparseVectorParams],
+    ) -> object: ...
+
+    def upsert(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[models.PointStruct],
+        wait: bool,
+    ) -> object: ...
+
+
+class AsyncHybridQdrantClient(Protocol):
+    """Async Qdrant client surface used by AsyncQdrantHybridStore."""
+
+    async def collection_exists(self, collection_name: str) -> bool: ...
+
+    async def create_collection(
+        self,
+        *,
+        collection_name: str,
+        vectors_config: Mapping[str, models.VectorParams],
+        sparse_vectors_config: Mapping[str, models.SparseVectorParams],
+    ) -> object: ...
+
+    async def upsert(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[models.PointStruct],
+        wait: bool,
+    ) -> object: ...
 
 
 @dataclass(frozen=True)
@@ -62,6 +145,75 @@ class RetrievedPoint:
             "security_level": self.security_level,
             "payload": self.payload,
         }
+
+
+@dataclass(frozen=True)
+class HybridCollectionConfig:
+    """Qdrant v2 hybrid collection contract.
+
+    The collection uses named vectors: ``dense`` for Qwen3 dense embeddings and
+    ``sparse`` for BM25/FastEmbed sparse vectors. Future named-vector queries
+    with Qdrant's ``using=`` parameter require Qdrant server >= 1.10.
+    """
+
+    collection_name: str = HYBRID_COLLECTION_NAME
+    dense_dimensions: int = QWEN3_EMBEDDING_DIMENSIONS
+    dense_distance: models.Distance = models.Distance.COSINE
+    dense_vector_name: str = DENSE_VECTOR_NAME
+    sparse_vector_name: str = SPARSE_VECTOR_NAME
+    embedding_model: str = QWEN3_EMBEDDING_MODEL
+    embedding_provider: str = QWEN3_EMBEDDING_PROVIDER
+    embedding_dimensions: int = QWEN3_EMBEDDING_DIMENSIONS
+    embedding_version: str = QWEN3_EMBEDDING_VERSION
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if "\x00" in self.collection_name:
+            raise ValueError("collection_name cannot contain null bytes")
+        if not self.collection_name.strip():
+            raise ValueError("collection_name cannot be empty")
+        if self.collection_name == LEGACY_COLLECTION_NAME:
+            raise ValueError("legacy collection cannot be used for hybrid schema")
+        if self.dense_dimensions <= 0:
+            raise ValueError("dense_dimensions must be positive integer")
+        if self.embedding_dimensions != self.dense_dimensions:
+            raise ValueError("embedding_dimensions must match dense_dimensions")
+        if self.dense_vector_name == self.sparse_vector_name:
+            raise ValueError("dense_vector_name and sparse_vector_name must differ")
+
+    def to_qdrant_vectors_config(self) -> dict[str, object]:
+        """Return kwargs ready for ``QdrantClient.create_collection``.
+
+        ⚠️ SPARSE: ``modifier=None`` is intentional. FastEmbed BM25 already
+        applies TF-IDF. Adding ``Modifier.IDF`` would cause silent double-IDF.
+        """
+
+        return {
+            "vectors_config": {
+                self.dense_vector_name: models.VectorParams(
+                    size=self.dense_dimensions,
+                    distance=self.dense_distance,
+                )
+            },
+            "sparse_vectors_config": {
+                self.sparse_vector_name: SPARSE_VECTOR_PARAMS,
+            },
+        }
+
+    def schema_fingerprint(self) -> str:
+        """Return a stable SHA-256[:16] fingerprint for the schema contract."""
+
+        payload = {
+            "collection_name": self.collection_name,
+            "dense_dimensions": self.dense_dimensions,
+            "dense_distance": self.dense_distance.value,
+            "dense_vector_name": self.dense_vector_name,
+            "embedding_model": self.embedding_model,
+            "schema_version": self.schema_version,
+            "sparse_vector_name": self.sparse_vector_name,
+        }
+        canonical = json.dumps(payload, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()[:16]
 
 
 @dataclass
@@ -196,6 +348,219 @@ class QdrantVectorStore:
         return self.client
 
 
+@dataclass
+class AsyncQdrantHybridStore:
+    """Async store for the Qdrant v2 hybrid schema.
+
+    This store only ensures schema and upserts named dense/sparse vectors. It
+    does not implement HybridRetriever, fusion, query planning or Agentic RAG.
+    Future calls that query named vectors with ``using=`` require Qdrant server
+    >= 1.10.
+    """
+
+    config: HybridCollectionConfig = field(default_factory=HybridCollectionConfig)
+    host: str = DEFAULT_QDRANT_HOST
+    port: int = DEFAULT_QDRANT_PORT
+    client: AsyncHybridQdrantClient | None = None
+    _ensure_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+    _owns_client: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        if self.port <= 0:
+            raise ValueError("port must be greater than zero")
+        if self.client is None:
+            self.client = cast(
+                AsyncHybridQdrantClient,
+                AsyncQdrantClient(host=self.host, port=self.port),
+            )
+            self._owns_client = True
+
+    async def close(self) -> None:
+        """Close the owned async Qdrant client."""
+
+        if self._owns_client and self.client is not None:
+            await cast(AsyncQdrantClient, self.client).close()
+
+    async def ensure_hybrid_collection(self) -> None:
+        """Idempotently create the v2 collection, serialized by a process lock."""
+
+        async with self._ensure_lock:
+            client = self._client()
+            if await client.collection_exists(self.config.collection_name):
+                return
+            config_kwargs = self.config.to_qdrant_vectors_config()
+            await client.create_collection(
+                collection_name=self.config.collection_name,
+                vectors_config=cast(
+                    Mapping[str, models.VectorParams],
+                    config_kwargs["vectors_config"],
+                ),
+                sparse_vectors_config=cast(
+                    Mapping[str, models.SparseVectorParams],
+                    config_kwargs["sparse_vectors_config"],
+                ),
+            )
+
+    async def upsert_hybrid_point(
+        self,
+        *,
+        point_id: int | str,
+        dense_vector: Sequence[float],
+        sparse_vector: SparseVector,
+        payload: Mapping[str, object],
+    ) -> None:
+        """Upsert one point with named dense and sparse vectors."""
+
+        point = build_hybrid_point(
+            point_id=point_id,
+            dense_vector=dense_vector,
+            sparse_vector=sparse_vector,
+            payload=payload,
+            config=self.config,
+        )
+        await self._client().upsert(
+            collection_name=self.config.collection_name,
+            points=[point],
+            wait=True,
+        )
+
+    def _client(self) -> AsyncHybridQdrantClient:
+        if self.client is None:
+            raise RuntimeError("Qdrant client is not initialized")
+        return self.client
+
+
+def create_hybrid_collection(
+    client: HybridQdrantClient,
+    config: HybridCollectionConfig | None = None,
+) -> None:
+    """Create the v2 hybrid collection schema without touching legacy storage."""
+
+    resolved_config = config or HybridCollectionConfig()
+    config_kwargs = resolved_config.to_qdrant_vectors_config()
+    client.create_collection(
+        collection_name=resolved_config.collection_name,
+        vectors_config=cast(
+            Mapping[str, models.VectorParams],
+            config_kwargs["vectors_config"],
+        ),
+        sparse_vectors_config=cast(
+            Mapping[str, models.SparseVectorParams],
+            config_kwargs["sparse_vectors_config"],
+        ),
+    )
+
+
+def ensure_hybrid_collection(
+    client: HybridQdrantClient,
+    config: HybridCollectionConfig | None = None,
+) -> None:
+    """Create the v2 hybrid collection if missing; validate by name only here."""
+
+    resolved_config = config or HybridCollectionConfig()
+    if client.collection_exists(resolved_config.collection_name):
+        return
+    create_hybrid_collection(client, resolved_config)
+
+
+def validate_hybrid_payload(
+    payload: Mapping[str, object],
+    config: HybridCollectionConfig | None = None,
+) -> HybridPointPayload:
+    """Validate mandatory embedding metadata for ``quimera_knowledge_v2``."""
+
+    resolved_config = config or HybridCollectionConfig()
+    doc_id = _validate_payload_text(payload, "doc_id")
+    security_level = _validate_payload_text(payload, "security_level")
+    embedding_model = _validate_payload_text(payload, "embedding_model")
+    embedding_provider = _validate_payload_text(payload, "embedding_provider")
+    embedding_version = _validate_payload_text(payload, "embedding_version")
+    schema_version = _validate_payload_text(payload, "schema_version")
+    chunk_index = _validate_payload_int(payload, "chunk_index")
+    embedding_dimensions = _validate_payload_int(payload, "embedding_dimensions")
+
+    if chunk_index < 0:
+        raise ValueError("chunk_index cannot be negative")
+    if embedding_model != resolved_config.embedding_model:
+        raise ValueError(
+            "hybrid payload embedding_model does not match Qwen3 v2 contract"
+        )
+    if embedding_provider != resolved_config.embedding_provider:
+        raise ValueError("hybrid payload embedding_provider does not match v2 contract")
+    if embedding_dimensions != resolved_config.embedding_dimensions:
+        raise ValueError(
+            "hybrid payload embedding_dimensions does not match Qwen3 v2 contract"
+        )
+    if embedding_version != resolved_config.embedding_version:
+        raise ValueError("hybrid payload embedding_version does not match v2 contract")
+    if schema_version != resolved_config.schema_version:
+        raise ValueError("hybrid payload schema_version does not match v2 contract")
+
+    return {
+        "doc_id": doc_id,
+        "chunk_index": chunk_index,
+        "security_level": security_level,
+        "embedding_model": embedding_model,
+        "embedding_provider": embedding_provider,
+        "embedding_dimensions": embedding_dimensions,
+        "embedding_version": embedding_version,
+        "schema_version": schema_version,
+    }
+
+
+def build_hybrid_point(
+    *,
+    point_id: int | str,
+    dense_vector: Sequence[float],
+    sparse_vector: SparseVector,
+    payload: Mapping[str, object],
+    config: HybridCollectionConfig | None = None,
+) -> models.PointStruct:
+    """Build a Qdrant point with named dense and sparse vectors."""
+
+    resolved_config = config or HybridCollectionConfig()
+    clean_payload = validate_hybrid_payload(payload, resolved_config)
+    dense = _validate_vector(dense_vector, resolved_config.dense_dimensions)
+    sparse = models.SparseVector(
+        indices=list(sparse_vector.indices),
+        values=list(sparse_vector.values),
+    )
+    return models.PointStruct(
+        id=point_id,
+        vector={
+            resolved_config.dense_vector_name: dense,
+            resolved_config.sparse_vector_name: sparse,
+        },
+        payload=dict(clean_payload),
+    )
+
+
+def upsert_hybrid_point(
+    client: HybridQdrantClient,
+    *,
+    point_id: int | str,
+    dense_vector: Sequence[float],
+    sparse_vector: SparseVector,
+    payload: Mapping[str, object],
+    config: HybridCollectionConfig | None = None,
+) -> None:
+    """Upsert one point into the v2 collection with named dense/sparse vectors."""
+
+    resolved_config = config or HybridCollectionConfig()
+    point = build_hybrid_point(
+        point_id=point_id,
+        dense_vector=dense_vector,
+        sparse_vector=sparse_vector,
+        payload=payload,
+        config=resolved_config,
+    )
+    client.upsert(
+        collection_name=resolved_config.collection_name,
+        points=[point],
+        wait=True,
+    )
+
+
 def _payload_for_chunk(chunk: VectorStoreChunk) -> dict[str, Any]:
     doc_id = _validate_non_empty(chunk.doc_id, "doc_id")
     text = _validate_non_empty(chunk.text, "text")
@@ -233,6 +598,8 @@ def _validate_vector(vector: Sequence[float], vector_size: int) -> list[float]:
     for value in vector:
         if not isinstance(value, (int, float)):
             raise TypeError("vector values must be numeric")
+        if not math.isfinite(float(value)):
+            raise ValueError("vector values must be finite")
         values.append(float(value))
     return values
 
@@ -241,7 +608,23 @@ def _validate_non_empty(value: str, field_name: str) -> str:
     clean_value = value.strip()
     if not clean_value:
         raise ValueError(f"{field_name} cannot be empty")
+    if "\x00" in clean_value:
+        raise ValueError(f"{field_name} cannot contain null bytes")
     return clean_value
+
+
+def _validate_payload_text(payload: Mapping[str, object], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} is required and must be a string")
+    return _validate_non_empty(value, field_name)
+
+
+def _validate_payload_int(payload: Mapping[str, object], field_name: str) -> int:
+    value = payload.get(field_name)
+    if not isinstance(value, int):
+        raise ValueError(f"{field_name} is required and must be an integer")
+    return value
 
 
 def _filter_from_mapping(filters: Mapping[str, Any]) -> models.Filter | None:
@@ -270,3 +653,29 @@ def _point_to_result(point: models.ScoredPoint) -> RetrievedPoint:
         security_level=str(payload.get("security_level", "")),
         payload=payload,
     )
+
+
+__all__ = [
+    "DENSE_VECTOR_NAME",
+    "SPARSE_VECTOR_NAME",
+    "LEGACY_COLLECTION_NAME",
+    "HYBRID_COLLECTION_NAME",
+    "QWEN3_EMBEDDING_MODEL",
+    "QWEN3_EMBEDDING_PROVIDER",
+    "QWEN3_EMBEDDING_DIMENSIONS",
+    "QWEN3_EMBEDDING_VERSION",
+    "SCHEMA_VERSION",
+    "SPARSE_VECTOR_PARAMS",
+    "DEFAULT_COLLECTION_NAME",
+    "VectorStoreChunk",
+    "RetrievedPoint",
+    "QdrantVectorStore",
+    "HybridCollectionConfig",
+    "HybridPointPayload",
+    "validate_hybrid_payload",
+    "build_hybrid_point",
+    "ensure_hybrid_collection",
+    "create_hybrid_collection",
+    "upsert_hybrid_point",
+    "AsyncQdrantHybridStore",
+]

--- a/tests/unit/test_qdrant_store_hybrid.py
+++ b/tests/unit/test_qdrant_store_hybrid.py
@@ -261,7 +261,7 @@ class HybridPointTests(unittest.TestCase):
         self.assertEqual(payload["embedding_model"], QWEN3_EMBEDDING_MODEL)
 
     def test_build_hybrid_point_rejects_wrong_dense_dimension(self) -> None:
-        with self.assertRaisesRegex(ValueError, "expected vector size"):
+        with self.assertRaisesRegex(ValueError, "dense_vector has 1d, spec expects 1024d"):
             build_hybrid_point(
                 point_id="point-1",
                 dense_vector=[0.1],
@@ -283,6 +283,25 @@ class HybridPointTests(unittest.TestCase):
         self.assertEqual(len(client.upserts), 1)
         self.assertEqual(client.upserts[0]["collection_name"], HYBRID_COLLECTION_NAME)
         self.assertTrue(client.upserts[0]["wait"])
+
+    def test_upsert_hybrid_point_rejects_wrong_dense_dimension_before_client_call(
+        self,
+    ) -> None:
+        client = FakeSyncQdrantClient()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "dense_vector has 768d, spec expects 1024d",
+        ):
+            upsert_hybrid_point(
+                client,
+                point_id=1,
+                dense_vector=[0.0] * 768,
+                sparse_vector=SparseVector(indices=[1], values=[1.0]),
+                payload=_valid_payload(),
+            )
+
+        self.assertEqual(client.upserts, [])
 
 
 class AsyncQdrantHybridStoreTests(unittest.IsolatedAsyncioTestCase):
@@ -308,6 +327,25 @@ class AsyncQdrantHybridStoreTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(client.upserts), 1)
         self.assertEqual(client.upserts[0]["collection_name"], HYBRID_COLLECTION_NAME)
+
+    async def test_async_upsert_rejects_wrong_dense_dimension_before_client_call(
+        self,
+    ) -> None:
+        client = FakeAsyncQdrantClient()
+        store = AsyncQdrantHybridStore(client=client)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "dense_vector has 768d, spec expects 1024d",
+        ):
+            await store.upsert_hybrid_point(
+                point_id="point-1",
+                dense_vector=[0.0] * 768,
+                sparse_vector=SparseVector(indices=[1], values=[1.0]),
+                payload=_valid_payload(),
+            )
+
+        self.assertEqual(client.upserts, [])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_qdrant_store_hybrid.py
+++ b/tests/unit/test_qdrant_store_hybrid.py
@@ -1,0 +1,314 @@
+"""Unit tests for the Qdrant hybrid v2 collection contract."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+from qdrant_client.http import models
+
+from backend.rag.qdrant_store import (
+    DENSE_VECTOR_NAME,
+    HYBRID_COLLECTION_NAME,
+    LEGACY_COLLECTION_NAME,
+    QWEN3_EMBEDDING_DIMENSIONS,
+    QWEN3_EMBEDDING_MODEL,
+    QWEN3_EMBEDDING_PROVIDER,
+    QWEN3_EMBEDDING_VERSION,
+    SCHEMA_VERSION,
+    SPARSE_VECTOR_NAME,
+    SPARSE_VECTOR_PARAMS,
+    AsyncQdrantHybridStore,
+    HybridCollectionConfig,
+    HybridPointPayload,
+    QdrantVectorStore,
+    build_hybrid_point,
+    create_hybrid_collection,
+    ensure_hybrid_collection,
+    upsert_hybrid_point,
+    validate_hybrid_payload,
+)
+from backend.rag.sparse_vector import SparseVector
+
+
+def _valid_payload(**overrides: object) -> HybridPointPayload:
+    payload: dict[str, object] = {
+        "doc_id": "doc-001",
+        "chunk_index": 0,
+        "security_level": "Level 0",
+        "embedding_model": QWEN3_EMBEDDING_MODEL,
+        "embedding_provider": QWEN3_EMBEDDING_PROVIDER,
+        "embedding_dimensions": QWEN3_EMBEDDING_DIMENSIONS,
+        "embedding_version": QWEN3_EMBEDDING_VERSION,
+        "schema_version": SCHEMA_VERSION,
+    }
+    payload.update(overrides)
+    return cast(HybridPointPayload, payload)
+
+
+class FakeSyncQdrantClient:
+    def __init__(self, *, exists: bool = False) -> None:
+        self.exists = exists
+        self.created: list[dict[str, object]] = []
+        self.upserts: list[dict[str, object]] = []
+
+    def collection_exists(self, collection_name: str) -> bool:
+        return self.exists and collection_name == HYBRID_COLLECTION_NAME
+
+    def create_collection(
+        self,
+        *,
+        collection_name: str,
+        vectors_config: Mapping[str, models.VectorParams],
+        sparse_vectors_config: Mapping[str, models.SparseVectorParams],
+    ) -> object:
+        self.created.append(
+            {
+                "collection_name": collection_name,
+                "vectors_config": dict(vectors_config),
+                "sparse_vectors_config": dict(sparse_vectors_config),
+            }
+        )
+        self.exists = True
+        return True
+
+    def upsert(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[models.PointStruct],
+        wait: bool,
+    ) -> object:
+        self.upserts.append(
+            {
+                "collection_name": collection_name,
+                "points": list(points),
+                "wait": wait,
+            }
+        )
+        return True
+
+
+class FakeAsyncQdrantClient:
+    def __init__(self) -> None:
+        self.exists = False
+        self.created: list[dict[str, object]] = []
+        self.upserts: list[dict[str, object]] = []
+        self.exists_calls = 0
+
+    async def collection_exists(self, collection_name: str) -> bool:
+        self.exists_calls += 1
+        await asyncio.sleep(0)
+        return self.exists and collection_name == HYBRID_COLLECTION_NAME
+
+    async def create_collection(
+        self,
+        *,
+        collection_name: str,
+        vectors_config: Mapping[str, models.VectorParams],
+        sparse_vectors_config: Mapping[str, models.SparseVectorParams],
+    ) -> object:
+        await asyncio.sleep(0)
+        self.created.append(
+            {
+                "collection_name": collection_name,
+                "vectors_config": dict(vectors_config),
+                "sparse_vectors_config": dict(sparse_vectors_config),
+            }
+        )
+        self.exists = True
+        return True
+
+    async def upsert(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[models.PointStruct],
+        wait: bool,
+    ) -> object:
+        self.upserts.append(
+            {
+                "collection_name": collection_name,
+                "points": list(points),
+                "wait": wait,
+            }
+        )
+        return True
+
+
+class HybridCollectionConfigTests(unittest.TestCase):
+    def test_default_contract_uses_qwen3_dense_and_bm25_sparse_names(self) -> None:
+        config = HybridCollectionConfig()
+
+        self.assertEqual(config.collection_name, HYBRID_COLLECTION_NAME)
+        self.assertEqual(config.dense_vector_name, DENSE_VECTOR_NAME)
+        self.assertEqual(config.sparse_vector_name, SPARSE_VECTOR_NAME)
+        self.assertEqual(config.embedding_model, QWEN3_EMBEDDING_MODEL)
+        self.assertEqual(config.embedding_dimensions, 1024)
+
+    def test_qdrant_schema_uses_named_dense_and_sparse_vectors(self) -> None:
+        config = HybridCollectionConfig()
+        schema = config.to_qdrant_vectors_config()
+        vectors = cast(dict[str, models.VectorParams], schema["vectors_config"])
+        sparse = cast(dict[str, models.SparseVectorParams], schema["sparse_vectors_config"])
+
+        self.assertEqual(set(vectors), {"dense"})
+        self.assertEqual(vectors["dense"].size, 1024)
+        self.assertEqual(vectors["dense"].distance, models.Distance.COSINE)
+        self.assertEqual(set(sparse), {"sparse"})
+        self.assertIs(sparse["sparse"], SPARSE_VECTOR_PARAMS)
+
+    def test_sparse_vector_params_never_use_idf_modifier(self) -> None:
+        self.assertIsNone(SPARSE_VECTOR_PARAMS.modifier)
+
+    def test_config_rejects_legacy_collection_and_bad_names(self) -> None:
+        with self.assertRaisesRegex(ValueError, "legacy collection"):
+            HybridCollectionConfig(collection_name=LEGACY_COLLECTION_NAME)
+        with self.assertRaisesRegex(ValueError, "null bytes"):
+            HybridCollectionConfig(collection_name="bad\x00name")
+        with self.assertRaisesRegex(ValueError, "must differ"):
+            HybridCollectionConfig(dense_vector_name="same", sparse_vector_name="same")
+
+    def test_config_rejects_dimension_mismatch(self) -> None:
+        with self.assertRaisesRegex(ValueError, "embedding_dimensions"):
+            HybridCollectionConfig(dense_dimensions=1024, embedding_dimensions=4096)
+
+    def test_schema_fingerprint_is_stable_and_material(self) -> None:
+        first = HybridCollectionConfig()
+        second = HybridCollectionConfig()
+        changed = HybridCollectionConfig(collection_name="quimera_knowledge_v3")
+
+        self.assertEqual(first.schema_fingerprint(), second.schema_fingerprint())
+        self.assertNotEqual(first.schema_fingerprint(), changed.schema_fingerprint())
+
+
+class HybridCollectionOperationTests(unittest.TestCase):
+    def test_create_hybrid_collection_calls_qdrant_with_v2_schema(self) -> None:
+        client = FakeSyncQdrantClient()
+
+        create_hybrid_collection(client)
+
+        self.assertEqual(len(client.created), 1)
+        created = client.created[0]
+        self.assertEqual(created["collection_name"], HYBRID_COLLECTION_NAME)
+        vectors = cast(dict[str, models.VectorParams], created["vectors_config"])
+        sparse = cast(dict[str, models.SparseVectorParams], created["sparse_vectors_config"])
+        self.assertEqual(vectors["dense"].size, QWEN3_EMBEDDING_DIMENSIONS)
+        self.assertIsNone(sparse["sparse"].modifier)
+
+    def test_ensure_hybrid_collection_is_idempotent(self) -> None:
+        client = FakeSyncQdrantClient(exists=True)
+
+        ensure_hybrid_collection(client)
+
+        self.assertEqual(client.created, [])
+
+    def test_legacy_qdrant_vector_store_default_remains_unchanged(self) -> None:
+        store = QdrantVectorStore(client=cast(Any, FakeSyncQdrantClient()))
+
+        self.assertEqual(store.collection_name, "openclaw_knowledge")
+        self.assertEqual(store.vector_size, 768)
+
+
+class HybridPayloadValidationTests(unittest.TestCase):
+    def test_valid_payload_is_returned_as_typed_payload(self) -> None:
+        payload = validate_hybrid_payload(_valid_payload())
+
+        self.assertEqual(payload["embedding_model"], QWEN3_EMBEDDING_MODEL)
+        self.assertEqual(payload["embedding_dimensions"], 1024)
+
+    def test_payload_rejects_nomic_or_wrong_dimensions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "embedding_model"):
+            validate_hybrid_payload(_valid_payload(embedding_model="nomic-embed-text"))
+        with self.assertRaisesRegex(ValueError, "embedding_dimensions"):
+            validate_hybrid_payload(_valid_payload(embedding_dimensions=768))
+
+    def test_payload_rejects_wrong_provider_version_or_schema(self) -> None:
+        with self.assertRaisesRegex(ValueError, "embedding_provider"):
+            validate_hybrid_payload(_valid_payload(embedding_provider="ollama"))
+        with self.assertRaisesRegex(ValueError, "embedding_version"):
+            validate_hybrid_payload(_valid_payload(embedding_version="v0"))
+        with self.assertRaisesRegex(ValueError, "schema_version"):
+            validate_hybrid_payload(_valid_payload(schema_version="old-schema"))
+
+    def test_payload_rejects_missing_empty_or_null_byte_fields(self) -> None:
+        with self.assertRaisesRegex(ValueError, "doc_id"):
+            validate_hybrid_payload(_valid_payload(doc_id=" "))
+        with self.assertRaisesRegex(ValueError, "security_level"):
+            validate_hybrid_payload(_valid_payload(security_level="Level\x000"))
+        with self.assertRaisesRegex(ValueError, "chunk_index"):
+            validate_hybrid_payload(_valid_payload(chunk_index=-1))
+
+
+class HybridPointTests(unittest.TestCase):
+    def test_build_hybrid_point_uses_named_dense_and_sparse_vectors(self) -> None:
+        point = build_hybrid_point(
+            point_id="point-1",
+            dense_vector=[0.1] * QWEN3_EMBEDDING_DIMENSIONS,
+            sparse_vector=SparseVector(indices=[7, 3], values=[0.4, 0.2]),
+            payload=_valid_payload(),
+        )
+
+        vector = cast(dict[str, object], point.vector)
+        self.assertEqual(set(vector), {"dense", "sparse"})
+        self.assertEqual(cast(list[float], vector["dense"])[0], 0.1)
+        sparse = cast(models.SparseVector, vector["sparse"])
+        self.assertEqual(sparse.indices, [7, 3])
+        self.assertEqual(sparse.values, [0.4, 0.2])
+        payload = cast(dict[str, object], point.payload)
+        self.assertEqual(payload["embedding_model"], QWEN3_EMBEDDING_MODEL)
+
+    def test_build_hybrid_point_rejects_wrong_dense_dimension(self) -> None:
+        with self.assertRaisesRegex(ValueError, "expected vector size"):
+            build_hybrid_point(
+                point_id="point-1",
+                dense_vector=[0.1],
+                sparse_vector=SparseVector(indices=[1], values=[1.0]),
+                payload=_valid_payload(),
+            )
+
+    def test_upsert_hybrid_point_writes_only_to_v2_collection(self) -> None:
+        client = FakeSyncQdrantClient()
+
+        upsert_hybrid_point(
+            client,
+            point_id=1,
+            dense_vector=[0.0] * QWEN3_EMBEDDING_DIMENSIONS,
+            sparse_vector=SparseVector(indices=[1], values=[1.0]),
+            payload=_valid_payload(),
+        )
+
+        self.assertEqual(len(client.upserts), 1)
+        self.assertEqual(client.upserts[0]["collection_name"], HYBRID_COLLECTION_NAME)
+        self.assertTrue(client.upserts[0]["wait"])
+
+
+class AsyncQdrantHybridStoreTests(unittest.IsolatedAsyncioTestCase):
+    async def test_concurrent_ensure_uses_single_create_call(self) -> None:
+        client = FakeAsyncQdrantClient()
+        store = AsyncQdrantHybridStore(client=client)
+
+        await asyncio.gather(*(store.ensure_hybrid_collection() for _ in range(5)))
+
+        self.assertEqual(len(client.created), 1)
+        self.assertGreaterEqual(client.exists_calls, 5)
+
+    async def test_async_upsert_uses_named_v2_collection(self) -> None:
+        client = FakeAsyncQdrantClient()
+        store = AsyncQdrantHybridStore(client=client)
+
+        await store.upsert_hybrid_point(
+            point_id="point-1",
+            dense_vector=[0.0] * QWEN3_EMBEDDING_DIMENSIONS,
+            sparse_vector=SparseVector(indices=[1], values=[1.0]),
+            payload=_valid_payload(),
+        )
+
+        self.assertEqual(len(client.upserts), 1)
+        self.assertEqual(client.upserts[0]["collection_name"], HYBRID_COLLECTION_NAME)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #99

## Objetivo
Preparar o contrato de storage Qdrant para a collection hibrida quimera_knowledge_v2, com named vector dense e named vector sparse, preservando o caminho legacy intacto.

## O que mudou
- Adiciona constantes de contrato para collection v2 e Qwen3-Embedding-0.6B/1024.
- Adiciona HybridCollectionConfig com schema fingerprint e schema Qdrant named dense + sparse.
- Mantem SPARSE_VECTOR_PARAMS = models.SparseVectorParams() sem modifier para evitar double-IDF com fastembed BM25.
- Adiciona HybridPointPayload, validacao de metadata obrigatoria e protecao contra mistura Nomic/Qwen3.
- Adiciona helpers sync e AsyncQdrantHybridStore com asyncio.Lock para ensure_hybrid_collection.
- Adiciona testes offline com fake clients em tests/unit/test_qdrant_store_hybrid.py.

## Fora de escopo
- HybridRetriever, fusion, RRF/DBSF.
- Busca hibrida ou query planner.
- Qdrant live/smoke obrigatorio.
- Alterar quimera_knowledge/legacy runtime.

## Validacao
- uv run pytest tests/unit/test_qdrant_store_hybrid.py -v -> 18 passed
- uv run pytest tests/unit/ -v -> 788 passed, 253 subtests passed
- uv run mypy --strict backend/rag/qdrant_store.py tests/unit/test_qdrant_store_hybrid.py -> 0 errors
- uv run mypy --strict . -> 0 errors
- uv run pyright backend/rag/qdrant_store.py tests/unit/test_qdrant_store_hybrid.py -> 0 errors
- uv run pyright -> 0 errors
- git diff --check -> clean

## Notas de review
- query_points(using=...) nao e implementado neste PR; docstring registra que chamadas futuras com named vectors exigem Qdrant server >= 1.10.
- O contrato sparse documenta explicitamente a armadilha de double-IDF: fastembed BM25 ja aplica TF-IDF, entao modifier=Modifier.IDF nao deve ser usado.