### PR TITLE
[RAG-1A] PR 07 — Weighted RRF Fusion Core

### DIFF
--- a/backend/rag/fusion.py
+++ b/backend/rag/fusion.py
@@ -14,38 +14,10 @@ from typing import Any, Final
 
 SOURCE_DENSE: Final[str] = "dense"
 SOURCE_SPARSE: Final[str] = "sparse"
-DENSE_SOURCE: Final[str] = SOURCE_DENSE
-SPARSE_SOURCE: Final[str] = SOURCE_SPARSE
 
 DEFAULT_RRF_K: Final[float] = 60.0
 DEFAULT_DENSE_WEIGHT: Final[float] = 1.0
 DEFAULT_SPARSE_WEIGHT: Final[float] = 1.0
-
-_FORBIDDEN_PAYLOAD_KEYS: Final[frozenset[str]] = frozenset(
-    {
-        "answer",
-        "chunk",
-        "chunk_text",
-        "completion",
-        "content",
-        "dense_vector",
-        "document",
-        "documents",
-        "embedding",
-        "embeddings",
-        "messages",
-        "page_content",
-        "prompt",
-        "query",
-        "question",
-        "raw_text",
-        "response",
-        "sparse_vector",
-        "text",
-        "vector",
-        "vectors",
-    }
-)
 
 
 def _validate_numeric(value: float, field_name: str) -> float:
