### PR TITLE
[RAG-1A] PR 09 — Hybrid Ingest Script

### DIFF
--- a/docs/RAG_HYBRID_INGEST_PR09.md
+++ b/docs/RAG_HYBRID_INGEST_PR09.md
@@ -1,0 +1,114 @@
+# PR-09 Hybrid Ingest Handoff
+
+## Status
+
+PR-09 creates an offline-first hybrid ingest script for preparing points for
+`quimera_knowledge_v2`.
+
+The script does not create, delete, reset, migrate, or verify Qdrant
+collections. It prepares named-vector points and can call an injected upsert
+client only when `--execute` is explicitly enabled by a future integration
+layer.
+
+## Current Contract
+
+- Default collection: `quimera_knowledge_v2`.
+- Protected legacy collection: `quimera_knowledge`.
+- Dense vector name: `dense`.
+- Sparse vector name: `sparse`.
+- Dense dimensions: `1024`.
+- Default mode: dry-run.
+- Real execute mode is blocked in PR-09 CLI until a real upsert adapter is
+  explicitly wired in a later PR.
+- Point IDs are deterministic UUID strings derived from chunk content.
+- Payloads include metadata only, not chunk text or vectors.
+- Summary output is safe and does not include raw text, vectors, embeddings,
+  prompts, answers, or payload blobs.
+
+## Residual Risks
+
+### RISK-1: Collection Name Case Sensitivity
+
+`assert_collection_is_safe_for_ingest()` intentionally protects the exact legacy
+name after trimming whitespace. It does not casefold collection names.
+
+That means `quimera_knowledge` is blocked, while `QUIMERA_KNOWLEDGE` is treated
+as a different collection name.
+
+This is acceptable for PR-09 because Qdrant collection names are operational
+identifiers and the script should not silently rewrite operator input.
+
+PR-10 should decide whether the real Qdrant adapter should:
+
+- keep exact case-sensitive semantics, or
+- add an explicit denylist for known legacy aliases.
+
+### RISK-2: Sequential Embedding
+
+`embed_chunks()` embeds dense vectors for all chunks, then sparse vectors for
+all chunks. This is deliberately conservative and easy to test.
+
+With real local Qwen/Ollama embedding, this will be the main throughput
+bottleneck.
+
+PR-10 should introduce controlled concurrency with a semaphore, for example:
+
+```python
+async def bounded_embed(
+    chunks: Sequence[Chunk],
+    *,
+    concurrency: int,
+) -> list[EmbeddingResult]:
+    ...
+```
+
+The implementation must keep deterministic output ordering even when execution
+is concurrent.
+
+### RISK-3: Destination Schema Is Not Verified
+
+PR-09 checks that the target collection is not the protected legacy collection.
+It does not check that `quimera_knowledge_v2` exists or that it has the expected
+named vectors:
+
+- dense: 1024 dimensions, cosine
+- sparse: sparse vector without server-side IDF modifier
+
+PR-10 must add a preflight check in the real upsert adapter before sending any
+points:
+
+```python
+async def assert_hybrid_collection_ready(
+    *,
+    collection_name: str,
+    dense_vector_name: str,
+    sparse_vector_name: str,
+    dense_dimensions: int,
+) -> None:
+    ...
+```
+
+The preflight should fail before any upsert if the schema does not match.
+
+### RISK-4: Demo Sparse Embedder Is Not Production BM25
+
+`_DeterministicSparseEmbedder` is only for dry-run demos and tests. It now emits
+unique sparse indices, but it is not BM25 and must not be used as production
+retrieval semantics.
+
+PR-10 should wire the real sparse embedder from the sparse component and keep
+the deterministic embedder only for tests/dry-run demos.
+
+## PR-10 Recommendations
+
+1. Add a real Qdrant upsert adapter that only calls `upsert`.
+2. Add schema preflight before any upload.
+3. Keep `dry-run` as the default path.
+4. Require explicit `--execute` plus a real adapter for upload.
+5. Keep legacy collection protection in both script and adapter.
+6. Add bounded concurrency for embedding with stable output order.
+7. Keep summaries content-free and vector-free.
+8. Add an integration smoke test guarded by an environment variable.
+9. Do not add collection creation/deletion to the ingest script.
+10. Keep payload text out of PR-09 ingest payloads; retrieval payload policy
+    should remain owned by the store/retriever integration layer.