@@ -320,6 +292,10 @@ def fuse(
     the ``result_id`` first appeared. Inputs are iterated as provided and are
     never sorted or mutated in place. ``limit`` is applied after full fusion
     and deterministic sorting.
+
+    Disabled channels still advance the concatenated input boundary. For
+    example, with ``dense_weight=0.0``, sparse-only results keep
+    ``first_seen_order`` offsets after ``len(dense_results)``.
     """
 
     clean_limit = _validate_optional_limit(limit)
@@ -327,7 +303,7 @@ def fuse(
     next_order = 0
 
     next_order = _consume_ranking(
-        source=DENSE_SOURCE,
+        source=SOURCE_DENSE,
         results=dense_results,
         weight=profile.dense_weight,
         k=profile.k,
@@ -335,7 +311,7 @@ def fuse(
         start_order=next_order,
     )
     _consume_ranking(
-        source=SPARSE_SOURCE,
+        source=SOURCE_SPARSE,
         results=sparse_results,
         weight=profile.sparse_weight,
         k=profile.k,
@@ -465,12 +441,12 @@ def _apply_contribution(
     raw_score: float | None,
 ) -> None:
     accumulator.rrf_score += contribution
-    if source == DENSE_SOURCE:
+    if source == SOURCE_DENSE:
         accumulator.dense_rank = rank
         accumulator.dense_contribution = contribution
         accumulator.dense_raw_score = raw_score
         return
-    if source == SPARSE_SOURCE:
+    if source == SOURCE_SPARSE:
         accumulator.sparse_rank = rank
         accumulator.sparse_contribution = contribution
         accumulator.sparse_raw_score = raw_score
@@ -493,8 +469,8 @@ def _maybe_update_payload(
 
     if (
         result.rank == current_rank
-        and source == DENSE_SOURCE
-        and accumulator.payload_source != DENSE_SOURCE
+        and source == SOURCE_DENSE
+        and accumulator.payload_source != SOURCE_DENSE
     ):
         accumulator.payload = result.payload
         accumulator.payload_rank = result.rank
@@ -512,9 +488,9 @@ def _build_fused_result(accumulator: _RRFAccumulator) -> FusedResult:
 
     sources: set[str] = set()
     if accumulator.dense_rank is not None:
-        sources.add(DENSE_SOURCE)
+        sources.add(SOURCE_DENSE)
     if accumulator.sparse_rank is not None:
-        sources.add(SPARSE_SOURCE)
+        sources.add(SOURCE_SPARSE)
 
     return FusedResult(
         result_id=accumulator.result_id,
@@ -548,18 +524,12 @@ def _freeze_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
         if not isinstance(key, str):
             raise TypeError("payload keys must be strings")
         clean_payload[key] = value
-
-    normalized_keys = {key.casefold() for key in clean_payload}
-    forbidden = _FORBIDDEN_PAYLOAD_KEYS.intersection(normalized_keys)
-    if forbidden:
-        keys = ", ".join(sorted(forbidden))
-        raise ValueError(f"payload cannot contain sensitive keys: {keys}")
     return MappingProxyType(clean_payload)
 
 
 def _validate_source(source: str) -> str:
     clean_source = _validate_text_id(source, "source")
-    if clean_source not in {DENSE_SOURCE, SPARSE_SOURCE}:
+    if clean_source not in {SOURCE_DENSE, SOURCE_SPARSE}:
         raise ValueError(f"unsupported RRF source: {clean_source}")
     return clean_source
 
@@ -598,8 +568,6 @@ def _validate_optional_limit(value: int | None) -> int | None:
 __all__ = [
     "SOURCE_DENSE",
     "SOURCE_SPARSE",
-    "DENSE_SOURCE",
-    "SPARSE_SOURCE",
     "DEFAULT_RRF_K",
     "DEFAULT_DENSE_WEIGHT",
     "DEFAULT_SPARSE_WEIGHT",

--- a/backend/rag/fusion.py
+++ b/backend/rag/fusion.py
@@ -24,10 +24,23 @@ DEFAULT_SPARSE_WEIGHT: Final[float] = 1.0
 _FORBIDDEN_PAYLOAD_KEYS: Final[frozenset[str]] = frozenset(
     {
         "answer",
+        "chunk",
         "chunk_text",
+        "completion",
+        "content",
+        "dense_vector",
+        "document",
+        "documents",
         "embedding",
         "embeddings",
+        "messages",
+        "page_content",
         "prompt",
+        "query",
+        "question",
+        "raw_text",
+        "response",
+        "sparse_vector",
         "text",
         "vector",
         "vectors",
@@ -115,7 +128,10 @@ class RankedResult:
 
 @dataclass(frozen=True, slots=True)
 class RRFWeightProfile:
-    """Immutable Weighted RRF configuration."""
+    """Immutable Weighted RRF configuration.
+
+    ``k`` is stored as float to support future benchmark sweeps.
+    """
 
     dense_weight: float = DEFAULT_DENSE_WEIGHT
     sparse_weight: float = DEFAULT_SPARSE_WEIGHT
@@ -295,10 +311,15 @@ def fuse(
 ) -> list[FusedResult]:
     """Fuse dense and sparse rankings with deterministic Weighted RRF.
 
+    The function trusts ``RankedResult.rank``. Callers must assign ranks from
+    the retrieval order before calling ``fuse()``; raw scores are diagnostic
+    only and are never used in the RRF formula.
+
     ``first_seen_order`` in each output is the 0-based index in the
     concatenated ``[*dense_results, *sparse_results]`` input sequence where
     the ``result_id`` first appeared. Inputs are iterated as provided and are
-    never sorted or mutated in place.
+    never sorted or mutated in place. ``limit`` is applied after full fusion
+    and deterministic sorting.
     """
 
     clean_limit = _validate_optional_limit(limit)
@@ -348,6 +369,29 @@ class RRFFusion:
             profile=self.profile,
             limit=limit,
         )
+
+
+def ranked_result_from_position(
+    *,
+    result_id: str,
+    doc_id: str,
+    zero_based_position: int,
+    raw_score: float | None = None,
+    payload: Mapping[str, object] | None = None,
+) -> RankedResult:
+    """Build a ``RankedResult`` from a retriever's 0-based ordered position."""
+
+    clean_position = _validate_non_negative_int(
+        zero_based_position,
+        "zero_based_position",
+    )
+    return RankedResult(
+        result_id=result_id,
+        doc_id=doc_id,
+        rank=clean_position + 1,
+        raw_score=raw_score,
+        payload={} if payload is None else payload,
+    )
 
 
 def _consume_ranking(
@@ -499,12 +543,18 @@ def _fused_sort_key(result: FusedResult) -> tuple[float, int, int, str]:
 
 
 def _freeze_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
-    normalized_keys = {str(key).casefold() for key in payload}
+    clean_payload: dict[str, object] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise TypeError("payload keys must be strings")
+        clean_payload[key] = value
+
+    normalized_keys = {key.casefold() for key in clean_payload}
     forbidden = _FORBIDDEN_PAYLOAD_KEYS.intersection(normalized_keys)
     if forbidden:
         keys = ", ".join(sorted(forbidden))
         raise ValueError(f"payload cannot contain sensitive keys: {keys}")
-    return MappingProxyType(dict(payload))
+    return MappingProxyType(clean_payload)
 
 
 def _validate_source(source: str) -> str:
@@ -550,10 +600,14 @@ __all__ = [
     "SOURCE_SPARSE",
     "DENSE_SOURCE",
     "SPARSE_SOURCE",
+    "DEFAULT_RRF_K",
+    "DEFAULT_DENSE_WEIGHT",
+    "DEFAULT_SPARSE_WEIGHT",
     "RankedResult",
     "FusedResult",
     "RRFWeightProfile",
     "DEFAULT_PROFILE",
     "RRFFusion",
+    "ranked_result_from_position",
     "fuse",
 ]

--- a/backend/rag/fusion.py
+++ b/backend/rag/fusion.py
@@ -8,14 +8,16 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from math import isfinite
+from math import isclose, isfinite
 from types import MappingProxyType
 from typing import Any, Final
 
-DENSE_SOURCE: Final[str] = "dense"
-SPARSE_SOURCE: Final[str] = "sparse"
+SOURCE_DENSE: Final[str] = "dense"
+SOURCE_SPARSE: Final[str] = "sparse"
+DENSE_SOURCE: Final[str] = SOURCE_DENSE
+SPARSE_SOURCE: Final[str] = SOURCE_SPARSE
 
-DEFAULT_RRF_K: Final[int] = 60
+DEFAULT_RRF_K: Final[float] = 60.0
 DEFAULT_DENSE_WEIGHT: Final[float] = 1.0
 DEFAULT_SPARSE_WEIGHT: Final[float] = 1.0
 
@@ -70,29 +72,44 @@ def _validate_positive_int(value: int, field_name: str) -> int:
     return value
 
 
+def _validate_positive_float(value: float, field_name: str) -> float:
+    clean_value = _validate_numeric(value, field_name)
+    if clean_value <= 0.0:
+        if field_name == "RRF k":
+            raise ValueError("RRF k must be > 0")
+        raise ValueError(f"{field_name} must be > 0")
+    return clean_value
+
+
 @dataclass(frozen=True, slots=True)
 class RankedResult:
-    """One retrieval result in an already-ranked list."""
+    """One retrieval result in an already-ranked list.
+
+    ``rank`` is the only retrieval signal used by RRF. ``raw_score`` is kept
+    for diagnostics and never participates in the fusion formula.
+    """
 
     result_id: str
     doc_id: str
     rank: int
-    score: float | None = None
+    raw_score: float | None = None
     payload: Mapping[str, object] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         clean_result_id = _validate_text_id(self.result_id, "result_id")
         clean_doc_id = _validate_text_id(self.doc_id, "doc_id")
         clean_rank = _validate_positive_int(self.rank, "rank")
-        clean_score = (
-            None if self.score is None else _validate_optional_score(self.score, "score")
+        clean_raw_score = (
+            None
+            if self.raw_score is None
+            else _validate_optional_score(self.raw_score, "raw_score")
         )
         clean_payload = _freeze_payload(self.payload)
 
         object.__setattr__(self, "result_id", clean_result_id)
         object.__setattr__(self, "doc_id", clean_doc_id)
         object.__setattr__(self, "rank", clean_rank)
-        object.__setattr__(self, "score", clean_score)
+        object.__setattr__(self, "raw_score", clean_raw_score)
         object.__setattr__(self, "payload", clean_payload)
 
 
@@ -102,14 +119,14 @@ class RRFWeightProfile:
 
     dense_weight: float = DEFAULT_DENSE_WEIGHT
     sparse_weight: float = DEFAULT_SPARSE_WEIGHT
-    k: int = DEFAULT_RRF_K
+    k: float = DEFAULT_RRF_K
     name: str = "default"
 
     def __post_init__(self) -> None:
         clean_name = _validate_text_id(self.name, "RRF profile name")
         clean_dense_weight = _validate_weight(self.dense_weight, "dense_weight")
         clean_sparse_weight = _validate_weight(self.sparse_weight, "sparse_weight")
-        clean_k = _validate_positive_int(self.k, "RRF k")
+        clean_k = _validate_positive_float(self.k, "RRF k")
 
         if clean_dense_weight == 0.0 and clean_sparse_weight == 0.0:
             raise ValueError("at least one RRF weight must be positive")
@@ -135,7 +152,12 @@ DEFAULT_PROFILE: Final[RRFWeightProfile] = RRFWeightProfile()
 
 @dataclass(frozen=True, slots=True)
 class FusedResult:
-    """Final result produced by Weighted RRF."""
+    """Final result produced by Weighted RRF.
+
+    ``first_seen_order`` is the 0-based index in the concatenated
+    ``[*dense_results, *sparse_results]`` input sequence where ``result_id``
+    first appeared.
+    """
 
     result_id: str
     doc_id: str
@@ -146,6 +168,8 @@ class FusedResult:
     sparse_contribution: float
     best_rank: int
     first_seen_order: int
+    dense_raw_score: float | None = None
+    sparse_raw_score: float | None = None
     payload: Mapping[str, object] = field(default_factory=dict)
     sources: frozenset[str] = frozenset()
 
@@ -167,6 +191,15 @@ class FusedResult:
             self.sparse_contribution,
             "sparse_contribution",
         )
+        if not isclose(
+            clean_rrf_score,
+            clean_dense_contribution + clean_sparse_contribution,
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        ):
+            raise ValueError(
+                "rrf_score must equal dense_contribution + sparse_contribution"
+            )
         clean_best_rank = _validate_positive_int(self.best_rank, "best_rank")
         clean_first_seen_order = _validate_non_negative_int(
             self.first_seen_order,
@@ -183,6 +216,23 @@ class FusedResult:
         clean_sources = frozenset(_validate_source(source) for source in self.sources)
         if not clean_sources:
             raise ValueError("sources cannot be empty")
+        expected_sources: set[str] = set()
+        if clean_dense_rank is not None:
+            expected_sources.add(SOURCE_DENSE)
+        if clean_sparse_rank is not None:
+            expected_sources.add(SOURCE_SPARSE)
+        if clean_sources != expected_sources:
+            raise ValueError("sources must match present source ranks")
+        clean_dense_raw_score = (
+            None
+            if self.dense_raw_score is None
+            else _validate_optional_score(self.dense_raw_score, "dense_raw_score")
+        )
+        clean_sparse_raw_score = (
+            None
+            if self.sparse_raw_score is None
+            else _validate_optional_score(self.sparse_raw_score, "sparse_raw_score")
+        )
         clean_payload = _freeze_payload(self.payload)
 
         object.__setattr__(self, "result_id", clean_result_id)
@@ -194,6 +244,8 @@ class FusedResult:
         object.__setattr__(self, "sparse_contribution", clean_sparse_contribution)
         object.__setattr__(self, "best_rank", clean_best_rank)
         object.__setattr__(self, "first_seen_order", clean_first_seen_order)
+        object.__setattr__(self, "dense_raw_score", clean_dense_raw_score)
+        object.__setattr__(self, "sparse_raw_score", clean_sparse_raw_score)
         object.__setattr__(self, "payload", clean_payload)
         object.__setattr__(self, "sources", clean_sources)
 
@@ -210,6 +262,8 @@ class FusedResult:
             "sparse_contribution": self.sparse_contribution,
             "best_rank": self.best_rank,
             "first_seen_order": self.first_seen_order,
+            "dense_raw_score": self.dense_raw_score,
+            "sparse_raw_score": self.sparse_raw_score,
             "sources": sorted(self.sources),
             "payload": dict(self.payload),
         }
@@ -225,6 +279,8 @@ class _RRFAccumulator:
     sparse_rank: int | None = None
     dense_contribution: float = 0.0
     sparse_contribution: float = 0.0
+    dense_raw_score: float | None = None
+    sparse_raw_score: float | None = None
     payload: Mapping[str, object] = field(default_factory=dict)
     payload_rank: int | None = None
     payload_source: str | None = None
@@ -237,7 +293,13 @@ def fuse(
     profile: RRFWeightProfile = DEFAULT_PROFILE,
     limit: int | None = None,
 ) -> list[FusedResult]:
-    """Fuse dense and sparse rankings with deterministic Weighted RRF."""
+    """Fuse dense and sparse rankings with deterministic Weighted RRF.
+
+    ``first_seen_order`` in each output is the 0-based index in the
+    concatenated ``[*dense_results, *sparse_results]`` input sequence where
+    the ``result_id`` first appeared. Inputs are iterated as provided and are
+    never sorted or mutated in place.
+    """
 
     clean_limit = _validate_optional_limit(limit)
     accumulators: dict[str, _RRFAccumulator] = {}
@@ -249,7 +311,7 @@ def fuse(
         weight=profile.dense_weight,
         k=profile.k,
         accumulators=accumulators,
-        next_order=next_order,
+        start_order=next_order,
     )
     _consume_ranking(
         source=SPARSE_SOURCE,
@@ -257,7 +319,7 @@ def fuse(
         weight=profile.sparse_weight,
         k=profile.k,
         accumulators=accumulators,
-        next_order=next_order,
+        start_order=next_order,
     )
 
     fused = [_build_fused_result(accumulator) for accumulator in accumulators.values()]
@@ -293,36 +355,41 @@ def _consume_ranking(
     source: str,
     results: Sequence[RankedResult],
     weight: float,
-    k: int,
+    k: float,
     accumulators: dict[str, _RRFAccumulator],
-    next_order: int,
+    start_order: int,
 ) -> int:
     if weight == 0.0:
-        return next_order
+        return start_order + len(results)
 
     seen_in_source: set[str] = set()
-    accepted_order = next_order
-    for result in results:
+    for zero_based_position, result in enumerate(results):
         if result.result_id in seen_in_source:
+            _validate_doc_id_consistency(
+                accumulator=accumulators.get(result.result_id),
+                result=result,
+            )
             continue
         seen_in_source.add(result.result_id)
 
-        contribution = weight / float(k + result.rank)
+        contribution = weight / (k + float(result.rank))
         accumulator = accumulators.get(result.result_id)
         if accumulator is None:
             accumulator = _RRFAccumulator(
                 result_id=result.result_id,
                 doc_id=result.doc_id,
-                first_seen_order=accepted_order,
+                first_seen_order=start_order + zero_based_position,
             )
             accumulators[result.result_id] = accumulator
-            accepted_order += 1
+        else:
+            _validate_doc_id_consistency(accumulator=accumulator, result=result)
 
         _apply_contribution(
             accumulator=accumulator,
             source=source,
             rank=result.rank,
             contribution=contribution,
+            raw_score=result.raw_score,
         )
         _maybe_update_payload(
             accumulator=accumulator,
@@ -330,7 +397,19 @@ def _consume_ranking(
             source=source,
         )
 
-    return accepted_order
+    return start_order + len(results)
+
+
+def _validate_doc_id_consistency(
+    *,
+    accumulator: _RRFAccumulator | None,
+    result: RankedResult,
+) -> None:
+    if accumulator is not None and accumulator.doc_id != result.doc_id:
+        raise ValueError(
+            "conflicting doc_id for the same result_id: "
+            f"{result.result_id}"
+        )
 
 
 def _apply_contribution(
@@ -339,15 +418,18 @@ def _apply_contribution(
     source: str,
     rank: int,
     contribution: float,
+    raw_score: float | None,
 ) -> None:
     accumulator.rrf_score += contribution
     if source == DENSE_SOURCE:
         accumulator.dense_rank = rank
         accumulator.dense_contribution = contribution
+        accumulator.dense_raw_score = raw_score
         return
     if source == SPARSE_SOURCE:
         accumulator.sparse_rank = rank
         accumulator.sparse_contribution = contribution
+        accumulator.sparse_raw_score = raw_score
         return
     raise ValueError(f"unsupported RRF source: {source}")
 
@@ -400,17 +482,25 @@ def _build_fused_result(accumulator: _RRFAccumulator) -> FusedResult:
         sparse_contribution=accumulator.sparse_contribution,
         best_rank=min(ranks),
         first_seen_order=accumulator.first_seen_order,
+        dense_raw_score=accumulator.dense_raw_score,
+        sparse_raw_score=accumulator.sparse_raw_score,
         payload=accumulator.payload,
         sources=frozenset(sources),
     )
 
 
 def _fused_sort_key(result: FusedResult) -> tuple[float, int, int, str]:
-    return (-result.rrf_score, result.best_rank, result.first_seen_order, result.result_id)
+    return (
+        -result.rrf_score,
+        result.best_rank,
+        result.first_seen_order,
+        result.result_id,
+    )
 
 
 def _freeze_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
-    forbidden = _FORBIDDEN_PAYLOAD_KEYS.intersection(payload)
+    normalized_keys = {str(key).casefold() for key in payload}
+    forbidden = _FORBIDDEN_PAYLOAD_KEYS.intersection(normalized_keys)
     if forbidden:
         keys = ", ".join(sorted(forbidden))
         raise ValueError(f"payload cannot contain sensitive keys: {keys}")
@@ -456,6 +546,10 @@ def _validate_optional_limit(value: int | None) -> int | None:
 
 
 __all__ = [
+    "SOURCE_DENSE",
+    "SOURCE_SPARSE",
+    "DENSE_SOURCE",
+    "SPARSE_SOURCE",
     "RankedResult",
     "FusedResult",
     "RRFWeightProfile",

--- a/backend/rag/fusion.py
+++ b/backend/rag/fusion.py
@@ -1,0 +1,465 @@
+"""Deterministic Weighted Reciprocal Rank Fusion for OPENCLAW RAG.
+
+This module is intentionally pure Python: no Qdrant imports, no network calls,
+no file I/O, no embeddings, no rerankers and no runtime auto-tuning.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from math import isfinite
+from types import MappingProxyType
+from typing import Any, Final
+
+DENSE_SOURCE: Final[str] = "dense"
+SPARSE_SOURCE: Final[str] = "sparse"
+
+DEFAULT_RRF_K: Final[int] = 60
+DEFAULT_DENSE_WEIGHT: Final[float] = 1.0
+DEFAULT_SPARSE_WEIGHT: Final[float] = 1.0
+
+_FORBIDDEN_PAYLOAD_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "answer",
+        "chunk_text",
+        "embedding",
+        "embeddings",
+        "prompt",
+        "text",
+        "vector",
+        "vectors",
+    }
+)
+
+
+def _validate_numeric(value: float, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field_name} must be numeric")
+    clean_value = float(value)
+    if not isfinite(clean_value):
+        raise ValueError(f"{field_name} must be finite")
+    return clean_value
+
+
+def _validate_text_id(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if "\x00" in value:
+        raise ValueError(f"{field_name} cannot contain null bytes")
+    clean_value = value.strip()
+    if not clean_value:
+        raise ValueError(f"{field_name} cannot be blank")
+    return clean_value
+
+
+def _validate_weight(value: float, field_name: str) -> float:
+    clean_value = _validate_numeric(value, field_name)
+    if clean_value < 0.0:
+        raise ValueError("RRF weights must be non-negative")
+    return clean_value
+
+
+def _validate_positive_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value <= 0:
+        if field_name == "RRF k":
+            raise ValueError("RRF k must be > 0")
+        raise ValueError(f"{field_name} must be >= 1")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class RankedResult:
+    """One retrieval result in an already-ranked list."""
+
+    result_id: str
+    doc_id: str
+    rank: int
+    score: float | None = None
+    payload: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        clean_result_id = _validate_text_id(self.result_id, "result_id")
+        clean_doc_id = _validate_text_id(self.doc_id, "doc_id")
+        clean_rank = _validate_positive_int(self.rank, "rank")
+        clean_score = (
+            None if self.score is None else _validate_optional_score(self.score, "score")
+        )
+        clean_payload = _freeze_payload(self.payload)
+
+        object.__setattr__(self, "result_id", clean_result_id)
+        object.__setattr__(self, "doc_id", clean_doc_id)
+        object.__setattr__(self, "rank", clean_rank)
+        object.__setattr__(self, "score", clean_score)
+        object.__setattr__(self, "payload", clean_payload)
+
+
+@dataclass(frozen=True, slots=True)
+class RRFWeightProfile:
+    """Immutable Weighted RRF configuration."""
+
+    dense_weight: float = DEFAULT_DENSE_WEIGHT
+    sparse_weight: float = DEFAULT_SPARSE_WEIGHT
+    k: int = DEFAULT_RRF_K
+    name: str = "default"
+
+    def __post_init__(self) -> None:
+        clean_name = _validate_text_id(self.name, "RRF profile name")
+        clean_dense_weight = _validate_weight(self.dense_weight, "dense_weight")
+        clean_sparse_weight = _validate_weight(self.sparse_weight, "sparse_weight")
+        clean_k = _validate_positive_int(self.k, "RRF k")
+
+        if clean_dense_weight == 0.0 and clean_sparse_weight == 0.0:
+            raise ValueError("at least one RRF weight must be positive")
+
+        object.__setattr__(self, "name", clean_name)
+        object.__setattr__(self, "dense_weight", clean_dense_weight)
+        object.__setattr__(self, "sparse_weight", clean_sparse_weight)
+        object.__setattr__(self, "k", clean_k)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly representation."""
+
+        return {
+            "name": self.name,
+            "dense_weight": self.dense_weight,
+            "sparse_weight": self.sparse_weight,
+            "k": self.k,
+        }
+
+
+DEFAULT_PROFILE: Final[RRFWeightProfile] = RRFWeightProfile()
+
+
+@dataclass(frozen=True, slots=True)
+class FusedResult:
+    """Final result produced by Weighted RRF."""
+
+    result_id: str
+    doc_id: str
+    rrf_score: float
+    dense_rank: int | None
+    sparse_rank: int | None
+    dense_contribution: float
+    sparse_contribution: float
+    best_rank: int
+    first_seen_order: int
+    payload: Mapping[str, object] = field(default_factory=dict)
+    sources: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        clean_result_id = _validate_text_id(self.result_id, "result_id")
+        clean_doc_id = _validate_text_id(self.doc_id, "doc_id")
+        clean_dense_rank = _validate_optional_rank(self.dense_rank, "dense_rank")
+        clean_sparse_rank = _validate_optional_rank(self.sparse_rank, "sparse_rank")
+
+        if clean_dense_rank is None and clean_sparse_rank is None:
+            raise ValueError("at least one source rank must be present")
+
+        clean_rrf_score = _validate_non_negative_float(self.rrf_score, "rrf_score")
+        clean_dense_contribution = _validate_non_negative_float(
+            self.dense_contribution,
+            "dense_contribution",
+        )
+        clean_sparse_contribution = _validate_non_negative_float(
+            self.sparse_contribution,
+            "sparse_contribution",
+        )
+        clean_best_rank = _validate_positive_int(self.best_rank, "best_rank")
+        clean_first_seen_order = _validate_non_negative_int(
+            self.first_seen_order,
+            "first_seen_order",
+        )
+        present_ranks = [
+            rank
+            for rank in (clean_dense_rank, clean_sparse_rank)
+            if rank is not None
+        ]
+        if clean_best_rank != min(present_ranks):
+            raise ValueError("best_rank must be the minimum present source rank")
+
+        clean_sources = frozenset(_validate_source(source) for source in self.sources)
+        if not clean_sources:
+            raise ValueError("sources cannot be empty")
+        clean_payload = _freeze_payload(self.payload)
+
+        object.__setattr__(self, "result_id", clean_result_id)
+        object.__setattr__(self, "doc_id", clean_doc_id)
+        object.__setattr__(self, "rrf_score", clean_rrf_score)
+        object.__setattr__(self, "dense_rank", clean_dense_rank)
+        object.__setattr__(self, "sparse_rank", clean_sparse_rank)
+        object.__setattr__(self, "dense_contribution", clean_dense_contribution)
+        object.__setattr__(self, "sparse_contribution", clean_sparse_contribution)
+        object.__setattr__(self, "best_rank", clean_best_rank)
+        object.__setattr__(self, "first_seen_order", clean_first_seen_order)
+        object.__setattr__(self, "payload", clean_payload)
+        object.__setattr__(self, "sources", clean_sources)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-friendly representation."""
+
+        return {
+            "result_id": self.result_id,
+            "doc_id": self.doc_id,
+            "rrf_score": self.rrf_score,
+            "dense_rank": self.dense_rank,
+            "sparse_rank": self.sparse_rank,
+            "dense_contribution": self.dense_contribution,
+            "sparse_contribution": self.sparse_contribution,
+            "best_rank": self.best_rank,
+            "first_seen_order": self.first_seen_order,
+            "sources": sorted(self.sources),
+            "payload": dict(self.payload),
+        }
+
+
+@dataclass(slots=True)
+class _RRFAccumulator:
+    result_id: str
+    doc_id: str
+    first_seen_order: int
+    rrf_score: float = 0.0
+    dense_rank: int | None = None
+    sparse_rank: int | None = None
+    dense_contribution: float = 0.0
+    sparse_contribution: float = 0.0
+    payload: Mapping[str, object] = field(default_factory=dict)
+    payload_rank: int | None = None
+    payload_source: str | None = None
+
+
+def fuse(
+    *,
+    dense_results: Sequence[RankedResult],
+    sparse_results: Sequence[RankedResult],
+    profile: RRFWeightProfile = DEFAULT_PROFILE,
+    limit: int | None = None,
+) -> list[FusedResult]:
+    """Fuse dense and sparse rankings with deterministic Weighted RRF."""
+
+    clean_limit = _validate_optional_limit(limit)
+    accumulators: dict[str, _RRFAccumulator] = {}
+    next_order = 0
+
+    next_order = _consume_ranking(
+        source=DENSE_SOURCE,
+        results=dense_results,
+        weight=profile.dense_weight,
+        k=profile.k,
+        accumulators=accumulators,
+        next_order=next_order,
+    )
+    _consume_ranking(
+        source=SPARSE_SOURCE,
+        results=sparse_results,
+        weight=profile.sparse_weight,
+        k=profile.k,
+        accumulators=accumulators,
+        next_order=next_order,
+    )
+
+    fused = [_build_fused_result(accumulator) for accumulator in accumulators.values()]
+    fused.sort(key=_fused_sort_key)
+    return fused if clean_limit is None else fused[:clean_limit]
+
+
+@dataclass(frozen=True, slots=True)
+class RRFFusion:
+    """Configurable Weighted RRF fusion object for dependency injection."""
+
+    profile: RRFWeightProfile = DEFAULT_PROFILE
+
+    def fuse(
+        self,
+        *,
+        dense_results: Sequence[RankedResult],
+        sparse_results: Sequence[RankedResult],
+        limit: int | None = None,
+    ) -> list[FusedResult]:
+        """Fuse dense and sparse rankings with the configured profile."""
+
+        return fuse(
+            dense_results=dense_results,
+            sparse_results=sparse_results,
+            profile=self.profile,
+            limit=limit,
+        )
+
+
+def _consume_ranking(
+    *,
+    source: str,
+    results: Sequence[RankedResult],
+    weight: float,
+    k: int,
+    accumulators: dict[str, _RRFAccumulator],
+    next_order: int,
+) -> int:
+    if weight == 0.0:
+        return next_order
+
+    seen_in_source: set[str] = set()
+    accepted_order = next_order
+    for result in results:
+        if result.result_id in seen_in_source:
+            continue
+        seen_in_source.add(result.result_id)
+
+        contribution = weight / float(k + result.rank)
+        accumulator = accumulators.get(result.result_id)
+        if accumulator is None:
+            accumulator = _RRFAccumulator(
+                result_id=result.result_id,
+                doc_id=result.doc_id,
+                first_seen_order=accepted_order,
+            )
+            accumulators[result.result_id] = accumulator
+            accepted_order += 1
+
+        _apply_contribution(
+            accumulator=accumulator,
+            source=source,
+            rank=result.rank,
+            contribution=contribution,
+        )
+        _maybe_update_payload(
+            accumulator=accumulator,
+            result=result,
+            source=source,
+        )
+
+    return accepted_order
+
+
+def _apply_contribution(
+    *,
+    accumulator: _RRFAccumulator,
+    source: str,
+    rank: int,
+    contribution: float,
+) -> None:
+    accumulator.rrf_score += contribution
+    if source == DENSE_SOURCE:
+        accumulator.dense_rank = rank
+        accumulator.dense_contribution = contribution
+        return
+    if source == SPARSE_SOURCE:
+        accumulator.sparse_rank = rank
+        accumulator.sparse_contribution = contribution
+        return
+    raise ValueError(f"unsupported RRF source: {source}")
+
+
+def _maybe_update_payload(
+    *,
+    accumulator: _RRFAccumulator,
+    result: RankedResult,
+    source: str,
+) -> None:
+    current_rank = accumulator.payload_rank
+    if current_rank is None or result.rank < current_rank:
+        accumulator.payload = result.payload
+        accumulator.payload_rank = result.rank
+        accumulator.payload_source = source
+        return
+
+    if (
+        result.rank == current_rank
+        and source == DENSE_SOURCE
+        and accumulator.payload_source != DENSE_SOURCE
+    ):
+        accumulator.payload = result.payload
+        accumulator.payload_rank = result.rank
+        accumulator.payload_source = source
+
+
+def _build_fused_result(accumulator: _RRFAccumulator) -> FusedResult:
+    ranks = [
+        rank
+        for rank in (accumulator.dense_rank, accumulator.sparse_rank)
+        if rank is not None
+    ]
+    if not ranks:
+        raise RuntimeError("internal RRF error: accumulator has no source rank")
+
+    sources: set[str] = set()
+    if accumulator.dense_rank is not None:
+        sources.add(DENSE_SOURCE)
+    if accumulator.sparse_rank is not None:
+        sources.add(SPARSE_SOURCE)
+
+    return FusedResult(
+        result_id=accumulator.result_id,
+        doc_id=accumulator.doc_id,
+        rrf_score=accumulator.rrf_score,
+        dense_rank=accumulator.dense_rank,
+        sparse_rank=accumulator.sparse_rank,
+        dense_contribution=accumulator.dense_contribution,
+        sparse_contribution=accumulator.sparse_contribution,
+        best_rank=min(ranks),
+        first_seen_order=accumulator.first_seen_order,
+        payload=accumulator.payload,
+        sources=frozenset(sources),
+    )
+
+
+def _fused_sort_key(result: FusedResult) -> tuple[float, int, int, str]:
+    return (-result.rrf_score, result.best_rank, result.first_seen_order, result.result_id)
+
+
+def _freeze_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
+    forbidden = _FORBIDDEN_PAYLOAD_KEYS.intersection(payload)
+    if forbidden:
+        keys = ", ".join(sorted(forbidden))
+        raise ValueError(f"payload cannot contain sensitive keys: {keys}")
+    return MappingProxyType(dict(payload))
+
+
+def _validate_source(source: str) -> str:
+    clean_source = _validate_text_id(source, "source")
+    if clean_source not in {DENSE_SOURCE, SPARSE_SOURCE}:
+        raise ValueError(f"unsupported RRF source: {clean_source}")
+    return clean_source
+
+
+def _validate_optional_score(value: float, field_name: str) -> float:
+    return _validate_numeric(value, field_name)
+
+
+def _validate_non_negative_float(value: float, field_name: str) -> float:
+    clean_value = _validate_numeric(value, field_name)
+    if clean_value < 0.0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return clean_value
+
+
+def _validate_non_negative_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return value
+
+
+def _validate_optional_rank(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _validate_positive_int(value, field_name)
+
+
+def _validate_optional_limit(value: int | None) -> int | None:
+    if value is None:
+        return None
+    return _validate_positive_int(value, "limit")
+
+
+__all__ = [
+    "RankedResult",
+    "FusedResult",
+    "RRFWeightProfile",
+    "DEFAULT_PROFILE",
+    "RRFFusion",
+    "fuse",
+]

--- a/tests/unit/test_fusion.py
+++ b/tests/unit/test_fusion.py
@@ -1,0 +1,430 @@
+"""Unit tests for deterministic Weighted RRF fusion."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from collections.abc import Mapping
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import backend.rag.fusion as fusion_module
+from backend.rag.fusion import (
+    DEFAULT_PROFILE,
+    FusedResult,
+    RRFFusion,
+    RRFWeightProfile,
+    RankedResult,
+    fuse,
+)
+
+
+def rr(
+    result_id: str,
+    doc_id: str | None = None,
+    rank: int = 1,
+    score: float | None = None,
+    payload: Mapping[str, object] | None = None,
+) -> RankedResult:
+    return RankedResult(
+        result_id=result_id,
+        doc_id=result_id if doc_id is None else doc_id,
+        rank=rank,
+        score=score,
+        payload={} if payload is None else payload,
+    )
+
+
+def ids(results: list[FusedResult]) -> list[str]:
+    return [result.result_id for result in results]
+
+
+def test_fusion_module_is_pure_stdlib_without_io_or_print() -> None:
+    tree = ast.parse(inspect.getsource(fusion_module))
+    allowed_roots = {
+        "__future__",
+        "collections",
+        "dataclasses",
+        "math",
+        "types",
+        "typing",
+    }
+    forbidden_calls = {"open", "print"}
+    forbidden_attrs = {"read", "write"}
+
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_roots.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_attrs
+
+    assert imported_roots <= allowed_roots
+
+
+def test_ranked_result_validates_rank_and_ids() -> None:
+    with pytest.raises(ValueError, match="rank must be >= 1"):
+        rr("A", rank=0)
+    with pytest.raises(ValueError, match="result_id cannot be blank"):
+        rr(" ")
+    with pytest.raises(ValueError, match="doc_id cannot be blank"):
+        rr("A", doc_id=" ")
+    with pytest.raises(ValueError, match="result_id cannot contain null bytes"):
+        rr("A\x00B")
+    with pytest.raises(ValueError, match="doc_id cannot contain null bytes"):
+        rr("A", doc_id="doc\x00A")
+
+
+def test_ranked_result_is_frozen_and_payload_is_defensive_mapping() -> None:
+    payload = {"source": "dense"}
+    result = rr("A", payload=payload)
+    payload["source"] = "mutated"
+
+    assert dict(result.payload) == {"source": "dense"}
+    with pytest.raises(TypeError):
+        result.payload["source"] = "mutated"  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        result.rank = 2  # type: ignore[misc]
+
+
+def test_rrf_weight_profile_defaults_and_validation() -> None:
+    assert DEFAULT_PROFILE.dense_weight == 1.0
+    assert DEFAULT_PROFILE.sparse_weight == 1.0
+    assert DEFAULT_PROFILE.k == 60
+
+    with pytest.raises(ValueError, match="RRF weights must be non-negative"):
+        RRFWeightProfile(dense_weight=-0.1)
+    with pytest.raises(ValueError, match="at least one RRF weight must be positive"):
+        RRFWeightProfile(dense_weight=0.0, sparse_weight=0.0)
+    with pytest.raises(ValueError, match="RRF k must be > 0"):
+        RRFWeightProfile(k=0)
+    with pytest.raises(ValueError, match="RRF profile name cannot contain null bytes"):
+        RRFWeightProfile(name="bad\x00name")
+
+    assert RRFWeightProfile(dense_weight=0.0).dense_weight == 0.0
+    assert RRFWeightProfile(sparse_weight=0.0).sparse_weight == 0.0
+
+
+def test_fuse_empty_and_single_channel_cases() -> None:
+    assert fuse(dense_results=[], sparse_results=[]) == []
+
+    dense_only = fuse(dense_results=[rr("D", rank=2)], sparse_results=[])
+    assert ids(dense_only) == ["D"]
+    assert dense_only[0].dense_rank == 2
+    assert dense_only[0].sparse_rank is None
+    assert dense_only[0].sources == frozenset({"dense"})
+
+    sparse_only = fuse(dense_results=[], sparse_results=[rr("S", rank=3)])
+    assert ids(sparse_only) == ["S"]
+    assert sparse_only[0].dense_rank is None
+    assert sparse_only[0].sparse_rank == 3
+    assert sparse_only[0].sources == frozenset({"sparse"})
+
+
+def test_fuse_limit_validation_and_truncation() -> None:
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        fuse(dense_results=[rr("A")], sparse_results=[], limit=0)
+
+    fused = fuse(
+        dense_results=[rr("A", rank=1), rr("B", rank=2), rr("C", rank=3)],
+        sparse_results=[],
+        limit=2,
+    )
+
+    assert ids(fused) == ["A", "B"]
+
+
+def test_document_present_in_both_rankings_receives_two_contributions() -> None:
+    fused = RRFFusion().fuse(
+        dense_results=[rr("A", rank=1), rr("B", rank=2)],
+        sparse_results=[rr("B", rank=1), rr("C", rank=2)],
+    )
+
+    assert ids(fused)[0] == "B"
+    assert fused[0].dense_rank == 2
+    assert fused[0].sparse_rank == 1
+    assert fused[0].dense_contribution == pytest.approx(1.0 / 62.0)
+    assert fused[0].sparse_contribution == pytest.approx(1.0 / 61.0)
+    assert fused[0].rrf_score == pytest.approx((1.0 / 62.0) + (1.0 / 61.0))
+    assert fused[0].best_rank == 1
+    assert fused[0].sources == frozenset({"dense", "sparse"})
+
+
+def test_score_is_preserved_nowhere_and_does_not_affect_ordering() -> None:
+    first = fuse(
+        dense_results=[rr("A", rank=1, score=0.01), rr("B", rank=2, score=999.0)],
+        sparse_results=[],
+    )
+    second = fuse(
+        dense_results=[rr("A", rank=1, score=999.0), rr("B", rank=2, score=0.01)],
+        sparse_results=[],
+    )
+
+    assert ids(first) == ["A", "B"]
+    assert ids(second) == ["A", "B"]
+    assert [result.to_dict() for result in first] == [
+        result.to_dict() for result in second
+    ]
+
+
+def test_duplicate_in_dense_or_sparse_counts_only_first_occurrence() -> None:
+    dense_duplicate = fuse(
+        dense_results=[rr("A", rank=3), rr("A", rank=1)],
+        sparse_results=[],
+    )
+    sparse_duplicate = fuse(
+        dense_results=[],
+        sparse_results=[rr("B", rank=4), rr("B", rank=1)],
+    )
+
+    assert len(dense_duplicate) == 1
+    assert dense_duplicate[0].dense_rank == 3
+    assert dense_duplicate[0].rrf_score == pytest.approx(1.0 / 63.0)
+    assert len(sparse_duplicate) == 1
+    assert sparse_duplicate[0].sparse_rank == 4
+    assert sparse_duplicate[0].rrf_score == pytest.approx(1.0 / 64.0)
+
+
+def test_first_seen_order_counts_accepted_candidates_not_duplicates() -> None:
+    fused = fuse(
+        dense_results=[rr("A", rank=1), rr("A", rank=2), rr("B", rank=3)],
+        sparse_results=[rr("C", rank=1)],
+    )
+    by_id = {result.result_id: result for result in fused}
+
+    assert by_id["A"].first_seen_order == 0
+    assert by_id["B"].first_seen_order == 1
+    assert by_id["C"].first_seen_order == 2
+
+
+def test_ablation_with_zero_weights_behaves_as_single_channel() -> None:
+    sparse_only = fuse(
+        dense_results=[rr("dense_only", rank=1)],
+        sparse_results=[rr("sparse_only", rank=1)],
+        profile=RRFWeightProfile(dense_weight=0.0, sparse_weight=1.0),
+    )
+    dense_only = fuse(
+        dense_results=[rr("dense_only", rank=1)],
+        sparse_results=[rr("sparse_only", rank=1)],
+        profile=RRFWeightProfile(dense_weight=1.0, sparse_weight=0.0),
+    )
+
+    assert ids(sparse_only) == ["sparse_only"]
+    assert sparse_only[0].sources == frozenset({"sparse"})
+    assert ids(dense_only) == ["dense_only"]
+    assert dense_only[0].sources == frozenset({"dense"})
+
+
+def test_determinism_across_repeated_calls() -> None:
+    dense = [rr("A", rank=1), rr("B", rank=2), rr("C", rank=3)]
+    sparse = [rr("C", rank=1), rr("B", rank=2), rr("D", rank=3)]
+
+    first = RRFFusion().fuse(dense_results=dense, sparse_results=sparse)
+    second = RRFFusion().fuse(dense_results=dense, sparse_results=sparse)
+
+    assert first == second
+
+
+def test_inputs_are_not_mutated() -> None:
+    dense = [rr("A", rank=1), rr("B", rank=2)]
+    sparse = [rr("B", rank=1), rr("C", rank=2)]
+    dense_before = list(dense)
+    sparse_before = list(sparse)
+
+    RRFFusion().fuse(dense_results=dense, sparse_results=sparse)
+
+    assert dense == dense_before
+    assert sparse == sparse_before
+
+
+def test_tie_breaks_by_best_rank_then_first_seen_then_result_id() -> None:
+    k = 60
+    best_rank_tie = fuse(
+        dense_results=[rr("A", rank=1)],
+        sparse_results=[rr("placeholder", rank=99), rr("B", rank=2)],
+        profile=RRFWeightProfile(
+            dense_weight=1.0,
+            sparse_weight=(k + 2) / (k + 1),
+            k=k,
+            name="best-rank-tie",
+        ),
+    )
+    assert ids(best_rank_tie).index("A") < ids(best_rank_tie).index("B")
+    assert best_rank_tie[0].rrf_score == pytest.approx(best_rank_tie[1].rrf_score)
+
+    first_seen_tie = fuse(
+        dense_results=[rr("A", rank=1)],
+        sparse_results=[rr("B", rank=1)],
+    )
+    assert ids(first_seen_tie) == ["A", "B"]
+    assert first_seen_tie[0].rrf_score == pytest.approx(first_seen_tie[1].rrf_score)
+    assert first_seen_tie[0].best_rank == first_seen_tie[1].best_rank
+
+    result_id_tie = sorted(
+        [
+            FusedResult(
+                result_id="b",
+                doc_id="doc-b",
+                rrf_score=1.0,
+                dense_rank=1,
+                sparse_rank=None,
+                dense_contribution=1.0,
+                sparse_contribution=0.0,
+                best_rank=1,
+                first_seen_order=0,
+                sources=frozenset({"dense"}),
+            ),
+            FusedResult(
+                result_id="a",
+                doc_id="doc-a",
+                rrf_score=1.0,
+                dense_rank=1,
+                sparse_rank=None,
+                dense_contribution=1.0,
+                sparse_contribution=0.0,
+                best_rank=1,
+                first_seen_order=0,
+                sources=frozenset({"dense"}),
+            ),
+        ],
+        key=fusion_module._fused_sort_key,  # noqa: SLF001
+    )
+    assert ids(result_id_tie) == ["a", "b"]
+
+
+def test_payload_selection_uses_best_rank_and_dense_wins_rank_tie() -> None:
+    dense_best = fuse(
+        dense_results=[rr("A", doc_id="doc-1", rank=1, payload={"source": "dense"})],
+        sparse_results=[rr("x", rank=1), rr("A", doc_id="doc-1", rank=2, payload={"source": "sparse"})],
+    )
+    sparse_best = fuse(
+        dense_results=[rr("A", doc_id="doc-1", rank=3, payload={"source": "dense"})],
+        sparse_results=[rr("A", doc_id="doc-1", rank=1, payload={"source": "sparse"})],
+    )
+    dense_tie = fuse(
+        dense_results=[rr("A", doc_id="doc-1", rank=1, payload={"source": "dense"})],
+        sparse_results=[rr("A", doc_id="doc-1", rank=1, payload={"source": "sparse"})],
+    )
+
+    assert dict(dense_best[0].payload) == {"source": "dense"}
+    assert dict(sparse_best[0].payload) == {"source": "sparse"}
+    assert dict(dense_tie[0].payload) == {"source": "dense"}
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    ["answer", "chunk_text", "embedding", "prompt", "text", "vector"],
+)
+def test_payload_rejects_sensitive_keys(bad_key: str) -> None:
+    with pytest.raises(ValueError, match="payload cannot contain sensitive keys"):
+        rr("A", payload={bad_key: "blocked"})
+
+
+def test_to_dict_is_stable_and_json_friendly() -> None:
+    result = fuse(
+        dense_results=[rr("A", doc_id="doc-1", rank=1, payload={"kind": "dense"})],
+        sparse_results=[],
+    )[0]
+
+    assert result.to_dict() == {
+        "result_id": "A",
+        "doc_id": "doc-1",
+        "rrf_score": pytest.approx(1.0 / 61.0),
+        "dense_rank": 1,
+        "sparse_rank": None,
+        "dense_contribution": pytest.approx(1.0 / 61.0),
+        "sparse_contribution": 0.0,
+        "best_rank": 1,
+        "first_seen_order": 0,
+        "sources": ["dense"],
+        "payload": {"kind": "dense"},
+    }
+
+
+def test_function_matches_wrapper_class() -> None:
+    profile = RRFWeightProfile(name="function-test")
+    dense = [rr("A", rank=1), rr("B", rank=2)]
+    sparse = [rr("B", rank=1), rr("C", rank=2)]
+
+    assert RRFFusion(profile=profile).fuse(dense_results=dense, sparse_results=sparse) == fuse(
+        dense_results=dense,
+        sparse_results=sparse,
+        profile=profile,
+    )
+
+
+def test_snapshot_fixed_weighted_rrf_output() -> None:
+    fused = fuse(
+        dense_results=[
+            rr("chunk-a", doc_id="doc-a", rank=1),
+            rr("chunk-b", doc_id="doc-b", rank=2),
+            rr("chunk-c", doc_id="doc-c", rank=3),
+        ],
+        sparse_results=[
+            rr("chunk-b", doc_id="doc-b", rank=1),
+            rr("chunk-d", doc_id="doc-d", rank=2),
+            rr("chunk-a", doc_id="doc-a", rank=3),
+        ],
+    )
+
+    assert [result.to_dict() for result in fused] == [
+        {
+            "result_id": "chunk-b",
+            "doc_id": "doc-b",
+            "rrf_score": pytest.approx((1.0 / 62.0) + (1.0 / 61.0)),
+            "dense_rank": 2,
+            "sparse_rank": 1,
+            "dense_contribution": pytest.approx(1.0 / 62.0),
+            "sparse_contribution": pytest.approx(1.0 / 61.0),
+            "best_rank": 1,
+            "first_seen_order": 1,
+            "sources": ["dense", "sparse"],
+            "payload": {},
+        },
+        {
+            "result_id": "chunk-a",
+            "doc_id": "doc-a",
+            "rrf_score": pytest.approx((1.0 / 61.0) + (1.0 / 63.0)),
+            "dense_rank": 1,
+            "sparse_rank": 3,
+            "dense_contribution": pytest.approx(1.0 / 61.0),
+            "sparse_contribution": pytest.approx(1.0 / 63.0),
+            "best_rank": 1,
+            "first_seen_order": 0,
+            "sources": ["dense", "sparse"],
+            "payload": {},
+        },
+        {
+            "result_id": "chunk-d",
+            "doc_id": "doc-d",
+            "rrf_score": pytest.approx(1.0 / 62.0),
+            "dense_rank": None,
+            "sparse_rank": 2,
+            "dense_contribution": 0.0,
+            "sparse_contribution": pytest.approx(1.0 / 62.0),
+            "best_rank": 2,
+            "first_seen_order": 3,
+            "sources": ["sparse"],
+            "payload": {},
+        },
+        {
+            "result_id": "chunk-c",
+            "doc_id": "doc-c",
+            "rrf_score": pytest.approx(1.0 / 63.0),
+            "dense_rank": 3,
+            "sparse_rank": None,
+            "dense_contribution": pytest.approx(1.0 / 63.0),
+            "sparse_contribution": 0.0,
+            "best_rank": 3,
+            "first_seen_order": 2,
+            "sources": ["dense"],
+            "payload": {},
+        },
+    ]

--- a/tests/unit/test_fusion.py
+++ b/tests/unit/test_fusion.py
@@ -89,6 +89,17 @@ def test_ranked_result_validates_rank_and_ids() -> None:
         rr("A", doc_id="doc\x00A")
 
 
+def test_ranked_result_rank_boundary_values() -> None:
+    valid = rr("A", rank=1)
+    assert valid.rank == 1
+
+    with pytest.raises(ValueError, match="rank must be >= 1"):
+        rr("A", rank=0)
+
+    with pytest.raises(ValueError, match="rank must be >= 1"):
+        rr("A", rank=-1)
+
+
 def test_ranked_result_is_frozen_and_payload_is_defensive_mapping() -> None:
     payload = {"source": "dense"}
     result = rr("A", payload=payload)
@@ -118,6 +129,24 @@ def test_rrf_weight_profile_defaults_and_validation() -> None:
     assert RRFWeightProfile(dense_weight=0.0).dense_weight == 0.0
     assert RRFWeightProfile(sparse_weight=0.0).sparse_weight == 0.0
     assert RRFWeightProfile(k=60.5).k == 60.5
+
+
+def test_rrf_weight_profile_bva_symmetric_and_k_boundary() -> None:
+    with pytest.raises(ValueError, match="RRF weights must be non-negative"):
+        RRFWeightProfile(sparse_weight=-0.1)
+
+    profile = RRFWeightProfile(k=1.0)
+    assert profile.k == 1.0
+
+    result = fuse(
+        dense_results=[rr("A", rank=1)],
+        sparse_results=[],
+        profile=profile,
+    )
+    assert result[0].rrf_score == pytest.approx(1.0 / 2.0)
+
+    with pytest.raises(ValueError, match="RRF k must be > 0"):
+        RRFWeightProfile(k=-1.0)
 
 
 def test_fuse_empty_and_single_channel_cases() -> None:
@@ -220,6 +249,22 @@ def test_conflicting_doc_id_for_same_result_id_fails() -> None:
             dense_results=[rr("chunk-1", doc_id="doc-a", rank=1)],
             sparse_results=[rr("chunk-1", doc_id="doc-b", rank=1)],
         )
+
+
+def test_two_chunks_same_doc_id_different_result_id_do_not_collapse() -> None:
+    """Checklist 2: result_id is the dedup key, not doc_id."""
+
+    fused = fuse(
+        dense_results=[
+            rr("chunk-1", doc_id="doc-a", rank=1),
+            rr("chunk-2", doc_id="doc-a", rank=2),
+        ],
+        sparse_results=[],
+    )
+
+    assert len(fused) == 2
+    assert {result.result_id for result in fused} == {"chunk-1", "chunk-2"}
+    assert {result.doc_id for result in fused} == {"doc-a"}
 
 
 def test_first_seen_order_uses_concatenated_input_position_even_with_duplicates() -> None:
@@ -449,31 +494,19 @@ def test_payload_selection_uses_best_rank_and_dense_wins_rank_tie() -> None:
     assert dict(dense_tie[0].payload) == {"source": "dense"}
 
 
-@pytest.mark.parametrize(
-    "bad_key",
-    [
-        "answer",
-        "chunk_text",
-        "content",
-        "dense_vector",
-        "embedding",
-        "messages",
-        "page_content",
-        "prompt",
-        "query",
-        "raw_text",
-        "sparse_vector",
-        "text",
-        "vector",
-        "Text",
-        "VECTOR",
-        "Embedding",
-        "Prompt",
-    ],
-)
-def test_payload_rejects_sensitive_keys(bad_key: str) -> None:
-    with pytest.raises(ValueError, match="payload cannot contain sensitive keys"):
-        rr("A", payload={bad_key: "blocked"})
+def test_payload_allows_schema_content_because_fusion_is_schema_agnostic() -> None:
+    result = rr(
+        "A",
+        payload={
+            "text": "chunk text belongs to retriever/schema layers",
+            "vector": [1.0, 2.0],
+        },
+    )
+
+    assert dict(result.payload) == {
+        "text": "chunk text belongs to retriever/schema layers",
+        "vector": [1.0, 2.0],
+    }
 
 
 def test_payload_rejects_non_string_keys() -> None:
@@ -538,6 +571,8 @@ def test_public_exports_include_benchmark_constants_and_helper() -> None:
         "SOURCE_SPARSE",
         "ranked_result_from_position",
     } <= set(fusion_module.__all__)
+    assert "DENSE_SOURCE" not in fusion_module.__all__
+    assert "SPARSE_SOURCE" not in fusion_module.__all__
 
 
 def test_snapshot_fixed_weighted_rrf_output() -> None:

--- a/tests/unit/test_fusion.py
+++ b/tests/unit/test_fusion.py
@@ -16,6 +16,8 @@ from backend.rag.fusion import (
     RRFFusion,
     RRFWeightProfile,
     RankedResult,
+    SOURCE_DENSE,
+    SOURCE_SPARSE,
     fuse,
 )
 
@@ -24,14 +26,14 @@ def rr(
     result_id: str,
     doc_id: str | None = None,
     rank: int = 1,
-    score: float | None = None,
+    raw_score: float | None = None,
     payload: Mapping[str, object] | None = None,
 ) -> RankedResult:
     return RankedResult(
         result_id=result_id,
         doc_id=result_id if doc_id is None else doc_id,
         rank=rank,
-        score=score,
+        raw_score=raw_score,
         payload={} if payload is None else payload,
     )
 
@@ -97,7 +99,7 @@ def test_ranked_result_is_frozen_and_payload_is_defensive_mapping() -> None:
 def test_rrf_weight_profile_defaults_and_validation() -> None:
     assert DEFAULT_PROFILE.dense_weight == 1.0
     assert DEFAULT_PROFILE.sparse_weight == 1.0
-    assert DEFAULT_PROFILE.k == 60
+    assert DEFAULT_PROFILE.k == 60.0
 
     with pytest.raises(ValueError, match="RRF weights must be non-negative"):
         RRFWeightProfile(dense_weight=-0.1)
@@ -110,6 +112,7 @@ def test_rrf_weight_profile_defaults_and_validation() -> None:
 
     assert RRFWeightProfile(dense_weight=0.0).dense_weight == 0.0
     assert RRFWeightProfile(sparse_weight=0.0).sparse_weight == 0.0
+    assert RRFWeightProfile(k=60.5).k == 60.5
 
 
 def test_fuse_empty_and_single_channel_cases() -> None:
@@ -119,13 +122,13 @@ def test_fuse_empty_and_single_channel_cases() -> None:
     assert ids(dense_only) == ["D"]
     assert dense_only[0].dense_rank == 2
     assert dense_only[0].sparse_rank is None
-    assert dense_only[0].sources == frozenset({"dense"})
+    assert dense_only[0].sources == frozenset({SOURCE_DENSE})
 
     sparse_only = fuse(dense_results=[], sparse_results=[rr("S", rank=3)])
     assert ids(sparse_only) == ["S"]
     assert sparse_only[0].dense_rank is None
     assert sparse_only[0].sparse_rank == 3
-    assert sparse_only[0].sources == frozenset({"sparse"})
+    assert sparse_only[0].sources == frozenset({SOURCE_SPARSE})
 
 
 def test_fuse_limit_validation_and_truncation() -> None:
@@ -154,23 +157,37 @@ def test_document_present_in_both_rankings_receives_two_contributions() -> None:
     assert fused[0].sparse_contribution == pytest.approx(1.0 / 61.0)
     assert fused[0].rrf_score == pytest.approx((1.0 / 62.0) + (1.0 / 61.0))
     assert fused[0].best_rank == 1
-    assert fused[0].sources == frozenset({"dense", "sparse"})
+    assert fused[0].sources == frozenset({SOURCE_DENSE, SOURCE_SPARSE})
+    assert fused[0].rrf_score == pytest.approx(
+        fused[0].dense_contribution + fused[0].sparse_contribution
+    )
 
 
-def test_score_is_preserved_nowhere_and_does_not_affect_ordering() -> None:
+def test_raw_score_is_diagnostic_and_does_not_affect_ordering() -> None:
     first = fuse(
-        dense_results=[rr("A", rank=1, score=0.01), rr("B", rank=2, score=999.0)],
+        dense_results=[
+            rr("A", rank=1, raw_score=0.01),
+            rr("B", rank=2, raw_score=999.0),
+        ],
         sparse_results=[],
     )
     second = fuse(
-        dense_results=[rr("A", rank=1, score=999.0), rr("B", rank=2, score=0.01)],
+        dense_results=[
+            rr("A", rank=1, raw_score=999.0),
+            rr("B", rank=2, raw_score=0.01),
+        ],
         sparse_results=[],
     )
 
     assert ids(first) == ["A", "B"]
     assert ids(second) == ["A", "B"]
-    assert [result.to_dict() for result in first] == [
-        result.to_dict() for result in second
+    assert first[0].dense_raw_score == 0.01
+    assert second[0].dense_raw_score == 999.0
+    assert [result.result_id for result in first] == [
+        result.result_id for result in second
+    ]
+    assert [result.rrf_score for result in first] == [
+        result.rrf_score for result in second
     ]
 
 
@@ -192,7 +209,15 @@ def test_duplicate_in_dense_or_sparse_counts_only_first_occurrence() -> None:
     assert sparse_duplicate[0].rrf_score == pytest.approx(1.0 / 64.0)
 
 
-def test_first_seen_order_counts_accepted_candidates_not_duplicates() -> None:
+def test_conflicting_doc_id_for_same_result_id_fails() -> None:
+    with pytest.raises(ValueError, match="conflicting doc_id for the same result_id"):
+        fuse(
+            dense_results=[rr("chunk-1", doc_id="doc-a", rank=1)],
+            sparse_results=[rr("chunk-1", doc_id="doc-b", rank=1)],
+        )
+
+
+def test_first_seen_order_uses_concatenated_dense_sparse_index() -> None:
     fused = fuse(
         dense_results=[rr("A", rank=1), rr("A", rank=2), rr("B", rank=3)],
         sparse_results=[rr("C", rank=1)],
@@ -200,8 +225,20 @@ def test_first_seen_order_counts_accepted_candidates_not_duplicates() -> None:
     by_id = {result.result_id: result for result in fused}
 
     assert by_id["A"].first_seen_order == 0
-    assert by_id["B"].first_seen_order == 1
-    assert by_id["C"].first_seen_order == 2
+    assert by_id["B"].first_seen_order == 2
+    assert by_id["C"].first_seen_order == 3
+
+
+def test_first_seen_order_respects_dense_sparse_boundary() -> None:
+    fused = fuse(
+        dense_results=[rr("a", rank=10), rr("x", rank=10), rr("y", rank=10)],
+        sparse_results=[rr("b", rank=1), rr("c", rank=2)],
+    )
+    by_id = {result.result_id: result for result in fused}
+
+    assert by_id["b"].first_seen_order == 3
+    assert by_id["c"].first_seen_order == 4
+    assert ids(fused).index("b") < ids(fused).index("c")
 
 
 def test_ablation_with_zero_weights_behaves_as_single_channel() -> None:
@@ -217,9 +254,33 @@ def test_ablation_with_zero_weights_behaves_as_single_channel() -> None:
     )
 
     assert ids(sparse_only) == ["sparse_only"]
-    assert sparse_only[0].sources == frozenset({"sparse"})
+    assert sparse_only[0].sources == frozenset({SOURCE_SPARSE})
     assert ids(dense_only) == ["dense_only"]
-    assert dense_only[0].sources == frozenset({"dense"})
+    assert dense_only[0].sources == frozenset({SOURCE_DENSE})
+
+
+def test_rrf_score_equals_sum_of_contributions_and_rank1_spot_check() -> None:
+    result = fuse(
+        dense_results=[rr("a", rank=1)],
+        sparse_results=[rr("a", rank=2)],
+        profile=DEFAULT_PROFILE,
+    )[0]
+
+    assert result.rrf_score == pytest.approx(
+        result.dense_contribution + result.sparse_contribution
+    )
+    assert result.dense_contribution == pytest.approx(1.0 / 61.0, abs=1e-15)
+    assert result.sparse_contribution == pytest.approx(1.0 / 62.0, abs=1e-15)
+
+
+def test_rank1_k60_weight1_contribution_is_correct() -> None:
+    result = fuse(
+        dense_results=[rr("x", rank=1, raw_score=1.0)],
+        sparse_results=[],
+        profile=DEFAULT_PROFILE,
+    )[0]
+
+    assert result.rrf_score == pytest.approx(1.0 / 61.0, abs=1e-15)
 
 
 def test_determinism_across_repeated_calls() -> None:
@@ -279,7 +340,7 @@ def test_tie_breaks_by_best_rank_then_first_seen_then_result_id() -> None:
                 sparse_contribution=0.0,
                 best_rank=1,
                 first_seen_order=0,
-                sources=frozenset({"dense"}),
+                sources=frozenset({SOURCE_DENSE}),
             ),
             FusedResult(
                 result_id="a",
@@ -291,7 +352,7 @@ def test_tie_breaks_by_best_rank_then_first_seen_then_result_id() -> None:
                 sparse_contribution=0.0,
                 best_rank=1,
                 first_seen_order=0,
-                sources=frozenset({"dense"}),
+                sources=frozenset({SOURCE_DENSE}),
             ),
         ],
         key=fusion_module._fused_sort_key,  # noqa: SLF001
@@ -299,10 +360,48 @@ def test_tie_breaks_by_best_rank_then_first_seen_then_result_id() -> None:
     assert ids(result_id_tie) == ["a", "b"]
 
 
+def test_fused_result_requires_sources_to_match_present_ranks() -> None:
+    with pytest.raises(ValueError, match="sources must match present source ranks"):
+        FusedResult(
+            result_id="a",
+            doc_id="doc-a",
+            rrf_score=1.0,
+            dense_rank=1,
+            sparse_rank=None,
+            dense_contribution=1.0,
+            sparse_contribution=0.0,
+            best_rank=1,
+            first_seen_order=0,
+            sources=frozenset({SOURCE_SPARSE}),
+        )
+
+
+def test_fused_result_requires_rrf_score_to_equal_contributions() -> None:
+    with pytest.raises(
+        ValueError,
+        match="rrf_score must equal dense_contribution",
+    ):
+        FusedResult(
+            result_id="a",
+            doc_id="doc-a",
+            rrf_score=0.5,
+            dense_rank=1,
+            sparse_rank=None,
+            dense_contribution=1.0,
+            sparse_contribution=0.0,
+            best_rank=1,
+            first_seen_order=0,
+            sources=frozenset({SOURCE_DENSE}),
+        )
+
+
 def test_payload_selection_uses_best_rank_and_dense_wins_rank_tie() -> None:
     dense_best = fuse(
         dense_results=[rr("A", doc_id="doc-1", rank=1, payload={"source": "dense"})],
-        sparse_results=[rr("x", rank=1), rr("A", doc_id="doc-1", rank=2, payload={"source": "sparse"})],
+        sparse_results=[
+            rr("x", rank=1),
+            rr("A", doc_id="doc-1", rank=2, payload={"source": "sparse"}),
+        ],
     )
     sparse_best = fuse(
         dense_results=[rr("A", doc_id="doc-1", rank=3, payload={"source": "dense"})],
@@ -320,7 +419,7 @@ def test_payload_selection_uses_best_rank_and_dense_wins_rank_tie() -> None:
 
 @pytest.mark.parametrize(
     "bad_key",
-    ["answer", "chunk_text", "embedding", "prompt", "text", "vector"],
+    ["answer", "chunk_text", "embedding", "prompt", "text", "vector", "Text", "VECTOR"],
 )
 def test_payload_rejects_sensitive_keys(bad_key: str) -> None:
     with pytest.raises(ValueError, match="payload cannot contain sensitive keys"):
@@ -329,7 +428,15 @@ def test_payload_rejects_sensitive_keys(bad_key: str) -> None:
 
 def test_to_dict_is_stable_and_json_friendly() -> None:
     result = fuse(
-        dense_results=[rr("A", doc_id="doc-1", rank=1, payload={"kind": "dense"})],
+        dense_results=[
+            rr(
+                "A",
+                doc_id="doc-1",
+                rank=1,
+                raw_score=0.99,
+                payload={"kind": "dense"},
+            )
+        ],
         sparse_results=[],
     )[0]
 
@@ -343,6 +450,8 @@ def test_to_dict_is_stable_and_json_friendly() -> None:
         "sparse_contribution": 0.0,
         "best_rank": 1,
         "first_seen_order": 0,
+        "dense_raw_score": 0.99,
+        "sparse_raw_score": None,
         "sources": ["dense"],
         "payload": {"kind": "dense"},
     }
@@ -353,7 +462,10 @@ def test_function_matches_wrapper_class() -> None:
     dense = [rr("A", rank=1), rr("B", rank=2)]
     sparse = [rr("B", rank=1), rr("C", rank=2)]
 
-    assert RRFFusion(profile=profile).fuse(dense_results=dense, sparse_results=sparse) == fuse(
+    assert RRFFusion(profile=profile).fuse(
+        dense_results=dense,
+        sparse_results=sparse,
+    ) == fuse(
         dense_results=dense,
         sparse_results=sparse,
         profile=profile,
@@ -385,6 +497,8 @@ def test_snapshot_fixed_weighted_rrf_output() -> None:
             "sparse_contribution": pytest.approx(1.0 / 61.0),
             "best_rank": 1,
             "first_seen_order": 1,
+            "dense_raw_score": None,
+            "sparse_raw_score": None,
             "sources": ["dense", "sparse"],
             "payload": {},
         },
@@ -398,6 +512,8 @@ def test_snapshot_fixed_weighted_rrf_output() -> None:
             "sparse_contribution": pytest.approx(1.0 / 63.0),
             "best_rank": 1,
             "first_seen_order": 0,
+            "dense_raw_score": None,
+            "sparse_raw_score": None,
             "sources": ["dense", "sparse"],
             "payload": {},
         },
@@ -410,7 +526,9 @@ def test_snapshot_fixed_weighted_rrf_output() -> None:
             "dense_contribution": 0.0,
             "sparse_contribution": pytest.approx(1.0 / 62.0),
             "best_rank": 2,
-            "first_seen_order": 3,
+            "first_seen_order": 4,
+            "dense_raw_score": None,
+            "sparse_raw_score": None,
             "sources": ["sparse"],
             "payload": {},
         },
@@ -424,6 +542,8 @@ def test_snapshot_fixed_weighted_rrf_output() -> None:
             "sparse_contribution": 0.0,
             "best_rank": 3,
             "first_seen_order": 2,
+            "dense_raw_score": None,
+            "sparse_raw_score": None,
             "sources": ["dense"],
             "payload": {},
         },

--- a/tests/unit/test_fusion.py
+++ b/tests/unit/test_fusion.py
@@ -6,12 +6,16 @@ import ast
 import inspect
 from collections.abc import Mapping
 from dataclasses import FrozenInstanceError
+from typing import cast
 
 import pytest
 
 import backend.rag.fusion as fusion_module
 from backend.rag.fusion import (
+    DEFAULT_DENSE_WEIGHT,
     DEFAULT_PROFILE,
+    DEFAULT_RRF_K,
+    DEFAULT_SPARSE_WEIGHT,
     FusedResult,
     RRFFusion,
     RRFWeightProfile,
@@ -19,6 +23,7 @@ from backend.rag.fusion import (
     SOURCE_DENSE,
     SOURCE_SPARSE,
     fuse,
+    ranked_result_from_position,
 )
 
 
@@ -97,9 +102,9 @@ def test_ranked_result_is_frozen_and_payload_is_defensive_mapping() -> None:
 
 
 def test_rrf_weight_profile_defaults_and_validation() -> None:
-    assert DEFAULT_PROFILE.dense_weight == 1.0
-    assert DEFAULT_PROFILE.sparse_weight == 1.0
-    assert DEFAULT_PROFILE.k == 60.0
+    assert DEFAULT_PROFILE.dense_weight == DEFAULT_DENSE_WEIGHT
+    assert DEFAULT_PROFILE.sparse_weight == DEFAULT_SPARSE_WEIGHT
+    assert DEFAULT_PROFILE.k == DEFAULT_RRF_K
 
     with pytest.raises(ValueError, match="RRF weights must be non-negative"):
         RRFWeightProfile(dense_weight=-0.1)
@@ -217,7 +222,7 @@ def test_conflicting_doc_id_for_same_result_id_fails() -> None:
         )
 
 