--- a/scripts/rag_ingest_hybrid.py
+++ b/scripts/rag_ingest_hybrid.py
@@ -1,0 +1,863 @@
+"""Hybrid ingest CLI for QUIMERA / OPENCLAW RAG.
+
+This script prepares dense + sparse named-vector points for
+``quimera_knowledge_v2``. It is conservative by design:
+
+- dry-run is the default
+- the legacy collection is protected
+- no collection is created or deleted
+- summaries never include raw text, vectors, embeddings, prompts, answers, or
+  payload blobs
+
+The core functions are pure and testable offline. A real Qdrant adapter can be
+attached later through ``HybridUpsertClientProtocol`` without changing the
+preparation contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import sys
+import time
+import uuid
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Protocol, TypeVar
+
+HYBRID_COLLECTION_NAME = "quimera_knowledge_v2"
+LEGACY_COLLECTION_NAME = "quimera_knowledge"
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+
+DEFAULT_EMBEDDING_MODEL = "Qwen/Qwen3-Embedding-0.6B"
+DEFAULT_EMBEDDING_PROVIDER = "local"
+DEFAULT_EMBEDDING_DIMENSIONS = 1024
+DEFAULT_EMBEDDING_VERSION = "qwen3-embedding-0.6b@pending-local"
+SCHEMA_VERSION = "qdrant-hybrid-v2"
+
+DEFAULT_BATCH_SIZE = 32
+MAX_BATCH_SIZE = 256
+
+PROTECTED_COLLECTIONS = frozenset({LEGACY_COLLECTION_NAME})
+
+FORBIDDEN_SUMMARY_KEYS = frozenset(
+    {
+        "text",
+        "chunk_text",
+        "raw_text",
+        "content",
+        "page_content",
+        "vector",
+        "vectors",
+        "dense_vector",
+        "sparse_vector",
+        "embedding",
+        "embeddings",
+        "prompt",
+        "answer",
+        "payload",
+    }
+)
+
+T = TypeVar("T")
+
+
+class HybridIngestError(RuntimeError):
+    """Sanitized ingest failure."""
+
+
+class ClockProtocol(Protocol):
+    def perf_counter(self) -> float: ...
+
+
+class DenseEmbedderProtocol(Protocol):
+    async def embed(self, text: str) -> Sequence[float]: ...
+
+
+class SparseEmbedderProtocol(Protocol):
+    async def embed(self, text: str) -> "SparseVector": ...
+
+
+class HybridUpsertClientProtocol(Protocol):
+    async def upsert_points(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence["HybridIngestPoint"],
+    ) -> None: ...
+
+
+class _PerfCounterClock:
+    def perf_counter(self) -> float:
+        return time.perf_counter()
+
+
+@dataclass(frozen=True, slots=True)
+class Document:
+    doc_id: str
+    text: str
+    source: str = "synthetic"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "doc_id", _validate_text(self.doc_id, "doc_id"))
+        object.__setattr__(self, "text", _validate_text(self.text, "text"))
+        object.__setattr__(self, "source", _validate_text(self.source, "source"))
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    doc_id: str
+    chunk_id: str
+    chunk_index: int
+    text: str
+    source: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "doc_id", _validate_text(self.doc_id, "doc_id"))
+        object.__setattr__(self, "chunk_id", _validate_text(self.chunk_id, "chunk_id"))
+        object.__setattr__(self, "chunk_index", _validate_non_negative_int(self.chunk_index, "chunk_index"))
+        object.__setattr__(self, "text", _validate_text(self.text, "text"))
+        object.__setattr__(self, "source", _validate_text(self.source, "source"))
+
+
+@dataclass(frozen=True, slots=True)
+class SparseVector:
+    indices: tuple[int, ...]
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        indices = tuple(_validate_sparse_index(index) for index in self.indices)
+        values = tuple(_validate_finite_number(value, "sparse value") for value in self.values)
+        if len(indices) != len(values):
+            raise ValueError("sparse indices and values must have the same length")
+        object.__setattr__(self, "indices", indices)
+        object.__setattr__(self, "values", values)
+
+
+@dataclass(frozen=True, slots=True)
+class HybridIngestPoint:
+    point_id: str
+    dense_vector: tuple[float, ...]
+    sparse_indices: tuple[int, ...]
+    sparse_values: tuple[float, ...]
+    payload: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "point_id", _validate_text(self.point_id, "point_id"))
+        object.__setattr__(
+            self,
+            "dense_vector",
+            tuple(_validate_finite_number(value, "dense value") for value in self.dense_vector),
+        )
+        sparse = SparseVector(indices=self.sparse_indices, values=self.sparse_values)
+        object.__setattr__(self, "sparse_indices", sparse.indices)
+        object.__setattr__(self, "sparse_values", sparse.values)
+        object.__setattr__(self, "payload", _freeze_payload(self.payload))
+
+    def to_qdrant_vector_dict(self) -> dict[str, object]:
+        """Return the conceptual named-vector shape expected by Qdrant."""
+
+        return {
+            DENSE_VECTOR_NAME: list(self.dense_vector),
+            SPARSE_VECTOR_NAME: {
+                "indices": list(self.sparse_indices),
+                "values": list(self.sparse_values),
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HybridIngestSummary:
+    collection_name: str
+    documents_count: int
+    chunks_count: int
+    points_prepared: int
+    points_sent: int
+    batches_sent: int
+    dense_ms: float
+    sparse_ms: float
+    upload_ms: float
+    total_ms: float
+    dry_run: bool
+    embedding_model: str
+    embedding_provider: str
+    embedding_dimensions: int
+    embedding_version: str
+    dense_vector_name: str
+    sparse_vector_name: str
+    batch_size: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "collection_name", _validate_text(self.collection_name, "collection_name"))
+        for field_name in (
+            "documents_count",
+            "chunks_count",
+            "points_prepared",
+            "points_sent",
+            "batches_sent",
+        ):
+            object.__setattr__(self, field_name, _validate_non_negative_int(getattr(self, field_name), field_name))
+        for field_name in ("dense_ms", "sparse_ms", "upload_ms", "total_ms"):
+            object.__setattr__(self, field_name, _validate_non_negative_float(getattr(self, field_name), field_name))
+        metadata = validate_embedding_metadata(
+            embedding_model=self.embedding_model,
+            embedding_provider=self.embedding_provider,
+            embedding_dimensions=self.embedding_dimensions,
+            embedding_version=self.embedding_version,
+            dense_vector_name=self.dense_vector_name,
+            sparse_vector_name=self.sparse_vector_name,
+        )
+        object.__setattr__(self, "embedding_model", metadata.embedding_model)
+        object.__setattr__(self, "embedding_provider", metadata.embedding_provider)
+        object.__setattr__(self, "embedding_dimensions", metadata.embedding_dimensions)
+        object.__setattr__(self, "embedding_version", metadata.embedding_version)
+        object.__setattr__(self, "dense_vector_name", metadata.dense_vector_name)
+        object.__setattr__(self, "sparse_vector_name", metadata.sparse_vector_name)
+        object.__setattr__(self, "batch_size", _validate_batch_size(self.batch_size))
+
+    def to_safe_dict(self) -> dict[str, object]:
+        """Return a stable summary that never exposes raw content or vectors."""
+
+        summary: dict[str, object] = {
+            "collection_name": self.collection_name,
+            "documents_count": self.documents_count,
+            "chunks_count": self.chunks_count,
+            "points_prepared": self.points_prepared,
+            "points_sent": self.points_sent,
+            "batches_sent": self.batches_sent,
+            "dense_ms": self.dense_ms,
+            "sparse_ms": self.sparse_ms,
+            "upload_ms": self.upload_ms,
+            "total_ms": self.total_ms,
+            "dry_run": self.dry_run,
+            "embedding_model": self.embedding_model,
+            "embedding_provider": self.embedding_provider,
+            "embedding_dimensions": self.embedding_dimensions,
+            "embedding_version": self.embedding_version,
+            "dense_vector_name": self.dense_vector_name,
+            "sparse_vector_name": self.sparse_vector_name,
+            "batch_size": self.batch_size,
+        }
+        forbidden = FORBIDDEN_SUMMARY_KEYS.intersection(summary)
+        if forbidden:
+            raise RuntimeError(f"unsafe summary keys: {sorted(forbidden)}")
+        return summary
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingMetadata:
+    embedding_model: str
+    embedding_provider: str
+    embedding_dimensions: int
+    embedding_version: str
+    dense_vector_name: str
+    sparse_vector_name: str
+
+
+def _validate_text(value: str, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if "\x00" in value:
+        raise ValueError(f"{field_name} cannot contain null bytes")
+    clean = value.strip()
+    if not clean:
+        raise ValueError(f"{field_name} cannot be empty")
+    return clean
+
+
+def _validate_non_negative_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return value
+
+
+def _validate_positive_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 1:
+        raise ValueError(f"{field_name} must be >= 1")
+    return value
+
+
+def _validate_finite_number(value: float, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field_name} must be numeric")
+    clean = float(value)
+    if not math.isfinite(clean):
+        raise ValueError(f"{field_name} must be finite")
+    return clean
+
+
+def _validate_non_negative_float(value: float, field_name: str) -> float:
+    clean = _validate_finite_number(value, field_name)
+    if clean < 0.0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return clean
+
+
+def _validate_sparse_index(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("sparse index must be an integer")
+    if value < 0:
+        raise ValueError("sparse index must be non-negative")
+    return value
+
+
+def _validate_optional_positive_int(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _validate_positive_int(value, field_name)
+
+
+def _validate_batch_size(batch_size: int) -> int:
+    clean = _validate_positive_int(batch_size, "batch_size")
+    if clean > MAX_BATCH_SIZE:
+        raise ValueError(f"batch_size must be <= {MAX_BATCH_SIZE}")
+    return clean
+
+
+def _freeze_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
+    clean_payload: dict[str, object] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise TypeError("payload keys must be strings")
+        clean_payload[key] = value
+    return MappingProxyType(clean_payload)
+
+
+def make_chunk_id(doc_id: str, chunk_index: int, text: str) -> str:
+    clean_doc_id = _validate_text(doc_id, "doc_id")
+    clean_index = _validate_non_negative_int(chunk_index, "chunk_index")
+    clean_text = _validate_text(text, "text")
+    raw = f"{clean_doc_id}\n{clean_index}\n{clean_text}".encode("utf-8")
+    digest = hashlib.sha256(raw).hexdigest()
+    return str(uuid.UUID(hex=digest[:32]))
+
+
+def chunk_document(
+    document: Document,
+    *,
+    max_chars: int = 1200,
+    overlap_chars: int = 0,
+) -> list[Chunk]:
+    clean_max_chars = _validate_positive_int(max_chars, "max_chars")
+    clean_overlap = _validate_non_negative_int(overlap_chars, "overlap_chars")
+    if clean_overlap >= clean_max_chars:
+        raise ValueError("overlap_chars must be < max_chars")
+
+    step = clean_max_chars - clean_overlap
+    chunks: list[Chunk] = []
+    start = 0
+    index = 0
+    text = document.text
+    while start < len(text):
+        raw_chunk = text[start : start + clean_max_chars].strip()
+        if raw_chunk:
+            chunks.append(
+                Chunk(
+                    doc_id=document.doc_id,
+                    chunk_id=make_chunk_id(document.doc_id, index, raw_chunk),
+                    chunk_index=index,
+                    text=raw_chunk,
+                    source=document.source,
+                )
+            )
+            index += 1
+        start += step
+    return chunks
+
+
+def generate_synthetic_corpus() -> list[Document]:
+    """Return small safe documents for dry-run demos and offline tests."""
+
+    return [
+        Document(
+            doc_id="synthetic-selic",
+            source="synthetic",
+            text="Selic is a benchmark interest-rate concept used in Brazilian financial examples.",
+        ),
+        Document(
+            doc_id="synthetic-fii",
+            source="synthetic",
+            text="Real estate funds can be represented as safe synthetic examples for retrieval tests.",
+        ),
+        Document(
+            doc_id="synthetic-risk",
+            source="synthetic",
+            text="Portfolio risk examples in this corpus are synthetic and contain no private data.",
+        ),
+    ]
+
+
+def load_corpus_from_path(path: Path, *, max_documents: int | None = None) -> list[Document]:
+    clean_max_documents = _validate_optional_positive_int(max_documents, "max_documents")
+    if not path.exists():
+        raise FileNotFoundError(f"corpus path does not exist: {path}")
+
+    files: list[Path]
+    if path.is_file():
+        if path.suffix.casefold() != ".txt":
+            raise ValueError("corpus file must be .txt")
+        files = [path]
+        base = path.parent
+    else:
+        files = sorted(candidate for candidate in path.rglob("*.txt") if candidate.is_file())
+        base = path
+
+    if clean_max_documents is not None:
+        files = files[:clean_max_documents]
+
+    documents: list[Document] = []
+    for file_path in files:
+        text = file_path.read_text(encoding="utf-8").strip()
+        if not text:
+            continue
+        documents.append(
+            Document(
+                doc_id=_doc_id_from_path(base, file_path),
+                text=text,
+                source=str(file_path.relative_to(base)),
+            )
+        )
+    return documents
+
+
+def _doc_id_from_path(base: Path, file_path: Path) -> str:
+    relative = file_path.relative_to(base).as_posix()
+    digest = hashlib.sha256(relative.encode("utf-8")).hexdigest()[:16]
+    stem = file_path.stem.strip() or "document"
+    return f"{stem}-{digest}"
+
+
+def validate_embedding_metadata(
+    *,
+    embedding_model: str,
+    embedding_provider: str,
+    embedding_dimensions: int,
+    embedding_version: str,
+    dense_vector_name: str,
+    sparse_vector_name: str,
+) -> EmbeddingMetadata:
+    clean_dense = _validate_text(dense_vector_name, "dense_vector_name")
+    clean_sparse = _validate_text(sparse_vector_name, "sparse_vector_name")
+    if clean_dense == clean_sparse:
+        raise ValueError("dense_vector_name and sparse_vector_name must differ")
+    return EmbeddingMetadata(
+        embedding_model=_validate_text(embedding_model, "embedding_model"),
+        embedding_provider=_validate_text(embedding_provider, "embedding_provider"),
+        embedding_dimensions=_validate_positive_int(embedding_dimensions, "embedding_dimensions"),
+        embedding_version=_validate_text(embedding_version, "embedding_version"),
+        dense_vector_name=clean_dense,
+        sparse_vector_name=clean_sparse,
+    )
+
+
+def validate_dense_vector(vector: Sequence[float], *, embedding_dimensions: int) -> tuple[float, ...]:
+    expected = _validate_positive_int(embedding_dimensions, "embedding_dimensions")
+    clean = tuple(_validate_finite_number(value, "dense value") for value in vector)
+    if len(clean) != expected:
+        raise ValueError(f"dense vector has {len(clean)} dimensions; expected {expected}")
+    return clean
+
+
+def validate_sparse_vector(vector: SparseVector, *, allow_empty_sparse: bool = False) -> SparseVector:
+    clean = SparseVector(indices=vector.indices, values=vector.values)
+    if not allow_empty_sparse and not clean.indices:
+        raise ValueError("sparse vector cannot be empty")
+    return clean
+
+
+def build_payload(
+    *,
+    chunk: Chunk,
+    embedding_model: str,
+    embedding_provider: str,
+    embedding_dimensions: int,
+    embedding_version: str,
+    dense_vector_name: str,
+    sparse_vector_name: str,
+) -> Mapping[str, object]:
+    return MappingProxyType(
+        {
+            "doc_id": chunk.doc_id,
+            "chunk_id": chunk.chunk_id,
+            "chunk_index": chunk.chunk_index,
+            "source": chunk.source,
+            "embedding_model": embedding_model,
+            "embedding_provider": embedding_provider,
+            "embedding_dimensions": embedding_dimensions,
+            "embedding_version": embedding_version,
+            "dense_vector_name": dense_vector_name,
+            "sparse_vector_name": sparse_vector_name,
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+
+
+def prepare_hybrid_points(
+    *,
+    chunks: Sequence[Chunk],
+    dense_vectors: Sequence[Sequence[float]],
+    sparse_vectors: Sequence[SparseVector],
+    embedding_model: str,
+    embedding_provider: str,
+    embedding_dimensions: int,
+    embedding_version: str,
+    dense_vector_name: str = DENSE_VECTOR_NAME,
+    sparse_vector_name: str = SPARSE_VECTOR_NAME,
+    allow_empty_sparse: bool = False,
+) -> list[HybridIngestPoint]:
+    if len(chunks) != len(dense_vectors) or len(chunks) != len(sparse_vectors):
+        raise ValueError("chunks, dense_vectors, and sparse_vectors must have the same length")
+
+    metadata = validate_embedding_metadata(
+        embedding_model=embedding_model,
+        embedding_provider=embedding_provider,
+        embedding_dimensions=embedding_dimensions,
+        embedding_version=embedding_version,
+        dense_vector_name=dense_vector_name,
+        sparse_vector_name=sparse_vector_name,
+    )
+    dimensions = metadata.embedding_dimensions
+
+    points: list[HybridIngestPoint] = []
+    for chunk, dense_vector, sparse_vector in zip(chunks, dense_vectors, sparse_vectors, strict=True):
+        clean_dense = validate_dense_vector(dense_vector, embedding_dimensions=dimensions)
+        clean_sparse = validate_sparse_vector(sparse_vector, allow_empty_sparse=allow_empty_sparse)
+        payload = build_payload(
+            chunk=chunk,
+            embedding_model=metadata.embedding_model,
+            embedding_provider=metadata.embedding_provider,
+            embedding_dimensions=dimensions,
+            embedding_version=metadata.embedding_version,
+            dense_vector_name=metadata.dense_vector_name,
+            sparse_vector_name=metadata.sparse_vector_name,
+        )
+        points.append(
+            HybridIngestPoint(
+                point_id=chunk.chunk_id,
+                dense_vector=clean_dense,
+                sparse_indices=clean_sparse.indices,
+                sparse_values=clean_sparse.values,
+                payload=payload,
+            )
+        )
+    return points
+
+
+async def embed_chunks(
+    *,
+    chunks: Sequence[Chunk],
+    dense_embedder: DenseEmbedderProtocol,
+    sparse_embedder: SparseEmbedderProtocol,
+    clock: ClockProtocol,
+) -> tuple[list[list[float]], list[SparseVector], float, float]:
+    dense_start = clock.perf_counter()
+    dense_vectors: list[list[float]] = []
+    try:
+        for chunk in chunks:
+            dense_vectors.append(list(await dense_embedder.embed(chunk.text)))
+    except Exception as exc:
+        raise HybridIngestError("dense embedding failed during hybrid ingest") from exc
+    dense_ms = _elapsed_ms(dense_start, clock.perf_counter())
+
+    sparse_start = clock.perf_counter()
+    sparse_vectors: list[SparseVector] = []
+    try:
+        for chunk in chunks:
+            sparse_vectors.append(await sparse_embedder.embed(chunk.text))
+    except Exception as exc:
+        raise HybridIngestError("sparse embedding failed during hybrid ingest") from exc
+    sparse_ms = _elapsed_ms(sparse_start, clock.perf_counter())
+
+    return dense_vectors, sparse_vectors, dense_ms, sparse_ms
+
+
+def batched(items: Sequence[T], batch_size: int) -> Iterator[list[T]]:
+    clean_batch_size = _validate_batch_size(batch_size)
+    for start in range(0, len(items), clean_batch_size):
+        yield list(items[start : start + clean_batch_size])
+
+
+def assert_collection_is_safe_for_ingest(collection_name: str) -> str:
+    clean = _validate_text(collection_name, "collection_name")
+    if clean in PROTECTED_COLLECTIONS:
+        raise HybridIngestError(f"collection {clean!r} is protected and cannot be used for hybrid ingest")
+    return clean
+
+
+async def upload_hybrid_points(
+    *,
+    client: HybridUpsertClientProtocol,
+    collection_name: str,
+    points: Sequence[HybridIngestPoint],
+    batch_size: int,
+    dry_run: bool,
+    clock: ClockProtocol,
+) -> tuple[int, int, float]:
+    clean_collection = assert_collection_is_safe_for_ingest(collection_name)
+    clean_batch_size = _validate_batch_size(batch_size)
+    start = clock.perf_counter()
+    if dry_run:
+        return 0, 0, _elapsed_ms(start, clock.perf_counter())
+
+    points_sent = 0
+    batches_sent = 0
+    try:
+        for batch in batched(points, clean_batch_size):
+            if not batch:
+                continue
+            await client.upsert_points(collection_name=clean_collection, points=batch)
+            points_sent += len(batch)
+            batches_sent += 1
+    except Exception as exc:
+        raise HybridIngestError("hybrid point upload failed") from exc
+    return points_sent, batches_sent, _elapsed_ms(start, clock.perf_counter())
+
+
+async def run_ingest(
+    *,
+    documents: Sequence[Document],
+    dense_embedder: DenseEmbedderProtocol,
+    sparse_embedder: SparseEmbedderProtocol,
+    upsert_client: HybridUpsertClientProtocol,
+    collection_name: str = HYBRID_COLLECTION_NAME,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = True,
+    max_chunks: int | None = None,
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL,
+    embedding_provider: str = DEFAULT_EMBEDDING_PROVIDER,
+    embedding_dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS,
+    embedding_version: str = DEFAULT_EMBEDDING_VERSION,
+    clock: ClockProtocol | None = None,
+) -> HybridIngestSummary:
+    active_clock = clock if clock is not None else _PerfCounterClock()
+    total_start = active_clock.perf_counter()
+    clean_collection = assert_collection_is_safe_for_ingest(collection_name)
+    clean_batch_size = _validate_batch_size(batch_size)
+    clean_max_chunks = _validate_optional_positive_int(max_chunks, "max_chunks")
+    metadata = validate_embedding_metadata(
+        embedding_model=embedding_model,
+        embedding_provider=embedding_provider,
+        embedding_dimensions=embedding_dimensions,
+        embedding_version=embedding_version,
+        dense_vector_name=DENSE_VECTOR_NAME,
+        sparse_vector_name=SPARSE_VECTOR_NAME,
+    )
+
+    chunks: list[Chunk] = []
+    for document in documents:
+        chunks.extend(chunk_document(document))
+    if clean_max_chunks is not None:
+        chunks = chunks[:clean_max_chunks]
+
+    dense_ms = 0.0
+    sparse_ms = 0.0
+    points: list[HybridIngestPoint] = []
+    if chunks:
+        dense_vectors, sparse_vectors, dense_ms, sparse_ms = await embed_chunks(
+            chunks=chunks,
+            dense_embedder=dense_embedder,
+            sparse_embedder=sparse_embedder,
+            clock=active_clock,
+        )
+        points = prepare_hybrid_points(
+            chunks=chunks,
+            dense_vectors=dense_vectors,
+            sparse_vectors=sparse_vectors,
+            embedding_model=metadata.embedding_model,
+            embedding_provider=metadata.embedding_provider,
+            embedding_dimensions=metadata.embedding_dimensions,
+            embedding_version=metadata.embedding_version,
+            dense_vector_name=metadata.dense_vector_name,
+            sparse_vector_name=metadata.sparse_vector_name,
+        )
+
+    points_sent, batches_sent, upload_ms = await upload_hybrid_points(
+        client=upsert_client,
+        collection_name=clean_collection,
+        points=points,
+        batch_size=clean_batch_size,
+        dry_run=dry_run,
+        clock=active_clock,
+    )
+    total_ms = _elapsed_ms(total_start, active_clock.perf_counter())
+    return HybridIngestSummary(
+        collection_name=clean_collection,
+        documents_count=len(documents),
+        chunks_count=len(chunks),
+        points_prepared=len(points),
+        points_sent=points_sent,
+        batches_sent=batches_sent,
+        dense_ms=dense_ms,
+        sparse_ms=sparse_ms,
+        upload_ms=upload_ms,
+        total_ms=total_ms,
+        dry_run=dry_run,
+        embedding_model=metadata.embedding_model,
+        embedding_provider=metadata.embedding_provider,
+        embedding_dimensions=metadata.embedding_dimensions,
+        embedding_version=metadata.embedding_version,
+        dense_vector_name=metadata.dense_vector_name,
+        sparse_vector_name=metadata.sparse_vector_name,
+        batch_size=clean_batch_size,
+    )
+
+
+def _elapsed_ms(start: float, end: float) -> float:
+    raw = (end - start) * 1000.0
+    if not math.isfinite(raw):
+        raise ValueError("latency must be finite")
+    return max(0.0, raw)
+
+
+class _DeterministicDenseEmbedder:
+    async def embed(self, text: str) -> Sequence[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        base = [((digest[index % len(digest)] / 255.0) * 2.0) - 1.0 for index in range(16)]
+        repeats = (DEFAULT_EMBEDDING_DIMENSIONS + len(base) - 1) // len(base)
+        return (base * repeats)[:DEFAULT_EMBEDDING_DIMENSIONS]
+
+
+class _DeterministicSparseEmbedder:
+    async def embed(self, text: str) -> SparseVector:
+        seen: set[int] = set()
+        indices: list[int] = []
+        counter = 0
+        while len(indices) < 4:
+            digest = hashlib.sha256(f"{text}\n{counter}".encode("utf-8")).digest()
+            candidate = int.from_bytes(digest[:4], byteorder="big") % 65_536
+            if candidate not in seen:
+                seen.add(candidate)
+                indices.append(candidate)
+            counter += 1
+        values = tuple(1.0 / float(index + 1) for index in range(len(indices)))
+        return SparseVector(indices=tuple(indices), values=values)
+
+
+class _DryRunUpsertClient:
+    async def upsert_points(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[HybridIngestPoint],
+    ) -> None:
+        raise HybridIngestError("execute mode requires an explicit real upsert client")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare hybrid dense+sparse ingest points.")
+    parser.add_argument("--corpus-path", type=Path)
+    parser.add_argument("--collection", default=HYBRID_COLLECTION_NAME)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument("--max-documents", type=int)
+    parser.add_argument("--max-chunks", type=int)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--embedding-model", default=DEFAULT_EMBEDDING_MODEL)
+    parser.add_argument("--embedding-provider", default=DEFAULT_EMBEDDING_PROVIDER)
+    parser.add_argument("--embedding-dimensions", type=int, default=DEFAULT_EMBEDDING_DIMENSIONS)
+    parser.add_argument("--embedding-version", default=DEFAULT_EMBEDDING_VERSION)
+    parser.add_argument("--synthetic", action="store_true")
+    return parser
+
+
+def _load_documents_for_cli(args: argparse.Namespace) -> list[Document]:
+    if args.corpus_path is not None:
+        return load_corpus_from_path(args.corpus_path, max_documents=args.max_documents)
+    if args.synthetic:
+        documents = generate_synthetic_corpus()
+        if args.max_documents is not None:
+            documents = documents[: _validate_positive_int(args.max_documents, "max_documents")]
+        return documents
+    raise HybridIngestError("provide --synthetic or --corpus-path")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    dry_run = not args.execute
+    if args.dry_run:
+        dry_run = True
+
+    try:
+        if args.execute:
+            raise HybridIngestError("execute mode is not wired to a real upsert client in PR-09")
+        documents = _load_documents_for_cli(args)
+        summary = asyncio.run(
+            run_ingest(
+                documents=documents,
+                dense_embedder=_DeterministicDenseEmbedder(),
+                sparse_embedder=_DeterministicSparseEmbedder(),
+                upsert_client=_DryRunUpsertClient(),
+                collection_name=args.collection,
+                batch_size=args.batch_size,
+                dry_run=dry_run,
+                max_chunks=args.max_chunks,
+                embedding_model=args.embedding_model,
+                embedding_provider=args.embedding_provider,
+                embedding_dimensions=args.embedding_dimensions,
+                embedding_version=args.embedding_version,
+            )
+        )
+        sys.stdout.write(json.dumps(summary.to_safe_dict(), indent=2, ensure_ascii=False))
+        sys.stdout.write("\n")
+        return 0
+    except Exception as exc:
+        sys.stderr.write(f"hybrid ingest failed: {exc.__class__.__name__}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "HYBRID_COLLECTION_NAME",
+    "LEGACY_COLLECTION_NAME",
+    "DENSE_VECTOR_NAME",
+    "SPARSE_VECTOR_NAME",
+    "DEFAULT_EMBEDDING_MODEL",
+    "DEFAULT_EMBEDDING_PROVIDER",
+    "DEFAULT_EMBEDDING_DIMENSIONS",
+    "DEFAULT_EMBEDDING_VERSION",
+    "DEFAULT_BATCH_SIZE",
+    "MAX_BATCH_SIZE",
+    "PROTECTED_COLLECTIONS",
+    "FORBIDDEN_SUMMARY_KEYS",
+    "HybridIngestError",
+    "Document",
+    "Chunk",
+    "SparseVector",
+    "EmbeddingMetadata",
+    "HybridIngestPoint",
+    "HybridIngestSummary",
+    "DenseEmbedderProtocol",
+    "SparseEmbedderProtocol",
+    "HybridUpsertClientProtocol",
+    "ClockProtocol",
+    "make_chunk_id",
+    "chunk_document",
+    "generate_synthetic_corpus",
+    "load_corpus_from_path",
+    "validate_embedding_metadata",
+    "validate_dense_vector",
+    "validate_sparse_vector",
+    "build_payload",
+    "prepare_hybrid_points",
+    "embed_chunks",
+    "batched",
+    "assert_collection_is_safe_for_ingest",
+    "upload_hybrid_points",
+    "run_ingest",
+    "main",
+]

--- a/tests/unit/test_rag_ingest_hybrid.py
+++ b/tests/unit/test_rag_ingest_hybrid.py
@@ -1,0 +1,651 @@
+"""Offline unit tests for PR-09 hybrid ingest script."""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections.abc import MutableMapping, Sequence
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import scripts.rag_ingest_hybrid as ingest
+from scripts.rag_ingest_hybrid import (
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_EMBEDDING_PROVIDER,
+    DEFAULT_EMBEDDING_VERSION,
+    DEFAULT_BATCH_SIZE,
+    DENSE_VECTOR_NAME,
+    HYBRID_COLLECTION_NAME,
+    LEGACY_COLLECTION_NAME,
+    MAX_BATCH_SIZE,
+    SPARSE_VECTOR_NAME,
+    Chunk,
+    Document,
+    HybridIngestError,
+    HybridIngestPoint,
+    SparseVector,
+)
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._value = 0.0
+
+    def perf_counter(self) -> float:
+        self._value += 0.001
+        return self._value
+
+
+class FakeDenseEmbedder:
+    def __init__(
+        self,
+        *,
+        dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS,
+        exc: Exception | None = None,
+    ) -> None:
+        self.dimensions = dimensions
+        self.exc = exc
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> Sequence[float]:
+        self.calls.append(text)
+        if self.exc is not None:
+            raise self.exc
+        return [0.1] * self.dimensions
+
+
+class FakeSparseEmbedder:
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.exc = exc
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> SparseVector:
+        self.calls.append(text)
+        if self.exc is not None:
+            raise self.exc
+        return SparseVector(indices=(1, 7), values=(1.0, 0.5))
+
+
+class FakeUpsertClient:
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.exc = exc
+        self.calls: list[tuple[str, list[HybridIngestPoint]]] = []
+
+    async def upsert_points(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[HybridIngestPoint],
+    ) -> None:
+        if self.exc is not None:
+            raise self.exc
+        self.calls.append((collection_name, list(points)))
+
+
+def doc(doc_id: str = "doc-a", text: str = "abc def ghi", source: str = "unit") -> Document:
+    return Document(doc_id=doc_id, text=text, source=source)
+
+
+def chunk(chunk_id: str = "chunk-a", text: str = "abc") -> Chunk:
+    return Chunk(
+        doc_id="doc-a",
+        chunk_id=chunk_id,
+        chunk_index=0,
+        text=text,
+        source="unit",
+    )
+
+
+def sparse(indices: tuple[int, ...] = (1, 3), values: tuple[float, ...] = (1.0, 0.5)) -> SparseVector:
+    return SparseVector(indices=indices, values=values)
+
+
+def dense(dimensions: int = 3) -> list[float]:
+    return [0.1] * dimensions
+
+
+def prepare_one_point() -> HybridIngestPoint:
+    return ingest.prepare_hybrid_points(
+        chunks=[chunk()],
+        dense_vectors=[dense()],
+        sparse_vectors=[sparse()],
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=3,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+    )[0]
+
+
+def test_make_chunk_id_is_deterministic() -> None:
+    first = ingest.make_chunk_id("doc-a", 0, "same text")
+    second = ingest.make_chunk_id("doc-a", 0, "same text")
+    assert first == second
+
+
+def test_make_chunk_id_changes_when_text_changes() -> None:
+    first = ingest.make_chunk_id("doc-a", 0, "first text")
+    second = ingest.make_chunk_id("doc-a", 0, "second text")
+    assert first != second
+
+
+def test_make_chunk_id_strips_doc_id_before_hashing() -> None:
+    assert ingest.make_chunk_id("doc-a ", 0, "t") == ingest.make_chunk_id("doc-a", 0, "t")
+
+
+def test_document_rejects_whitespace_only_fields() -> None:
+    with pytest.raises(ValueError, match="text cannot be empty"):
+        Document(doc_id="doc-a", text="   ")
+    with pytest.raises(ValueError, match="doc_id cannot be empty"):
+        Document(doc_id="   ", text="safe")
+
+
+def test_chunk_document_is_deterministic() -> None:
+    document = doc(text="abcdefghij")
+    first = ingest.chunk_document(document, max_chars=4, overlap_chars=1)
+    second = ingest.chunk_document(document, max_chars=4, overlap_chars=1)
+    assert first == second
+    assert [item.chunk_index for item in first] == [0, 1, 2, 3]
+
+
+def test_chunk_document_rejects_invalid_sizes() -> None:
+    document = doc()
+    with pytest.raises(ValueError, match="max_chars"):
+        ingest.chunk_document(document, max_chars=0)
+    with pytest.raises(ValueError, match="overlap_chars"):
+        ingest.chunk_document(document, max_chars=10, overlap_chars=-1)
+    with pytest.raises(ValueError, match="overlap_chars must be < max_chars"):
+        ingest.chunk_document(document, max_chars=10, overlap_chars=10)
+
+
+def test_generate_synthetic_corpus_returns_safe_documents() -> None:
+    documents = ingest.generate_synthetic_corpus()
+    assert len(documents) >= 2
+    assert all(document.source == "synthetic" for document in documents)
+    assert all("\x00" not in document.text for document in documents)
+
+
+def test_prepare_hybrid_points_builds_named_vectors_and_payload() -> None:
+    point = prepare_one_point()
+    vectors = point.to_qdrant_vector_dict()
+    assert set(vectors) == {DENSE_VECTOR_NAME, SPARSE_VECTOR_NAME}
+    assert vectors[DENSE_VECTOR_NAME] == [0.1, 0.1, 0.1]
+    assert vectors[SPARSE_VECTOR_NAME] == {"indices": [1, 3], "values": [1.0, 0.5]}
+    assert point.payload["doc_id"] == "doc-a"
+    assert point.payload["embedding_model"] == DEFAULT_EMBEDDING_MODEL
+    assert point.payload["schema_version"] == "qdrant-hybrid-v2"
+
+
+def test_prepare_hybrid_points_payload_has_exact_expected_keys() -> None:
+    point = prepare_one_point()
+    assert set(point.payload) == {
+        "doc_id",
+        "chunk_id",
+        "chunk_index",
+        "source",
+        "embedding_model",
+        "embedding_provider",
+        "embedding_dimensions",
+        "embedding_version",
+        "dense_vector_name",
+        "sparse_vector_name",
+        "schema_version",
+    }
+
+
+def test_prepare_hybrid_points_rejects_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        ingest.prepare_hybrid_points(
+            chunks=[chunk()],
+            dense_vectors=[],
+            sparse_vectors=[sparse()],
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=3,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+        )
+
+
+def test_prepare_hybrid_points_rejects_dense_dimension_mismatch() -> None:
+    with pytest.raises(ValueError, match="dense vector has"):
+        ingest.prepare_hybrid_points(
+            chunks=[chunk()],
+            dense_vectors=[[0.1, 0.2]],
+            sparse_vectors=[sparse()],
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=3,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+        )
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf")])
+def test_prepare_hybrid_points_rejects_non_finite_dense_values(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="dense value must be finite"):
+        ingest.prepare_hybrid_points(
+            chunks=[chunk()],
+            dense_vectors=[[0.1, bad_value, 0.3]],
+            sparse_vectors=[sparse()],
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=3,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+        )
+
+
+@pytest.mark.parametrize("bad_value", [True, False])
+def test_prepare_hybrid_points_rejects_bool_dense_values(bad_value: bool) -> None:
+    with pytest.raises(TypeError, match="dense value must be numeric"):
+        ingest.prepare_hybrid_points(
+            chunks=[chunk()],
+            dense_vectors=[[0.1, bad_value, 0.3]],
+            sparse_vectors=[sparse()],
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=3,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+        )
+
+
+def test_prepare_hybrid_points_rejects_sparse_length_mismatch() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        SparseVector(indices=(1,), values=())
+
+
+def test_sparse_vector_rejects_bool_index() -> None:
+    with pytest.raises(TypeError, match="sparse index must be an integer"):
+        SparseVector(indices=(True,), values=(1.0,))
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf")])
+def test_sparse_vector_rejects_non_finite_values(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="sparse value must be finite"):
+        SparseVector(indices=(1,), values=(bad_value,))
+
+
+def test_prepare_hybrid_points_rejects_empty_sparse_by_default() -> None:
+    with pytest.raises(ValueError, match="sparse vector cannot be empty"):
+        ingest.prepare_hybrid_points(
+            chunks=[chunk()],
+            dense_vectors=[dense()],
+            sparse_vectors=[SparseVector(indices=(), values=())],
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=3,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+        )
+
+
+def test_prepare_hybrid_points_allows_empty_sparse_when_explicit() -> None:
+    points = ingest.prepare_hybrid_points(
+        chunks=[chunk()],
+        dense_vectors=[dense()],
+        sparse_vectors=[SparseVector(indices=(), values=())],
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=3,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+        allow_empty_sparse=True,
+    )
+    assert points[0].sparse_indices == ()
+    assert points[0].sparse_values == ()
+
+
+def test_prepare_hybrid_points_payload_excludes_text_and_vectors() -> None:
+    point = prepare_one_point()
+    forbidden = {"text", "chunk_text", "dense_vector", "sparse_vector", "embedding", "prompt", "answer"}
+    assert forbidden.isdisjoint(point.payload)
+
+
+def test_hybrid_ingest_point_payload_is_immutable() -> None:
+    point = prepare_one_point()
+    with pytest.raises(TypeError):
+        cast(MutableMapping[str, object], point.payload)["doc_id"] = "mutated"
+
+
+def test_validate_embedding_metadata_rejects_equal_vector_names() -> None:
+    with pytest.raises(ValueError, match="must differ"):
+        ingest.validate_embedding_metadata(
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=DEFAULT_EMBEDDING_DIMENSIONS,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+            dense_vector_name="same",
+            sparse_vector_name="same",
+        )
+
+
+def test_assert_collection_rejects_legacy_collection() -> None:
+    with pytest.raises(HybridIngestError, match="protected"):
+        ingest.assert_collection_is_safe_for_ingest(LEGACY_COLLECTION_NAME)
+
+
+def test_assert_collection_allows_hybrid_collection() -> None:
+    assert ingest.assert_collection_is_safe_for_ingest(HYBRID_COLLECTION_NAME) == HYBRID_COLLECTION_NAME
+
+
+def test_batched_splits_points_deterministically() -> None:
+    items = [1, 2, 3, 4, 5]
+    assert list(ingest.batched(items, 2)) == [[1, 2], [3, 4], [5]]
+
+
+def test_batched_rejects_invalid_batch_size() -> None:
+    with pytest.raises(ValueError, match="batch_size"):
+        list(ingest.batched([1], 0))
+    with pytest.raises(ValueError, match=f"<= {MAX_BATCH_SIZE}"):
+        list(ingest.batched([1], MAX_BATCH_SIZE + 1))
+
+
+async def test_upload_dry_run_does_not_call_client() -> None:
+    client = FakeUpsertClient()
+    sent, batches, _upload_ms = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=[prepare_one_point()],
+        batch_size=DEFAULT_BATCH_SIZE,
+        dry_run=True,
+        clock=FakeClock(),
+    )
+    assert (sent, batches) == (0, 0)
+    assert client.calls == []
+
+
+async def test_upload_execute_calls_client_in_batches() -> None:
+    client = FakeUpsertClient()
+    points = [prepare_one_point(), prepare_one_point(), prepare_one_point()]
+    sent, batches, _upload_ms = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=points,
+        batch_size=2,
+        dry_run=False,
+        clock=FakeClock(),
+    )
+    assert (sent, batches) == (3, 2)
+    assert [len(call[1]) for call in client.calls] == [2, 1]
+    assert {call[0] for call in client.calls} == {HYBRID_COLLECTION_NAME}
+
+
+async def test_upload_never_allows_legacy_collection() -> None:
+    with pytest.raises(HybridIngestError, match="protected"):
+        await ingest.upload_hybrid_points(
+            client=FakeUpsertClient(),
+            collection_name=LEGACY_COLLECTION_NAME,
+            points=[],
+            batch_size=DEFAULT_BATCH_SIZE,
+            dry_run=True,
+            clock=FakeClock(),
+        )
+
+
+async def test_run_ingest_empty_corpus_returns_zero_summary() -> None:
+    dense_embedder = FakeDenseEmbedder()
+    sparse_embedder = FakeSparseEmbedder()
+    client = FakeUpsertClient()
+    summary = await ingest.run_ingest(
+        documents=[],
+        dense_embedder=dense_embedder,
+        sparse_embedder=sparse_embedder,
+        upsert_client=client,
+        clock=FakeClock(),
+    )
+    assert summary.documents_count == 0
+    assert summary.chunks_count == 0
+    assert summary.points_prepared == 0
+    assert summary.points_sent == 0
+    assert dense_embedder.calls == []
+    assert sparse_embedder.calls == []
+    assert client.calls == []
+
+
+async def test_run_ingest_dry_run_prepares_points_but_sends_zero() -> None:
+    client = FakeUpsertClient()
+    summary = await ingest.run_ingest(
+        documents=[doc(text="abc")],
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=client,
+        dry_run=True,
+        clock=FakeClock(),
+    )
+    assert summary.points_prepared == 1
+    assert summary.points_sent == 0
+    assert summary.dry_run is True
+    assert client.calls == []
+
+
+async def test_run_ingest_execute_sends_points_to_hybrid_collection() -> None:
+    client = FakeUpsertClient()
+    summary = await ingest.run_ingest(
+        documents=[doc(text="abc")],
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=client,
+        dry_run=False,
+        batch_size=1,
+        clock=FakeClock(),
+    )
+    assert summary.points_sent == 1
+    assert summary.batches_sent == 1
+    assert client.calls[0][0] == HYBRID_COLLECTION_NAME
+
+
+async def test_run_ingest_applies_max_chunks() -> None:
+    summary = await ingest.run_ingest(
+        documents=[doc(text="abcdefghij" * 300)],
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=FakeUpsertClient(),
+        dry_run=True,
+        max_chunks=1,
+        clock=FakeClock(),
+    )
+    assert summary.chunks_count == 1
+    assert summary.points_prepared == 1
+
+
+async def test_run_ingest_rejects_max_chunks_zero() -> None:
+    with pytest.raises(ValueError, match="max_chunks must be >= 1"):
+        await ingest.run_ingest(
+            documents=[doc(text="abcdefghij" * 300)],
+            dense_embedder=FakeDenseEmbedder(),
+            sparse_embedder=FakeSparseEmbedder(),
+            upsert_client=FakeUpsertClient(),
+            dry_run=True,
+            max_chunks=0,
+            clock=FakeClock(),
+        )
+
+
+async def test_run_ingest_is_deterministic_for_same_input() -> None:
+    first_client = FakeUpsertClient()
+    second_client = FakeUpsertClient()
+    document = doc(text="abcdefghij" * 300)
+    first = await ingest.run_ingest(
+        documents=[document],
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=first_client,
+        dry_run=False,
+        max_chunks=2,
+        batch_size=2,
+        clock=FakeClock(),
+    )
+    second = await ingest.run_ingest(
+        documents=[document],
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=second_client,
+        dry_run=False,
+        max_chunks=2,
+        batch_size=2,
+        clock=FakeClock(),
+    )
+    first_ids = [point.point_id for _collection, batch in first_client.calls for point in batch]
+    second_ids = [point.point_id for _collection, batch in second_client.calls for point in batch]
+    assert first.points_prepared == second.points_prepared == 2
+    assert first_ids == second_ids
+
+
+def test_elapsed_ms_clamps_retrograde_clock_to_zero() -> None:
+    assert ingest._elapsed_ms(2.0, 1.0) == 0.0
+
+
+def test_summary_to_safe_dict_has_no_text_vectors_payload() -> None:
+    summary = ingest.HybridIngestSummary(
+        collection_name=HYBRID_COLLECTION_NAME,
+        documents_count=1,
+        chunks_count=1,
+        points_prepared=1,
+        points_sent=0,
+        batches_sent=0,
+        dense_ms=1.0,
+        sparse_ms=1.0,
+        upload_ms=0.0,
+        total_ms=2.0,
+        dry_run=True,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=DEFAULT_EMBEDDING_DIMENSIONS,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+        dense_vector_name=DENSE_VECTOR_NAME,
+        sparse_vector_name=SPARSE_VECTOR_NAME,
+        batch_size=DEFAULT_BATCH_SIZE,
+    )
+    safe = summary.to_safe_dict()
+    assert ingest.FORBIDDEN_SUMMARY_KEYS.isdisjoint(safe)
+
+
+def test_main_dry_run_outputs_safe_json(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--synthetic"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["collection_name"] == HYBRID_COLLECTION_NAME
+    assert payload["dry_run"] is True
+    assert ingest.FORBIDDEN_SUMMARY_KEYS.isdisjoint(payload)
+
+
+def test_main_rejects_legacy_collection(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--synthetic", "--collection", LEGACY_COLLECTION_NAME])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+    assert LEGACY_COLLECTION_NAME not in captured.out
+    assert LEGACY_COLLECTION_NAME not in captured.err
+
+
+def test_main_execute_is_blocked_in_pr09(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--synthetic", "--execute"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_nonexistent_corpus_path_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--corpus-path", "/definitely/not/here.txt"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_invalid_batch_size_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--synthetic", "--batch-size", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_invalid_max_documents_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = ingest.main(["--synthetic", "--max-documents", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+async def test_deterministic_cli_embedders_emit_valid_vectors() -> None:
+    dense_vector = await ingest._DeterministicDenseEmbedder().embed("safe text")
+    sparse_vector = await ingest._DeterministicSparseEmbedder().embed("safe text")
+    assert len(dense_vector) == DEFAULT_EMBEDDING_DIMENSIONS
+    assert all(isinstance(value, float) for value in dense_vector)
+    assert sparse_vector.indices
+    assert len(sparse_vector.indices) == len(sparse_vector.values)
+    assert len(set(sparse_vector.indices)) == len(sparse_vector.indices)
+
+
+def test_all_exports_are_importable() -> None:
+    for name in ingest.__all__:
+        assert hasattr(ingest, name), name
+
+
+def test_unit_tests_do_not_import_qdrant_client() -> None:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_roots = _imported_roots(tree)
+    assert "qdrant_client" not in imported_roots
+
+
+def test_script_pure_functions_do_not_call_create_or_delete_collection() -> None:
+    source = Path(ingest.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_calls = {"create_collection", "delete_collection"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in forbidden_calls
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in forbidden_calls
+
+
+async def test_embedding_failure_is_sanitized() -> None:
+    with pytest.raises(HybridIngestError) as exc_info:
+        await ingest.run_ingest(
+            documents=[doc(text="private chunk text")],
+            dense_embedder=FakeDenseEmbedder(exc=RuntimeError("private chunk text")),
+            sparse_embedder=FakeSparseEmbedder(),
+            upsert_client=FakeUpsertClient(),
+            clock=FakeClock(),
+        )
+    assert "private chunk text" not in str(exc_info.value)
+
+
+async def test_upsert_failure_is_sanitized() -> None:
+    with pytest.raises(HybridIngestError) as exc_info:
+        await ingest.run_ingest(
+            documents=[doc(text="private chunk text")],
+            dense_embedder=FakeDenseEmbedder(),
+            sparse_embedder=FakeSparseEmbedder(),
+            upsert_client=FakeUpsertClient(exc=RuntimeError("private payload")),
+            dry_run=False,
+            clock=FakeClock(),
+        )
+    assert "private payload" not in str(exc_info.value)
+
+
+def test_no_qdrant_docker_ollama_required() -> None:
+    source = Path(ingest.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported_roots = _imported_roots(tree)
+    assert "qdrant_client" not in imported_roots
+    assert "docker" not in imported_roots
+    assert "ollama" not in imported_roots
+
+
+def test_load_corpus_from_path_reads_txt_deterministically(tmp_path: Path) -> None:
+    (tmp_path / "b.txt").write_text("second", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("first", encoding="utf-8")
+    documents = ingest.load_corpus_from_path(tmp_path)
+    assert [document.source for document in documents] == ["a.txt", "b.txt"]
+
+
+def _imported_roots(tree: ast.AST) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            roots.add(node.module.split(".")[0])
+    return roots

--- a/tests/unit/test_rag_ingest_hybrid_extended.py
+++ b/tests/unit/test_rag_ingest_hybrid_extended.py
@@ -1,0 +1,1050 @@
+"""Extended offline unit tests for PR-09 hybrid ingest script.
+
+Complementa a suite principal (test_rag_ingest_hybrid.py — 53 testes) com
+cobertura mais profunda em 8 seções:
+
+  A. Segurança operacional — null bytes, whitespace attack, protected collections
+  B. Conformidade de shape Qdrant — named vectors, UUID, traceabilidade
+  C. Determinismo profundo — embedders determinísticos, ordem de batches, reingest
+  D. Casos extremos — chunking de borda, sparse de borda, corpus edge cases
+  E. Completude do summary — exact key set, rejeição de valores inválidos
+  F. Invariantes estáticos — AST: sem uuid4, sem random, sem third-party
+  G. Upload edge cases — zero points, batch ordering, batch_size=1
+  H. Isolamento extrínseco — este arquivo não importa Qdrant, Docker, Ollama
+
+Todos os testes são offline — nenhum requer Qdrant, Docker, Ollama ou Qwen3.
+
+Autoria: COWORK / PR-09 deep review pass
+"""
+
+from __future__ import annotations
+
+import ast
+import uuid
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.rag_ingest_hybrid as ingest
+from scripts.rag_ingest_hybrid import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_EMBEDDING_DIMENSIONS,
+    DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_EMBEDDING_PROVIDER,
+    DEFAULT_EMBEDDING_VERSION,
+    DENSE_VECTOR_NAME,
+    HYBRID_COLLECTION_NAME,
+    LEGACY_COLLECTION_NAME,
+    MAX_BATCH_SIZE,
+    SPARSE_VECTOR_NAME,
+    Chunk,
+    Document,
+    HybridIngestError,
+    HybridIngestPoint,
+    SparseVector,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._value = 0.0
+
+    def perf_counter(self) -> float:
+        self._value += 0.001
+        return self._value
+
+
+class FakeDenseEmbedder:
+    def __init__(
+        self,
+        *,
+        dimensions: int = DEFAULT_EMBEDDING_DIMENSIONS,
+        exc: Exception | None = None,
+    ) -> None:
+        self.dimensions = dimensions
+        self.exc = exc
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> Sequence[float]:
+        self.calls.append(text)
+        if self.exc is not None:
+            raise self.exc
+        return [0.1] * self.dimensions
+
+
+class FakeSparseEmbedder:
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.exc = exc
+        self.calls: list[str] = []
+
+    async def embed(self, text: str) -> SparseVector:
+        self.calls.append(text)
+        if self.exc is not None:
+            raise self.exc
+        return SparseVector(indices=(1, 7), values=(1.0, 0.5))
+
+
+class FakeUpsertClient:
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.exc = exc
+        self.calls: list[tuple[str, list[HybridIngestPoint]]] = []
+
+    async def upsert_points(
+        self,
+        *,
+        collection_name: str,
+        points: Sequence[HybridIngestPoint],
+    ) -> None:
+        if self.exc is not None:
+            raise self.exc
+        self.calls.append((collection_name, list(points)))
+
+
+def _make_chunk(
+    doc_id: str = "doc-x",
+    text: str = "safe text for testing",
+    chunk_index: int = 0,
+) -> Chunk:
+    return Chunk(
+        doc_id=doc_id,
+        chunk_id=ingest.make_chunk_id(doc_id, chunk_index, text),
+        chunk_index=chunk_index,
+        text=text,
+        source="unit",
+    )
+
+
+def _one_point(dimensions: int = 3) -> HybridIngestPoint:
+    """Produce a single valid HybridIngestPoint with the given dense dimensions."""
+    return ingest.prepare_hybrid_points(
+        chunks=[_make_chunk()],
+        dense_vectors=[[0.1] * dimensions],
+        sparse_vectors=[SparseVector(indices=(5,), values=(1.0,))],
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=dimensions,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+    )[0]
+
+
+def _production_source() -> str:
+    return Path(ingest.__file__).read_text(encoding="utf-8")
+
+
+def _production_ast() -> ast.Module:
+    return ast.parse(_production_source())
+
+
+# ===========================================================================
+# A. SEGURANÇA OPERACIONAL
+# ===========================================================================
+
+
+def test_collection_whitespace_strips_to_legacy_and_is_blocked() -> None:
+    """`' quimera_knowledge '` strips to `'quimera_knowledge'` → PROTECTED → blocked.
+
+    Garante que whitespace-padding não bypassa a proteção da collection legada.
+    """
+    with pytest.raises(HybridIngestError, match="protected"):
+        ingest.assert_collection_is_safe_for_ingest(" quimera_knowledge ")
+
+
+def test_collection_tab_newline_strips_to_legacy_and_is_blocked() -> None:
+    r"""'\tquimera_knowledge\n' strips to legacy → blocked."""
+    with pytest.raises(HybridIngestError, match="protected"):
+        ingest.assert_collection_is_safe_for_ingest("\tquimera_knowledge\n")
+
+
+def test_collection_null_byte_raises_value_error_not_ingest_error() -> None:
+    """`'quimera_knowledge\\x00v2'` raises ValueError (null-byte check), not HybridIngestError.
+
+    A ValueError sai de _validate_text antes de chegar à proteção de collection.
+    """
+    with pytest.raises(ValueError, match="null byte"):
+        ingest.assert_collection_is_safe_for_ingest("quimera_knowledge\x00v2")
+
+
+def test_collection_uppercase_variant_is_not_protected() -> None:
+    """Case-sensitivity: 'QUIMERA_KNOWLEDGE' (uppercase) is NOT in PROTECTED_COLLECTIONS.
+
+    Este teste documenta o contrato explicitamente: a proteção é case-sensitive.
+    """
+    result = ingest.assert_collection_is_safe_for_ingest("QUIMERA_KNOWLEDGE")
+    assert result == "QUIMERA_KNOWLEDGE"
+
+
+def test_document_null_byte_in_doc_id_raises() -> None:
+    with pytest.raises(ValueError, match="null byte"):
+        Document(doc_id="doc\x00a", text="safe text")
+
+
+def test_document_null_byte_in_text_raises() -> None:
+    with pytest.raises(ValueError, match="null byte"):
+        Document(doc_id="doc-a", text="text\x00injection")
+
+
+def test_document_null_byte_in_source_raises() -> None:
+    with pytest.raises(ValueError, match="null byte"):
+        Document(doc_id="doc-a", text="safe", source="src\x00evil")
+
+
+def test_document_empty_source_raises() -> None:
+    with pytest.raises(ValueError, match="source cannot be empty"):
+        Document(doc_id="doc-a", text="safe", source="   ")
+
+
+def test_chunk_negative_chunk_index_raises() -> None:
+    with pytest.raises(ValueError, match="chunk_index must be non-negative"):
+        Chunk(
+            doc_id="doc-a",
+            chunk_id="c",
+            chunk_index=-1,
+            text="abc",
+            source="unit",
+        )
+
+
+def test_chunk_bool_chunk_index_raises() -> None:
+    """chunk_index=True would be silently accepted as 1 without the bool guard."""
+    with pytest.raises(TypeError, match="chunk_index must be an integer"):
+        Chunk(
+            doc_id="doc-a",
+            chunk_id="c",
+            chunk_index=True,  # bool is subclass of int — guard in __post_init__ catches it
+            text="abc",
+            source="unit",
+        )
+
+
+def test_validate_embedding_metadata_empty_model_raises() -> None:
+    with pytest.raises(ValueError, match="embedding_model cannot be empty"):
+        ingest.validate_embedding_metadata(
+            embedding_model="   ",
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=DEFAULT_EMBEDDING_DIMENSIONS,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+            dense_vector_name=DENSE_VECTOR_NAME,
+            sparse_vector_name=SPARSE_VECTOR_NAME,
+        )
+
+
+def test_validate_embedding_metadata_null_byte_in_version_raises() -> None:
+    with pytest.raises(ValueError, match="null byte"):
+        ingest.validate_embedding_metadata(
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=DEFAULT_EMBEDDING_DIMENSIONS,
+            embedding_version="v1\x00injected",
+            dense_vector_name=DENSE_VECTOR_NAME,
+            sparse_vector_name=SPARSE_VECTOR_NAME,
+        )
+
+
+def test_validate_embedding_metadata_zero_dimensions_raises() -> None:
+    with pytest.raises(ValueError, match="embedding_dimensions must be >= 1"):
+        ingest.validate_embedding_metadata(
+            embedding_model=DEFAULT_EMBEDDING_MODEL,
+            embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+            embedding_dimensions=0,
+            embedding_version=DEFAULT_EMBEDDING_VERSION,
+            dense_vector_name=DENSE_VECTOR_NAME,
+            sparse_vector_name=SPARSE_VECTOR_NAME,
+        )
+
+
+async def test_execute_with_zero_points_never_calls_upsert() -> None:
+    """dry_run=False com lista de pontos vazia → loop não executa → 0 chamadas ao client."""
+    client = FakeUpsertClient()
+    sent, batches, _ = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=[],
+        batch_size=DEFAULT_BATCH_SIZE,
+        dry_run=False,
+        clock=FakeClock(),
+    )
+    assert sent == 0
+    assert batches == 0
+    assert client.calls == []
+
+
+def test_main_missing_corpus_flag_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """main sem --synthetic e sem --corpus-path → exit 2."""
+    exit_code = ingest.main([])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_max_chunks_zero_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """--max-chunks 0 é rejeitado por _validate_optional_positive_int."""
+    exit_code = ingest.main(["--synthetic", "--max-chunks", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_embedding_dimensions_zero_returns_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """--embedding-dimensions 0 é rejeitado por _validate_positive_int."""
+    exit_code = ingest.main(["--synthetic", "--embedding-dimensions", "0"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "hybrid ingest failed" in captured.err
+
+
+def test_main_stderr_format_is_class_name_only(capsys: pytest.CaptureFixture[str]) -> None:
+    """Formato do stderr: exatamente 'hybrid ingest failed: <ClassName>'.
+
+    Verifica que o output de erro nunca vaza o conteúdo da mensagem da exceção,
+    apenas o nome da classe.
+    """
+    exit_code = ingest.main(["--collection", LEGACY_COLLECTION_NAME, "--synthetic"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    lines = captured.err.strip().splitlines()
+    assert len(lines) == 1, f"Expected 1 stderr line, got: {lines!r}"
+    assert lines[0].startswith("hybrid ingest failed: ")
+    class_name = lines[0].removeprefix("hybrid ingest failed: ")
+    assert class_name.isidentifier(), f"Not a valid Python identifier: {class_name!r}"
+    # The collection name must NOT appear in any error output
+    assert LEGACY_COLLECTION_NAME not in captured.err
+
+
+def test_main_stdout_is_empty_on_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Em caso de erro, stdout deve estar vazio — nenhum JSON parcial é emitido."""
+    exit_code = ingest.main(["--collection", LEGACY_COLLECTION_NAME, "--synthetic"])
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out.strip() == ""
+
+
+# ===========================================================================
+# B. CONFORMIDADE DE SHAPE QDRANT
+# ===========================================================================
+
+
+def test_point_id_is_a_valid_uuid_string() -> None:
+    """point_id deve ser um UUID string válido (Qdrant aceita UUID como ponto ID)."""
+    point = _one_point()
+    parsed = uuid.UUID(point.point_id)  # levanta ValueError se inválido
+    assert str(parsed) == point.point_id
+
+
+def test_point_id_equals_chunk_id_in_payload() -> None:
+    """point_id e payload['chunk_id'] devem ser iguais para rastreabilidade.
+
+    O HybridRetriever do PR-08 usa payload.chunk_id para proveniência — este
+    contrato deve ser mantido no ingest.
+    """
+    point = _one_point()
+    assert point.point_id == point.payload["chunk_id"]
+
+
+def test_qdrant_vector_dict_has_exactly_dense_and_sparse_keys() -> None:
+    point = _one_point()
+    d = point.to_qdrant_vector_dict()
+    assert set(d.keys()) == {"dense", "sparse"}
+
+
+def test_qdrant_vector_dict_dense_is_list_of_floats() -> None:
+    point = _one_point(dimensions=4)
+    d = point.to_qdrant_vector_dict()
+    dense = d["dense"]
+    assert isinstance(dense, list)
+    assert all(isinstance(v, float) for v in dense)
+    assert len(dense) == 4
+
+
+def test_qdrant_vector_dict_sparse_has_indices_and_values() -> None:
+    point = _one_point()
+    d = point.to_qdrant_vector_dict()
+    sparse = d["sparse"]
+    assert isinstance(sparse, dict)
+    assert set(sparse.keys()) == {"indices", "values"}
+    assert isinstance(sparse["indices"], list)
+    assert isinstance(sparse["values"], list)
+    assert len(sparse["indices"]) == len(sparse["values"])
+
+
+def test_qdrant_vector_dict_sparse_indices_are_ints() -> None:
+    """Qdrant exige list[int] para sparse indices."""
+    point = _one_point()
+    d = point.to_qdrant_vector_dict()
+    sparse = d["sparse"]
+    assert isinstance(sparse, dict)
+    for idx in sparse["indices"]:
+        assert isinstance(idx, int)
+
+
+def test_qdrant_vector_dict_sparse_values_are_floats() -> None:
+    """Qdrant exige list[float] para sparse values."""
+    point = _one_point()
+    d = point.to_qdrant_vector_dict()
+    sparse = d["sparse"]
+    assert isinstance(sparse, dict)
+    for val in sparse["values"]:
+        assert isinstance(val, float)
+
+
+def test_payload_contains_doc_id_for_retriever_traceability() -> None:
+    """payload['doc_id'] é necessário para o HybridRetriever fazer proveniência."""
+    point = _one_point()
+    assert "doc_id" in point.payload
+    assert isinstance(point.payload["doc_id"], str)
+
+
+def test_payload_schema_version_matches_module_constant() -> None:
+    """payload['schema_version'] deve ser igual a SCHEMA_VERSION do módulo."""
+    point = _one_point()
+    assert point.payload["schema_version"] == ingest.SCHEMA_VERSION
+
+
+def test_dense_vector_name_in_payload_matches_constant() -> None:
+    point = _one_point()
+    assert point.payload["dense_vector_name"] == DENSE_VECTOR_NAME
+
+
+def test_sparse_vector_name_in_payload_matches_constant() -> None:
+    point = _one_point()
+    assert point.payload["sparse_vector_name"] == SPARSE_VECTOR_NAME
+
+
+def test_payload_embedding_dimensions_is_int_greater_than_zero() -> None:
+    point = _one_point()
+    dims = point.payload["embedding_dimensions"]
+    assert isinstance(dims, int)
+    assert dims > 0
+
+
+# ===========================================================================
+# C. DETERMINISMO PROFUNDO
+# ===========================================================================
+
+
+async def test_deterministic_dense_embedder_same_input_same_output() -> None:
+    embedder = ingest._DeterministicDenseEmbedder()
+    v1 = await embedder.embed("test text")
+    v2 = await embedder.embed("test text")
+    assert list(v1) == list(v2)
+
+
+async def test_deterministic_dense_embedder_different_input_different_output() -> None:
+    embedder = ingest._DeterministicDenseEmbedder()
+    v1 = await embedder.embed("text A")
+    v2 = await embedder.embed("text B")
+    assert list(v1) != list(v2)
+
+
+async def test_deterministic_dense_embedder_values_in_range() -> None:
+    """Todos os valores de _DeterministicDenseEmbedder devem estar em [-1.0, 1.0]."""
+    embedder = ingest._DeterministicDenseEmbedder()
+    v = list(await embedder.embed("range check"))
+    out_of_range = [x for x in v if not (-1.0 <= x <= 1.0)]
+    assert not out_of_range, f"{len(out_of_range)} values outside [-1.0, 1.0]: {out_of_range[:5]}"
+
+
+async def test_deterministic_dense_embedder_exact_dimensions() -> None:
+    embedder = ingest._DeterministicDenseEmbedder()
+    v = list(await embedder.embed("dimension check"))
+    assert len(v) == DEFAULT_EMBEDDING_DIMENSIONS
+
+
+async def test_deterministic_sparse_embedder_same_input_same_output() -> None:
+    embedder = ingest._DeterministicSparseEmbedder()
+    s1 = await embedder.embed("test text")
+    s2 = await embedder.embed("test text")
+    assert s1.indices == s2.indices
+    assert s1.values == s2.values
+
+
+async def test_deterministic_sparse_embedder_different_input_different_output() -> None:
+    embedder = ingest._DeterministicSparseEmbedder()
+    s1 = await embedder.embed("text A")
+    s2 = await embedder.embed("text B")
+    assert (s1.indices != s2.indices) or (s1.values != s2.values)
+
+
+async def test_deterministic_sparse_embedder_output_is_valid_sparse_vector() -> None:
+    """Saída de _DeterministicSparseEmbedder deve ser aceita por validate_sparse_vector."""
+    embedder = ingest._DeterministicSparseEmbedder()
+    sv = await embedder.embed("some text")
+    validated = ingest.validate_sparse_vector(sv)
+    assert validated.indices == sv.indices
+    assert validated.values == sv.values
+
+
+async def test_deterministic_sparse_embedder_indices_are_unique() -> None:
+    """Embedder demo não deve produzir índices duplicados."""
+    embedder = ingest._DeterministicSparseEmbedder()
+    sv = await embedder.embed("duplicate guard")
+    assert len(set(sv.indices)) == len(sv.indices)
+
+
+def test_batched_preserves_element_order_across_all_batches() -> None:
+    """batched deve emitir os itens na mesma ordem do input, sem transposição."""
+    items = list(range(20))
+    result: list[int] = []
+    for batch in ingest.batched(items, 3):
+        result.extend(batch)
+    assert result == items
+
+
+def test_batched_five_items_two_per_batch_exact_pattern() -> None:
+    """5 itens, batch_size=2 → [[i0,i1],[i2,i3],[i4]]."""
+    items = ["a", "b", "c", "d", "e"]
+    batches = list(ingest.batched(items, 2))
+    assert batches == [["a", "b"], ["c", "d"], ["e"]]
+
+
+def test_chunk_document_chunk_indices_are_zero_based_contiguous() -> None:
+    """chunk_index deve ser 0-based e contíguo em qualquer chunking."""
+    document = Document(doc_id="doc-order", text="x" * 5000)
+    chunks = ingest.chunk_document(document, max_chars=100)
+    assert [c.chunk_index for c in chunks] == list(range(len(chunks)))
+
+
+async def test_run_ingest_point_order_matches_chunk_order() -> None:
+    """Pontos enviados ao client devem seguir a mesma ordem que os chunks gerados."""
+    client = FakeUpsertClient()
+    text = " ".join(f"word{i}" for i in range(500))
+    documents = [Document(doc_id="doc-order-test", text=text, source="unit")]
+
+    await ingest.run_ingest(
+        documents=documents,
+        dense_embedder=FakeDenseEmbedder(),
+        sparse_embedder=FakeSparseEmbedder(),
+        upsert_client=client,
+        dry_run=False,
+        batch_size=DEFAULT_BATCH_SIZE,
+        clock=FakeClock(),
+    )
+    sent_ids: list[str] = [p.point_id for _, batch in client.calls for p in batch]
+
+    # Regenerar a ordem esperada de forma independente
+    expected_chunks: list[Chunk] = []
+    for doc in documents:
+        expected_chunks.extend(ingest.chunk_document(doc))
+    expected_ids = [c.chunk_id for c in expected_chunks]
+
+    assert sent_ids == expected_ids
+
+
+async def test_reingest_same_corpus_produces_same_point_ids() -> None:
+    """Reingest com o mesmo corpus deve produzir os mesmos point_ids (idempotência de IDs)."""
+    client_a = FakeUpsertClient()
+    client_b = FakeUpsertClient()
+    document = Document(doc_id="doc-reingest", text="abcdefghij" * 100, source="unit")
+
+    for client in (client_a, client_b):
+        await ingest.run_ingest(
+            documents=[document],
+            dense_embedder=FakeDenseEmbedder(),
+            sparse_embedder=FakeSparseEmbedder(),
+            upsert_client=client,
+            dry_run=False,
+            max_chunks=3,
+            batch_size=10,
+            clock=FakeClock(),
+        )
+
+    ids_a = [p.point_id for _, batch in client_a.calls for p in batch]
+    ids_b = [p.point_id for _, batch in client_b.calls for p in batch]
+    assert ids_a == ids_b, "Reingest produziu point_ids diferentes para o mesmo corpus"
+
+
+# ===========================================================================
+# D. CASOS EXTREMOS
+# ===========================================================================
+
+
+def test_batched_empty_sequence_yields_nothing() -> None:
+    assert list(ingest.batched([], DEFAULT_BATCH_SIZE)) == []
+
+
+def test_batched_single_item_in_single_batch() -> None:
+    assert list(ingest.batched(["only"], 100)) == [["only"]]
+
+
+def test_batched_exact_max_batch_size_is_one_batch() -> None:
+    items = list(range(MAX_BATCH_SIZE))
+    batches = list(ingest.batched(items, MAX_BATCH_SIZE))
+    assert len(batches) == 1
+    assert len(batches[0]) == MAX_BATCH_SIZE
+
+
+def test_chunk_document_text_exactly_max_chars_produces_one_chunk() -> None:
+    text = "a" * 100
+    document = Document(doc_id="doc-exact", text=text)
+    chunks = ingest.chunk_document(document, max_chars=100)
+    assert len(chunks) == 1
+    assert chunks[0].text == text
+
+
+def test_chunk_document_text_max_chars_plus_one_produces_two_chunks() -> None:
+    text = "a" * 101
+    document = Document(doc_id="doc-overflow", text=text)
+    chunks = ingest.chunk_document(document, max_chars=100, overlap_chars=0)
+    assert len(chunks) == 2
+
+
+def test_chunk_document_with_overlap_step_and_correct_text() -> None:
+    """Chunking com overlap: step = max_chars - overlap_chars."""
+    text = "abcde"
+    document = Document(doc_id="doc-ov", text=text)
+    # max_chars=3, overlap_chars=1 → step=2, starts: 0, 2, 4
+    chunks = ingest.chunk_document(document, max_chars=3, overlap_chars=1)
+    assert len(chunks) == 3
+    assert chunks[0].text == "abc"
+    assert chunks[1].text == "cde"
+    assert chunks[2].text == "e"
+
+
+def test_chunk_document_all_whitespace_text_produces_no_chunks() -> None:
+    """Texto composto só de espaços após split deve ser rejeitado.
+
+    Nota: Document.__post_init__ rejeita texto whitespace-only antes mesmo de
+    chunk_document ser chamado. Este teste verifica que a proteção existe no
+    ponto de entrada certo.
+    """
+    with pytest.raises(ValueError, match="text cannot be empty"):
+        Document(doc_id="doc-ws", text="    ")
+
+
+def test_sparse_vector_index_zero_is_valid() -> None:
+    sv = SparseVector(indices=(0,), values=(1.0,))
+    assert sv.indices == (0,)
+
+
+def test_sparse_vector_large_index_is_valid() -> None:
+    sv = SparseVector(indices=(2**20,), values=(0.5,))
+    assert sv.indices == (2**20,)
+
+
+def test_sparse_vector_single_element_is_valid() -> None:
+    sv = SparseVector(indices=(42,), values=(0.9,))
+    assert len(sv.indices) == 1
+
+
+def test_dense_all_zeros_vector_is_valid() -> None:
+    points = ingest.prepare_hybrid_points(
+        chunks=[_make_chunk()],
+        dense_vectors=[[0.0, 0.0, 0.0]],
+        sparse_vectors=[SparseVector(indices=(1,), values=(1.0,))],
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=3,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+    )
+    assert points[0].dense_vector == (0.0, 0.0, 0.0)
+
+
+def test_dense_single_dimension_is_valid() -> None:
+    points = ingest.prepare_hybrid_points(
+        chunks=[_make_chunk()],
+        dense_vectors=[[0.5]],
+        sparse_vectors=[SparseVector(indices=(1,), values=(1.0,))],
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        embedding_provider=DEFAULT_EMBEDDING_PROVIDER,
+        embedding_dimensions=1,
+        embedding_version=DEFAULT_EMBEDDING_VERSION,
+    )
+    assert len(points[0].dense_vector) == 1
+
+
+def test_load_corpus_skips_empty_files(tmp_path: Path) -> None:
+    (tmp_path / "empty.txt").write_text("   \n", encoding="utf-8")
+    (tmp_path / "valid.txt").write_text("not empty", encoding="utf-8")
+    documents = ingest.load_corpus_from_path(tmp_path)
+    assert len(documents) == 1
+    assert documents[0].source == "valid.txt"
+
+
+def test_load_corpus_single_file_path(tmp_path: Path) -> None:
+    f = tmp_path / "single.txt"
+    f.write_text("single file content", encoding="utf-8")
+    documents = ingest.load_corpus_from_path(f)
+    assert len(documents) == 1
+    assert documents[0].text == "single file content"
+
+
+def test_load_corpus_non_txt_file_raises(tmp_path: Path) -> None:
+    f = tmp_path / "doc.md"
+    f.write_text("markdown content", encoding="utf-8")
+    with pytest.raises(ValueError, match=".txt"):
+        ingest.load_corpus_from_path(f)
+
+
+def test_load_corpus_max_documents_limits_results(tmp_path: Path) -> None:
+    for i in range(5):
+        (tmp_path / f"doc{i:02d}.txt").write_text(f"content {i}", encoding="utf-8")
+    documents = ingest.load_corpus_from_path(tmp_path, max_documents=3)
+    assert len(documents) == 3
+
+
+def test_load_corpus_max_documents_zero_raises(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("content", encoding="utf-8")
+    with pytest.raises(ValueError, match="max_documents must be >= 1"):
+        ingest.load_corpus_from_path(tmp_path, max_documents=0)
+
+
+def test_load_corpus_nonexistent_path_raises() -> None:
+    with pytest.raises(FileNotFoundError):
+        ingest.load_corpus_from_path(Path("/definitely/does/not/exist"))
+
+
+def test_make_chunk_id_different_doc_id_produces_different_id() -> None:
+    """doc_id diferente com mesmo texto e índice → chunk_id diferente."""
+    id_a = ingest.make_chunk_id("doc-a", 0, "same text")
+    id_b = ingest.make_chunk_id("doc-b", 0, "same text")
+    assert id_a != id_b
+
+
+def test_make_chunk_id_different_index_produces_different_id() -> None:
+    """chunk_index diferente → chunk_id diferente."""
+    id_0 = ingest.make_chunk_id("doc-a", 0, "same text")
+    id_1 = ingest.make_chunk_id("doc-a", 1, "same text")
+    assert id_0 != id_1
+
+
+# ===========================================================================
+# E. COMPLETUDE DO SUMMARY
+# ===========================================================================
+
+
+def _make_summary(**overrides: object) -> ingest.HybridIngestSummary:
+    defaults: dict[str, Any] = {
+        "collection_name": HYBRID_COLLECTION_NAME,
+        "documents_count": 1,
+        "chunks_count": 1,
+        "points_prepared": 1,
+        "points_sent": 0,
+        "batches_sent": 0,
+        "dense_ms": 1.0,
+        "sparse_ms": 1.0,
+        "upload_ms": 0.0,
+        "total_ms": 2.0,
+        "dry_run": True,
+        "embedding_model": DEFAULT_EMBEDDING_MODEL,
+        "embedding_provider": DEFAULT_EMBEDDING_PROVIDER,
+        "embedding_dimensions": DEFAULT_EMBEDDING_DIMENSIONS,
+        "embedding_version": DEFAULT_EMBEDDING_VERSION,
+        "dense_vector_name": DENSE_VECTOR_NAME,
+        "sparse_vector_name": SPARSE_VECTOR_NAME,
+        "batch_size": DEFAULT_BATCH_SIZE,
+    }
+    defaults.update(overrides)
+    return ingest.HybridIngestSummary(**defaults)
+
+
+def test_summary_to_safe_dict_has_exactly_18_keys() -> None:
+    """to_safe_dict() deve emitir exatamente 18 chaves — nem mais, nem menos."""
+    safe = _make_summary().to_safe_dict()
+    expected_keys = {
+        "collection_name",
+        "documents_count",
+        "chunks_count",
+        "points_prepared",
+        "points_sent",
+        "batches_sent",
+        "dense_ms",
+        "sparse_ms",
+        "upload_ms",
+        "total_ms",
+        "dry_run",
+        "embedding_model",
+        "embedding_provider",
+        "embedding_dimensions",
+        "embedding_version",
+        "dense_vector_name",
+        "sparse_vector_name",
+        "batch_size",
+    }
+    assert set(safe.keys()) == expected_keys, (
+        f"Unexpected keys: {set(safe.keys()) - expected_keys} | "
+        f"Missing keys: {expected_keys - set(safe.keys())}"
+    )
+
+
+def test_summary_rejects_negative_documents_count() -> None:
+    with pytest.raises(ValueError, match="documents_count must be non-negative"):
+        _make_summary(documents_count=-1)
+
+
+def test_summary_rejects_negative_chunks_count() -> None:
+    with pytest.raises(ValueError, match="chunks_count must be non-negative"):
+        _make_summary(chunks_count=-1)
+
+
+def test_summary_rejects_negative_points_sent() -> None:
+    with pytest.raises(ValueError, match="points_sent must be non-negative"):
+        _make_summary(points_sent=-1)
+
+
+def test_summary_rejects_negative_total_ms() -> None:
+    with pytest.raises(ValueError, match="total_ms must be non-negative"):
+        _make_summary(total_ms=-1.0)
+
+
+def test_summary_dry_run_flag_true_is_preserved() -> None:
+    assert _make_summary(dry_run=True).to_safe_dict()["dry_run"] is True
+
+
+def test_summary_dry_run_flag_false_is_preserved() -> None:
+    assert _make_summary(dry_run=False).to_safe_dict()["dry_run"] is False
+
+
+def test_summary_json_serialisable() -> None:
+    """to_safe_dict() deve ser serializável via json.dumps sem erros."""
+    import json
+
+    safe = _make_summary().to_safe_dict()
+    json_str = json.dumps(safe)
+    assert json_str  # não deve ser vazio
+
+
+# ===========================================================================
+# F. INVARIANTES ESTÁTICOS — análise AST do módulo de produção
+# ===========================================================================
+
+
+def test_script_does_not_use_uuid4() -> None:
+    """uuid4() produziria IDs não-determinísticos — proibido."""
+    source = _production_source()
+    assert "uuid4" not in source, "uuid4 encontrado no script — IDs não seriam determinísticos"
+
+
+def test_script_does_not_import_random_module() -> None:
+    """random quebraria determinismo de IDs."""
+    tree = _production_ast()
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported_roots.add(node.module.split(".")[0])
+    assert "random" not in imported_roots
+
+
+def test_script_does_not_import_known_forbidden_third_party() -> None:
+    """Script de produção usa apenas stdlib — sem third-party que vaze ou crie dependência."""
+    forbidden: set[str] = {
+        "qdrant_client",
+        "langchain",
+        "sentence_transformers",
+        "transformers",
+        "torch",
+        "fastapi",
+        "httpx",
+        "requests",
+        "openai",
+        "anthropic",
+        "ollama",
+    }
+    tree = _production_ast()
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported_roots.add(node.module.split(".")[0])
+    violations = imported_roots & forbidden
+    assert not violations, f"Third-party proibido encontrado: {violations}"
+
+
+def test_script_constants_have_correct_values() -> None:
+    """Contrato de valores das constantes públicas."""
+    assert ingest.HYBRID_COLLECTION_NAME == "quimera_knowledge_v2"
+    assert ingest.LEGACY_COLLECTION_NAME == "quimera_knowledge"
+    assert ingest.DENSE_VECTOR_NAME == "dense"
+    assert ingest.SPARSE_VECTOR_NAME == "sparse"
+    assert ingest.DEFAULT_EMBEDDING_DIMENSIONS == 1024
+    assert ingest.DEFAULT_BATCH_SIZE == 32
+    assert ingest.MAX_BATCH_SIZE == 256
+    assert ingest.SCHEMA_VERSION == "qdrant-hybrid-v2"
+    assert LEGACY_COLLECTION_NAME in ingest.PROTECTED_COLLECTIONS
+    assert isinstance(ingest.PROTECTED_COLLECTIONS, frozenset)
+    assert isinstance(ingest.FORBIDDEN_SUMMARY_KEYS, frozenset)
+
+
+def test_protected_collections_contains_only_legacy() -> None:
+    """PROTECTED_COLLECTIONS deve conter exatamente quimera_knowledge e nada mais.
+
+    Se outra collection for adicionada acidentalmente, algum workflow pode quebrar.
+    """
+    assert ingest.PROTECTED_COLLECTIONS == frozenset({"quimera_knowledge"})
+
+
+def test_forbidden_summary_keys_contains_all_expected_keys() -> None:
+    """FORBIDDEN_SUMMARY_KEYS deve cobrir todos os tipos de dado sensível."""
+    required_forbidden = {
+        "text", "chunk_text", "raw_text", "content", "page_content",
+        "vector", "vectors", "dense_vector", "sparse_vector",
+        "embedding", "embeddings", "prompt", "answer", "payload",
+    }
+    assert required_forbidden.issubset(ingest.FORBIDDEN_SUMMARY_KEYS), (
+        f"Chaves sensíveis faltando em FORBIDDEN_SUMMARY_KEYS: "
+        f"{required_forbidden - ingest.FORBIDDEN_SUMMARY_KEYS}"
+    )
+
+
+def test_make_chunk_id_uses_sha256_not_random_hash() -> None:
+    """make_chunk_id deve usar sha256 explicitamente, não hash() nativo do Python.
+
+    hash() é não-determinístico entre processos Python 3.3+ (PYTHONHASHSEED).
+    """
+    source = _production_source()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "make_chunk_id":
+            function_source = ast.get_source_segment(source, node) or ""
+            assert "sha256" in function_source, "make_chunk_id não usa sha256"
+            assert "uuid4" not in function_source, "make_chunk_id usa uuid4"
+            return
+    pytest.fail("make_chunk_id não encontrado no módulo")
+
+
+# ===========================================================================
+# G. UPLOAD EDGE CASES
+# ===========================================================================
+
+
+async def test_upload_dry_run_never_calls_upsert_even_with_100_points() -> None:
+    client = FakeUpsertClient()
+    points = [_one_point() for _ in range(100)]
+    sent, batches, _ = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=points,
+        batch_size=DEFAULT_BATCH_SIZE,
+        dry_run=True,
+        clock=FakeClock(),
+    )
+    assert sent == 0
+    assert batches == 0
+    assert client.calls == []
+
+
+async def test_upload_five_points_two_per_batch_exact_pattern() -> None:
+    """5 pontos, batch_size=2 → 3 chamadas [2,2,1], points_sent=5, batches_sent=3."""
+    client = FakeUpsertClient()
+    points = [_one_point() for _ in range(5)]
+    sent, batches, _ = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=points,
+        batch_size=2,
+        dry_run=False,
+        clock=FakeClock(),
+    )
+    assert sent == 5
+    assert batches == 3
+    assert [len(call[1]) for call in client.calls] == [2, 2, 1]
+
+
+async def test_upload_batch_size_one_sends_one_point_per_call() -> None:
+    client = FakeUpsertClient()
+    points = [_one_point() for _ in range(3)]
+    sent, batches, _ = await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=points,
+        batch_size=1,
+        dry_run=False,
+        clock=FakeClock(),
+    )
+    assert sent == 3
+    assert batches == 3
+    assert all(len(call[1]) == 1 for call in client.calls)
+
+
+async def test_upload_collection_used_in_all_batch_calls_is_hybrid() -> None:
+    """Todas as chamadas ao client devem usar HYBRID_COLLECTION_NAME, nunca outra."""
+    client = FakeUpsertClient()
+    await ingest.upload_hybrid_points(
+        client=client,
+        collection_name=HYBRID_COLLECTION_NAME,
+        points=[_one_point() for _ in range(4)],
+        batch_size=2,
+        dry_run=False,
+        clock=FakeClock(),
+    )
+    collections_used = {call[0] for call in client.calls}
+    assert collections_used == {HYBRID_COLLECTION_NAME}
+
+
+async def test_upload_failure_wraps_in_hybrid_ingest_error() -> None:
+    """Falha do client deve ser encapsulada em HybridIngestError, não propagada raw."""
+    client = FakeUpsertClient(exc=RuntimeError("connection refused"))
+    with pytest.raises(HybridIngestError):
+        await ingest.upload_hybrid_points(
+            client=client,
+            collection_name=HYBRID_COLLECTION_NAME,
+            points=[_one_point()],
+            batch_size=1,
+            dry_run=False,
+            clock=FakeClock(),
+        )
+
+
+async def test_upload_failure_message_does_not_contain_original_error_text() -> None:
+    """HybridIngestError não deve vazar a mensagem da exceção original."""
+    private_message = "private server connection error detail"
+    client = FakeUpsertClient(exc=RuntimeError(private_message))
+    with pytest.raises(HybridIngestError) as exc_info:
+        await ingest.upload_hybrid_points(
+            client=client,
+            collection_name=HYBRID_COLLECTION_NAME,
+            points=[_one_point()],
+            batch_size=1,
+            dry_run=False,
+            clock=FakeClock(),
+        )
+    assert private_message not in str(exc_info.value)
+
+
+# ===========================================================================
+# H. ISOLAMENTO EXTRÍNSECO — este arquivo não introduz dependências proibidas
+# ===========================================================================
+
+
+def test_extended_tests_do_not_import_qdrant_client() -> None:
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "qdrant_client" not in alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                assert "qdrant_client" not in node.module
+
+
+def test_extended_tests_do_not_require_network_or_docker() -> None:
+    """Nenhum import de rede, Docker ou Ollama neste arquivo.
+
+    Usa AST para verificar imports reais, não string search (que causaria
+    falsos positivos em docstrings e comentários).
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_import_roots = {"docker", "ollama", "httpx", "requests", "socket", "urllib3"}
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported_roots.add(node.module.split(".")[0])
+    violations = imported_roots & forbidden_import_roots
+    assert not violations, f"Import proibido encontrado nos testes estendidos: {violations}"


### PR DESCRIPTION
## Summary\n- Add offline-first hybrid ingest CLI for preparing dense + sparse named-vector points for quimera_knowledge_v2.\n- Add deterministic chunk IDs, safe summaries, protected legacy collection guard, dry-run default, and execute-only upsert protocol.\n- Add primary and extended offline unit suites plus PR-10 handoff documentation for residual integration risks.\n\n## Validation\n- uv run pytest tests/unit/test_rag_ingest_hybrid.py tests/unit/test_rag_ingest_hybrid_extended.py -q\n- uv run mypy --strict scripts/rag_ingest_hybrid.py tests/unit/test_rag_ingest_hybrid.py tests/unit/test_rag_ingest_hybrid_extended.py\n- uv run pyright scripts/rag_ingest_hybrid.py tests/unit/test_rag_ingest_hybrid.py tests/unit/test_rag_ingest_hybrid_extended.py\n- git diff --check\n\n## Safety\n- Does not create/delete/reset collections.\n- Does not touch quimera_knowledge.\n- Does not import qdrant_client in unit tests or pure ingest logic.\n- Does not emit chunk text, vectors, embeddings, prompts, answers, or raw payloads in summaries.