-def test_first_seen_order_uses_concatenated_dense_sparse_index() -> None:
+def test_first_seen_order_uses_concatenated_input_position_even_with_duplicates() -> None:
     fused = fuse(
         dense_results=[rr("A", rank=1), rr("A", rank=2), rr("B", rank=3)],
         sparse_results=[rr("C", rank=1)],
@@ -281,6 +286,33 @@ def test_rank1_k60_weight1_contribution_is_correct() -> None:
     )[0]
 
     assert result.rrf_score == pytest.approx(1.0 / 61.0, abs=1e-15)
+
+
+def test_ranked_result_from_position_assigns_one_based_rank() -> None:
+    result = ranked_result_from_position(
+        result_id="chunk-1",
+        doc_id="doc-1",
+        zero_based_position=2,
+        raw_score=0.42,
+        payload={"kind": "dense"},
+    )
+
+    assert result == rr(
+        "chunk-1",
+        doc_id="doc-1",
+        rank=3,
+        raw_score=0.42,
+        payload={"kind": "dense"},
+    )
+
+
+def test_ranked_result_from_position_rejects_negative_position() -> None:
+    with pytest.raises(ValueError, match="zero_based_position must be non-negative"):
+        ranked_result_from_position(
+            result_id="chunk-1",
+            doc_id="doc-1",
+            zero_based_position=-1,
+        )
 
 
 def test_determinism_across_repeated_calls() -> None:
@@ -419,11 +451,36 @@ def test_payload_selection_uses_best_rank_and_dense_wins_rank_tie() -> None:
 
 @pytest.mark.parametrize(
     "bad_key",
-    ["answer", "chunk_text", "embedding", "prompt", "text", "vector", "Text", "VECTOR"],
+    [
+        "answer",
+        "chunk_text",
+        "content",
+        "dense_vector",
+        "embedding",
+        "messages",
+        "page_content",
+        "prompt",
+        "query",
+        "raw_text",
+        "sparse_vector",
+        "text",
+        "vector",
+        "Text",
+        "VECTOR",
+        "Embedding",
+        "Prompt",
+    ],
 )
 def test_payload_rejects_sensitive_keys(bad_key: str) -> None:
     with pytest.raises(ValueError, match="payload cannot contain sensitive keys"):
         rr("A", payload={bad_key: "blocked"})
+
+
+def test_payload_rejects_non_string_keys() -> None:
+    payload = cast(Mapping[str, object], {1: "not-json-friendly"})
+
+    with pytest.raises(TypeError, match="payload keys must be strings"):
+        rr("A", payload=payload)
 
 
 def test_to_dict_is_stable_and_json_friendly() -> None:
@@ -470,6 +527,17 @@ def test_function_matches_wrapper_class() -> None:
         sparse_results=sparse,
         profile=profile,
     )
+
+
+def test_public_exports_include_benchmark_constants_and_helper() -> None:
+    assert {
+        "DEFAULT_RRF_K",
+        "DEFAULT_DENSE_WEIGHT",
+        "DEFAULT_SPARSE_WEIGHT",
+        "SOURCE_DENSE",
+        "SOURCE_SPARSE",
+        "ranked_result_from_position",
+    } <= set(fusion_module.__all__)
 
 
 def test_snapshot_fixed_weighted_rrf_output() -> None:


### PR DESCRIPTION
Closes #101

## Objetivo
Implementa o núcleo puro e determinístico de Weighted Reciprocal Rank Fusion para dense+sparse retrieval.

## Escopo
- Adiciona `backend/rag/fusion.py` com `RankedResult`, `RRFWeightProfile`, `FusedResult`, `fuse()` e `RRFFusion`.
- Adiciona `tests/unit/test_fusion.py` cobrindo pureza do módulo, validações, ablação, duplicatas, determinismo, desempates, payload e snapshot.

## Fora de escopo
- Sem Qdrant, HybridRetriever, async, I/O, logging, YAML, auto-tuning ou dependências externas.
- O arquivo untracked `Dockerfile.openclaw-sandbox` foi preservado fora deste PR.

## Validação
- `uv run pytest tests/unit/test_fusion.py -v` → 24 passed
- `uv run pytest tests/unit/ -v` → 814 passed, 253 subtests passed
- `uv run mypy --strict backend/rag/fusion.py tests/unit/test_fusion.py` → zero errors
- `uv run mypy --strict .` → zero errors
- `uv run pyright backend/rag/fusion.py tests/unit/test_fusion.py` → zero errors
- `uv run pyright` → zero errors
- `git diff --check` → clean
