### PR TITLE
RAG-01B-PR-03 — HybridRAG Semantic Cache Layer (Qdrant)

### DIFF
--- a/backend/rag/cache/__init__.py
+++ b/backend/rag/cache/__init__.py
@@ -1,0 +1,20 @@
+"""HybridRAG semantic retrieval cache contracts."""
+
+from backend.rag.cache.cache_config import CacheSettings, get_cache_settings
+from backend.rag.cache.cache_models import (
+    CacheEntry,
+    CacheFingerprint,
+    CacheHit,
+    CacheInvalidationResult,
+    RetrievalResult,
+)
+
+__all__ = [
+    "CacheEntry",
+    "CacheFingerprint",
+    "CacheHit",
+    "CacheInvalidationResult",
+    "CacheSettings",
+    "RetrievalResult",
+    "get_cache_settings",
+]

--- a/backend/rag/cache/cache_collection.py
+++ b/backend/rag/cache/cache_collection.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
+from qdrant_client import AsyncQdrantClient
 from qdrant_client.http import models
 
 from backend.rag.cache.cache_config import CacheDistance, CacheSettings
 from backend.rag.cache.errors import CacheCollectionMismatchError
+from backend.rag.cache.types import CacheCollectionClient
 
 
 CACHE_PAYLOAD_INDEXES: Mapping[str, models.PayloadSchemaType] = {
@@ -27,7 +29,11 @@ CACHE_PAYLOAD_INDEXES: Mapping[str, models.PayloadSchemaType] = {
 class CacheCollectionManager:
     """Create and validate the dedicated Qdrant cache collection."""
 
-    def __init__(self, client: Any, settings: CacheSettings) -> None:
+    def __init__(
+        self,
+        client: AsyncQdrantClient | CacheCollectionClient,
+        settings: CacheSettings,
+    ) -> None:
         self._client = client
         self._settings = settings
 

--- a/backend/rag/cache/cache_collection.py
+++ b/backend/rag/cache/cache_collection.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
-from qdrant_client import AsyncQdrantClient
 from qdrant_client.http import models
 
 from backend.rag.cache.cache_config import CacheDistance, CacheSettings
@@ -28,7 +27,7 @@ CACHE_PAYLOAD_INDEXES: Mapping[str, models.PayloadSchemaType] = {
 class CacheCollectionManager:
     """Create and validate the dedicated Qdrant cache collection."""
 
-    def __init__(self, client: AsyncQdrantClient, settings: CacheSettings) -> None:
+    def __init__(self, client: Any, settings: CacheSettings) -> None:
         self._client = client
         self._settings = settings
 

--- a/backend/rag/cache/cache_collection.py
+++ b/backend/rag/cache/cache_collection.py
@@ -1,0 +1,147 @@
+"""Qdrant collection management for the semantic retrieval cache."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http import models
+
+from backend.rag.cache.cache_config import CacheDistance, CacheSettings
+from backend.rag.cache.errors import CacheCollectionMismatchError
+
+
+CACHE_PAYLOAD_INDEXES: Mapping[str, models.PayloadSchemaType] = {
+    "schema_version": models.PayloadSchemaType.KEYWORD,
+    "profile_name": models.PayloadSchemaType.KEYWORD,
+    "embedding_model": models.PayloadSchemaType.KEYWORD,
+    "source_collection": models.PayloadSchemaType.KEYWORD,
+    "corpus_epoch": models.PayloadSchemaType.KEYWORD,
+    "retrieval_fingerprint": models.PayloadSchemaType.KEYWORD,
+    "hit_count": models.PayloadSchemaType.INTEGER,
+    "created_at": models.PayloadSchemaType.DATETIME,
+    "expires_at": models.PayloadSchemaType.DATETIME,
+}
+
+
+class CacheCollectionManager:
+    """Create and validate the dedicated Qdrant cache collection."""
+
+    def __init__(self, client: AsyncQdrantClient, settings: CacheSettings) -> None:
+        self._client = client
+        self._settings = settings
+
+    async def ensure_collection(self) -> None:
+        """Create collection if absent, otherwise validate compatibility."""
+
+        if await self.collection_exists():
+            await self.assert_collection_compatible()
+        else:
+            await self._client.create_collection(
+                collection_name=self._settings.collection_name,
+                vectors_config=models.VectorParams(
+                    size=self._settings.vector_size,
+                    distance=qdrant_distance(self._settings.distance),
+                ),
+            )
+        await self.ensure_payload_indexes()
+
+    async def collection_exists(self) -> bool:
+        """Return whether the configured cache collection exists."""
+
+        return bool(
+            await self._client.collection_exists(
+                collection_name=self._settings.collection_name
+            )
+        )
+
+    async def assert_collection_compatible(self) -> None:
+        """Raise if the existing collection does not match cache settings."""
+
+        info = await self._client.get_collection(
+            collection_name=self._settings.collection_name
+        )
+        vector_size, distance = _extract_unnamed_vector_config(info)
+        if vector_size != self._settings.vector_size:
+            raise CacheCollectionMismatchError("cache collection vector size mismatch")
+        if _normalize_distance(distance) != self._settings.distance:
+            raise CacheCollectionMismatchError("cache collection distance mismatch")
+
+    async def ensure_payload_indexes(self) -> None:
+        """Create required payload indexes idempotently."""
+
+        for field_name, field_schema in CACHE_PAYLOAD_INDEXES.items():
+            await self._client.create_payload_index(
+                collection_name=self._settings.collection_name,
+                field_name=field_name,
+                field_schema=field_schema,
+            )
+
+
+def qdrant_distance(distance: CacheDistance) -> models.Distance:
+    """Map settings distance string to Qdrant enum."""
+
+    if distance == "Cosine":
+        return models.Distance.COSINE
+    if distance == "Dot":
+        return models.Distance.DOT
+    if distance == "Euclid":
+        return models.Distance.EUCLID
+    if distance == "Manhattan":
+        return models.Distance.MANHATTAN
+    raise ValueError("unsupported cache distance")
+
+
+def _extract_unnamed_vector_config(info: object) -> tuple[int, str]:
+    raw = _model_to_mapping(info)
+    if "size" in raw and "distance" in raw:
+        return _coerce_int(raw["size"]), str(raw["distance"])
+    config = _safe_mapping(raw.get("config"))
+    params = _safe_mapping(config.get("params"))
+    vectors = params.get("vectors")
+    vector_mapping = _safe_mapping(vectors)
+    if "size" in vector_mapping and "distance" in vector_mapping:
+        return _coerce_int(vector_mapping["size"]), str(vector_mapping["distance"])
+    params_obj = getattr(getattr(info, "config", None), "params", None)
+    vectors_obj = getattr(params_obj, "vectors", None)
+    size = getattr(vectors_obj, "size", None)
+    distance = getattr(vectors_obj, "distance", None)
+    if size is not None and distance is not None:
+        return _coerce_int(size), str(getattr(distance, "value", distance))
+    raise CacheCollectionMismatchError("cache collection vector config is missing")
+
+
+def _normalize_distance(distance: str) -> CacheDistance:
+    value = distance.split(".")[-1]
+    normalized = value.lower()
+    if normalized == "cosine":
+        return "Cosine"
+    if normalized == "dot":
+        return "Dot"
+    if normalized == "euclid":
+        return "Euclid"
+    if normalized == "manhattan":
+        return "Manhattan"
+    raise CacheCollectionMismatchError("cache collection distance is unsupported")
+
+
+def _model_to_mapping(model: object) -> Mapping[str, object]:
+    if hasattr(model, "model_dump"):
+        dumpable = cast(Any, model)
+        dumped = dumpable.model_dump(mode="json", exclude_none=True)
+        if isinstance(dumped, Mapping):
+            return dumped
+    if isinstance(model, Mapping):
+        return model
+    return {}
+
+
+def _safe_mapping(value: object) -> dict[str, object]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _coerce_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CacheCollectionMismatchError("cache collection vector size is invalid")
+    return value

--- a/backend/rag/cache/cache_config.py
+++ b/backend/rag/cache/cache_config.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -48,6 +48,14 @@ class CacheSettings(BaseSettings):
         if not clean:
             raise ValueError("cache setting cannot be empty")
         return clean
+
+    @model_validator(mode="after")
+    def validate_collection_boundaries(self) -> Self:
+        """Keep the cache collection separate from the source collection."""
+
+        if self.collection_name == self.source_collection:
+            raise ValueError("collection_name and source_collection must differ")
+        return self
 
     @property
     def similarity_threshold(self) -> float:

--- a/backend/rag/cache/cache_config.py
+++ b/backend/rag/cache/cache_config.py
@@ -1,0 +1,63 @@
+"""Settings for the HybridRAG semantic retrieval cache."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+CacheDistance = Literal["Cosine", "Dot", "Euclid", "Manhattan"]
+
+
+class CacheSettings(BaseSettings):
+    """Environment-backed cache settings."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="QUIMERA_CACHE_",
+        env_ignore_empty=True,
+        extra="ignore",
+    )
+
+    enabled: bool = True
+    collection_name: str = "quimera_query_cache"
+    threshold: float = Field(default=0.92, ge=0.0, le=1.0)
+    vector_size: int = Field(default=1024, gt=0)
+    distance: CacheDistance = "Cosine"
+    embedding_model: str = "qwen3-embedding"
+    profile_name: str = "default"
+    source_collection: str = "quimera_knowledge"
+    corpus_epoch: str = "dev"
+    default_ttl_seconds: int | None = Field(default=None, gt=0)
+    max_result_docs: int = Field(default=50, gt=0)
+    hot_entries_oversample_factor: int = Field(default=3, ge=1)
+
+    @field_validator(
+        "collection_name",
+        "embedding_model",
+        "profile_name",
+        "source_collection",
+        "corpus_epoch",
+        mode="after",
+    )
+    @classmethod
+    def required_text_must_not_be_empty(cls, value: str) -> str:
+        clean = value.strip()
+        if not clean:
+            raise ValueError("cache setting cannot be empty")
+        return clean
+
+    @property
+    def similarity_threshold(self) -> float:
+        """Return the configured lookup score threshold."""
+
+        return self.threshold
+
+
+@lru_cache(maxsize=1)
+def get_cache_settings() -> CacheSettings:
+    """Return cached settings; tests may call cache_clear on this function."""
+
+    return CacheSettings()

--- a/backend/rag/cache/cache_fingerprint.py
+++ b/backend/rag/cache/cache_fingerprint.py
@@ -55,7 +55,10 @@ def build_retrieval_fingerprint(
 
 
 def hmac_query_hash(query_text: str, secret: str) -> str:
-    """Return HMAC of query text; callers must persist only the returned hash."""
+    """Return HMAC of query text; persist only the returned hash.
+
+    Never log query_text alongside the returned hash.
+    """
 
     if not query_text:
         raise ValueError("query_text cannot be empty")

--- a/backend/rag/cache/cache_fingerprint.py
+++ b/backend/rag/cache/cache_fingerprint.py
@@ -1,0 +1,72 @@
+"""Safe cache fingerprint helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from backend.rag.cache.cache_models import FORBIDDEN_CACHE_PAYLOAD_KEYS
+
+
+def stable_json_dumps(value: Mapping[str, Any]) -> str:
+    """Serialize a mapping deterministically."""
+
+    _reject_sensitive_keys(value)
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_hex(text: str) -> str:
+    """Return SHA-256 hex digest."""
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_retrieval_fingerprint(
+    *,
+    embedding_model: str,
+    embedding_dim: int,
+    source_collection: str,
+    corpus_epoch: str,
+    profile_name: str,
+    fusion_backend: str | None = None,
+    reranker_name: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> str:
+    """Build a stable retrieval fingerprint without storing raw queries."""
+
+    payload: dict[str, Any] = {
+        "embedding_dim": embedding_dim,
+        "embedding_model": embedding_model,
+        "source_collection": source_collection,
+        "corpus_epoch": corpus_epoch,
+        "profile_name": profile_name,
+    }
+    if fusion_backend is not None:
+        payload["fusion_backend"] = fusion_backend
+    if reranker_name is not None:
+        payload["reranker_name"] = reranker_name
+    if extra:
+        _reject_sensitive_keys(extra)
+        payload["extra"] = dict(extra)
+    return sha256_hex(stable_json_dumps(payload))
+
+
+def hmac_query_hash(query_text: str, secret: str) -> str:
+    """Return HMAC of query text without storing the text itself."""
+
+    if not query_text:
+        raise ValueError("query_text cannot be empty")
+    if not secret:
+        raise ValueError("secret cannot be empty")
+    return hmac.new(secret.encode("utf-8"), query_text.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _reject_sensitive_keys(value: Mapping[str, Any]) -> None:
+    for key, item in value.items():
+        if str(key).casefold() in FORBIDDEN_CACHE_PAYLOAD_KEYS:
+            raise ValueError("sensitive cache fingerprint key is not allowed")
+        if isinstance(item, Mapping):
+            _reject_sensitive_keys(item)

--- a/backend/rag/cache/cache_fingerprint.py
+++ b/backend/rag/cache/cache_fingerprint.py
@@ -55,13 +55,17 @@ def build_retrieval_fingerprint(
 
 
 def hmac_query_hash(query_text: str, secret: str) -> str:
-    """Return HMAC of query text without storing the text itself."""
+    """Return HMAC of query text; callers must persist only the returned hash."""
 
     if not query_text:
         raise ValueError("query_text cannot be empty")
     if not secret:
         raise ValueError("secret cannot be empty")
-    return hmac.new(secret.encode("utf-8"), query_text.encode("utf-8"), hashlib.sha256).hexdigest()
+    return hmac.new(
+        secret.encode("utf-8"),
+        query_text.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
 
 
 def _reject_sensitive_keys(value: Mapping[str, Any]) -> None:

--- a/backend/rag/cache/cache_layer.py
+++ b/backend/rag/cache/cache_layer.py
@@ -23,7 +23,11 @@ from backend.rag.cache.cache_models import (
     sanitize_metadata,
 )
 from backend.rag.cache.errors import CachePayloadError, CacheVectorDimensionError
-from backend.rag.cache.types import CacheFilterValue
+from backend.rag.cache.types import (
+    CacheCollectionClient,
+    CacheFilterValue,
+    CacheLayerClient,
+)
 
 
 class CacheLayer:
@@ -31,14 +35,14 @@ class CacheLayer:
 
     def __init__(
         self,
-        client: Any,
+        client: AsyncQdrantClient | CacheLayerClient,
         settings: CacheSettings,
         collection_manager: CacheCollectionManager | None = None,
     ) -> None:
         self._client = client
         self._settings = settings
         self._collection_manager = collection_manager or CacheCollectionManager(
-            client,
+            cast(AsyncQdrantClient | CacheCollectionClient, client),
             settings,
         )
 

--- a/backend/rag/cache/cache_layer.py
+++ b/backend/rag/cache/cache_layer.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from uuid import UUID, uuid4
 
+from loguru import logger
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.http import models
 
@@ -149,8 +150,9 @@ class CacheLayer:
         *,
         dry_run: bool = False,
     ) -> CacheInvalidationResult:
+        clean_version = _require_non_empty_text(version, "version")
         return await self._invalidate(
-            _filter_from_mapping({"schema_version": version}),
+            _filter_from_mapping({"schema_version": clean_version}),
             selector_kind="schema_version",
             dry_run=dry_run,
         )
@@ -173,8 +175,9 @@ class CacheLayer:
         *,
         dry_run: bool = False,
     ) -> CacheInvalidationResult:
+        clean_corpus_epoch = _require_non_empty_text(corpus_epoch, "corpus_epoch")
         return await self._invalidate(
-            _filter_from_mapping({"corpus_epoch": corpus_epoch}),
+            _filter_from_mapping({"corpus_epoch": clean_corpus_epoch}),
             selector_kind="corpus_epoch",
             dry_run=dry_run,
         )
@@ -239,7 +242,8 @@ class CacheLayer:
                 points=[str(cache_id)],
                 wait=True,
             )
-        except Exception:
+        except Exception as exc:
+            logger.opt(exception=exc).debug("cache_record_hit_failed")
             return
 
     async def _invalidate(
@@ -337,6 +341,13 @@ def _filter_from_mapping(values: Mapping[str, CacheFilterValue]) -> models.Filte
             for key, value in values.items()
         ]
     )
+
+
+def _require_non_empty_text(value: str, field_name: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise ValueError(f"{field_name} cannot be empty")
+    return clean
 
 
 def _cache_hit_from_point(point: object, *, score: float) -> CacheHit:

--- a/backend/rag/cache/cache_layer.py
+++ b/backend/rag/cache/cache_layer.py
@@ -85,7 +85,11 @@ class CacheLayer:
         score = float(getattr(point, "score", 0.0))
         if score < self._settings.threshold:
             return None
-        hit = _cache_hit_from_point(point, score=score)
+        try:
+            hit = _cache_hit_from_point(point, score=score)
+        except CachePayloadError as exc:
+            logger.opt(exception=exc).debug("cache_lookup_bad_payload_skipped")
+            return None
         if _is_hit_expired(hit):
             return None
         await self.record_hit(cache_id=hit.cache_id, current_hit_count=hit.hit_count)

--- a/backend/rag/cache/cache_layer.py
+++ b/backend/rag/cache/cache_layer.py
@@ -23,6 +23,7 @@ from backend.rag.cache.cache_models import (
     sanitize_metadata,
 )
 from backend.rag.cache.errors import CachePayloadError, CacheVectorDimensionError
+from backend.rag.cache.types import CacheFilterValue
 
 
 class CacheLayer:
@@ -30,7 +31,7 @@ class CacheLayer:
 
     def __init__(
         self,
-        client: AsyncQdrantClient,
+        client: Any,
         settings: CacheSettings,
         collection_manager: CacheCollectionManager | None = None,
     ) -> None:
@@ -322,7 +323,7 @@ def _filter_for_fingerprint(fingerprint: CacheFingerprint) -> models.Filter:
     return _filter_from_mapping(fingerprint.to_payload_filter_conditions())
 
 
-def _filter_from_mapping(values: Mapping[str, object]) -> models.Filter:
+def _filter_from_mapping(values: Mapping[str, CacheFilterValue]) -> models.Filter:
     return models.Filter(
         must=[
             models.FieldCondition(
@@ -352,7 +353,9 @@ def _cache_hit_from_point(point: object, *, score: float) -> CacheHit:
             schema_version=str(payload["schema_version"]),
         )
         doc_ids = tuple(str(item) for item in _sequence_payload(payload, "result_doc_ids"))
-        scores = tuple(float(item) for item in _sequence_payload(payload, "result_scores"))
+        scores = tuple(
+            _payload_float(item) for item in _sequence_payload(payload, "result_scores")
+        )
         created_at = _parse_datetime(payload["created_at"], "created_at")
         expires_at_raw = payload.get("expires_at")
         expires_at = (
@@ -382,6 +385,15 @@ def _sequence_payload(payload: Mapping[str, object], key: str) -> Sequence[objec
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         raise CachePayloadError("cache payload sequence field is malformed")
     return value
+
+
+def _payload_float(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise CachePayloadError("cache payload score is malformed")
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise CachePayloadError("cache payload score is malformed")
+    return parsed
 
 
 def _parse_datetime(value: object, field_name: str) -> datetime:

--- a/backend/rag/cache/cache_layer.py
+++ b/backend/rag/cache/cache_layer.py
@@ -1,0 +1,397 @@
+"""Async Qdrant-backed semantic retrieval cache layer."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http import models
+
+from backend.rag.cache.cache_collection import CacheCollectionManager
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.cache_models import (
+    SCHEMA_VERSION_QUERY_CACHE_V1,
+    CacheEntry,
+    CacheFingerprint,
+    CacheHit,
+    CacheInvalidationResult,
+    RetrievalResult,
+    sanitize_metadata,
+)
+from backend.rag.cache.errors import CachePayloadError, CacheVectorDimensionError
+
+
+class CacheLayer:
+    """Plug-in semantic retrieval cache over a dedicated Qdrant collection."""
+
+    def __init__(
+        self,
+        client: AsyncQdrantClient,
+        settings: CacheSettings,
+        collection_manager: CacheCollectionManager | None = None,
+    ) -> None:
+        self._client = client
+        self._settings = settings
+        self._collection_manager = collection_manager or CacheCollectionManager(
+            client,
+            settings,
+        )
+
+    def is_enabled(self) -> bool:
+        """Return whether cache is enabled."""
+
+        return self._settings.enabled
+
+    async def ensure_ready(self) -> None:
+        """Ensure the cache collection and indexes exist."""
+
+        if not self.is_enabled():
+            return
+        await self._collection_manager.ensure_collection()
+
+    async def lookup(
+        self,
+        *,
+        query_vector: Sequence[float],
+        fingerprint: CacheFingerprint,
+    ) -> CacheHit | None:
+        """Return a cache hit for a semantically equivalent query, if present."""
+
+        if not self.is_enabled():
+            return None
+        vector = _validate_query_vector(query_vector, self._settings.vector_size)
+        result = await self._client.query_points(
+            collection_name=self._settings.collection_name,
+            query=vector,
+            query_filter=_filter_for_fingerprint(fingerprint),
+            limit=1,
+            with_payload=True,
+            with_vectors=False,
+        )
+        points = list(getattr(result, "points", []))
+        if not points:
+            return None
+        point = points[0]
+        score = float(getattr(point, "score", 0.0))
+        if score < self._settings.threshold:
+            return None
+        hit = _cache_hit_from_point(point, score=score)
+        if _is_hit_expired(hit):
+            return None
+        await self.record_hit(cache_id=hit.cache_id, current_hit_count=hit.hit_count)
+        return hit
+
+    async def store(
+        self,
+        *,
+        query_vector: Sequence[float],
+        result: RetrievalResult,
+        fingerprint: CacheFingerprint,
+        cache_id: UUID | None = None,
+    ) -> CacheEntry | None:
+        """Store a retrieval result. Returns None when cache is disabled."""
+
+        if not self.is_enabled():
+            return None
+        if len(result.doc_ids) > self._settings.max_result_docs:
+            raise ValueError("result has more docs than max_result_docs")
+        resolved_cache_id = cache_id or uuid4()
+        vector = _validate_query_vector(query_vector, self._settings.vector_size)
+        created_at = datetime.now(UTC)
+        expires_at = (
+            created_at + timedelta(seconds=self._settings.default_ttl_seconds)
+            if self._settings.default_ttl_seconds is not None
+            else None
+        )
+        entry = CacheEntry(
+            cache_id=resolved_cache_id,
+            query_vector=tuple(vector),
+            result_doc_ids=result.doc_ids,
+            result_scores=result.scores,
+            fusion_backend=result.fusion_backend,
+            fingerprint=fingerprint,
+            created_at=created_at,
+            expires_at=expires_at,
+            hit_count=0,
+        )
+        payload = build_cache_payload(
+            cache_id=resolved_cache_id,
+            result=result,
+            fingerprint=fingerprint,
+            settings=self._settings,
+            created_at=created_at,
+            expires_at=expires_at,
+        )
+        point = models.PointStruct(
+            id=str(resolved_cache_id),
+            vector=vector,
+            payload=payload,
+        )
+        await self._client.upsert(
+            collection_name=self._settings.collection_name,
+            points=[point],
+            wait=True,
+        )
+        return entry
+
+    async def invalidate_by_schema_version(
+        self,
+        version: str,
+        *,
+        dry_run: bool = False,
+    ) -> CacheInvalidationResult:
+        return await self._invalidate(
+            _filter_from_mapping({"schema_version": version}),
+            selector_kind="schema_version",
+            dry_run=dry_run,
+        )
+
+    async def invalidate_by_fingerprint(
+        self,
+        fingerprint: CacheFingerprint,
+        *,
+        dry_run: bool = False,
+    ) -> CacheInvalidationResult:
+        return await self._invalidate(
+            _filter_for_fingerprint(fingerprint),
+            selector_kind="fingerprint",
+            dry_run=dry_run,
+        )
+
+    async def invalidate_by_corpus_epoch(
+        self,
+        corpus_epoch: str,
+        *,
+        dry_run: bool = False,
+    ) -> CacheInvalidationResult:
+        return await self._invalidate(
+            _filter_from_mapping({"corpus_epoch": corpus_epoch}),
+            selector_kind="corpus_epoch",
+            dry_run=dry_run,
+        )
+
+    async def invalidate_expired(
+        self,
+        *,
+        now: datetime | None = None,
+        dry_run: bool = False,
+    ) -> CacheInvalidationResult:
+        resolved_now = now or datetime.now(UTC)
+        return await self._invalidate(
+            models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key="expires_at",
+                        range=models.DatetimeRange(lte=resolved_now),
+                    )
+                ]
+            ),
+            selector_kind="expired",
+            dry_run=dry_run,
+        )
+
+    async def get_hot_entries(
+        self,
+        *,
+        top_n: int = 100,
+    ) -> list[CacheHit]:
+        """Return hot cache entries sorted by hit count descending."""
+
+        if top_n <= 0:
+            raise ValueError("top_n must be > 0")
+        limit = top_n * self._settings.hot_entries_oversample_factor
+        points, _ = await self._client.scroll(
+            collection_name=self._settings.collection_name,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        hits = [
+            _cache_hit_from_point(point, score=float(getattr(point, "score", 1.0)))
+            for point in points
+        ]
+        active = [hit for hit in hits if not _is_hit_expired(hit)]
+        return sorted(active, key=lambda hit: hit.hit_count, reverse=True)[:top_n]
+
+    async def record_hit(
+        self,
+        *,
+        cache_id: UUID,
+        current_hit_count: int | None = None,
+    ) -> None:
+        """Best-effort hit counter update."""
+
+        if current_hit_count is None:
+            return
+        try:
+            await self._client.set_payload(
+                collection_name=self._settings.collection_name,
+                payload={"hit_count": current_hit_count + 1},
+                points=[str(cache_id)],
+                wait=True,
+            )
+        except Exception:
+            return
+
+    async def _invalidate(
+        self,
+        query_filter: models.Filter,
+        *,
+        selector_kind: str,
+        dry_run: bool,
+    ) -> CacheInvalidationResult:
+        count = await self._client.count(
+            collection_name=self._settings.collection_name,
+            count_filter=query_filter,
+            exact=True,
+        )
+        matched = int(getattr(count, "count", 0))
+        if dry_run:
+            return CacheInvalidationResult(
+                matched_count=matched,
+                deleted_count=None,
+                selector_kind=selector_kind,
+                dry_run=True,
+            )
+        await self._client.delete(
+            collection_name=self._settings.collection_name,
+            points_selector=models.FilterSelector(filter=query_filter),
+            wait=True,
+        )
+        return CacheInvalidationResult(
+            matched_count=matched,
+            deleted_count=matched,
+            selector_kind=selector_kind,
+            dry_run=False,
+        )
+
+
+def build_cache_payload(
+    *,
+    cache_id: UUID,
+    result: RetrievalResult,
+    fingerprint: CacheFingerprint,
+    settings: CacheSettings,
+    created_at: datetime | None = None,
+    expires_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Build safe Qdrant payload for one cache entry."""
+
+    resolved_created_at = created_at or datetime.now(UTC)
+    resolved_expires_at = expires_at
+    if resolved_expires_at is None and settings.default_ttl_seconds is not None:
+        resolved_expires_at = resolved_created_at + timedelta(
+            seconds=settings.default_ttl_seconds
+        )
+    metadata = sanitize_metadata(result.metadata)
+    return {
+        "cache_id": str(cache_id),
+        "result_doc_ids": list(result.doc_ids),
+        "result_scores": list(result.scores),
+        "fusion_backend": result.fusion_backend,
+        "profile_name": fingerprint.profile_name,
+        "embedding_model": fingerprint.embedding_model,
+        "embedding_dim": fingerprint.embedding_dim,
+        "source_collection": fingerprint.source_collection,
+        "corpus_epoch": fingerprint.corpus_epoch,
+        "retrieval_fingerprint": fingerprint.retrieval_fingerprint,
+        "schema_version": SCHEMA_VERSION_QUERY_CACHE_V1,
+        "created_at": resolved_created_at.isoformat(),
+        "expires_at": resolved_expires_at.isoformat() if resolved_expires_at else None,
+        "hit_count": 0,
+        "metadata": metadata,
+    }
+
+
+def _validate_query_vector(vector: Sequence[float], expected_size: int) -> list[float]:
+    values = [float(item) for item in vector]
+    if not values:
+        raise CacheVectorDimensionError("query_vector cannot be empty")
+    if len(values) != expected_size:
+        raise CacheVectorDimensionError("query_vector dimension mismatch")
+    if any(not math.isfinite(item) for item in values):
+        raise CacheVectorDimensionError("query_vector must contain only finite values")
+    return values
+
+
+def _filter_for_fingerprint(fingerprint: CacheFingerprint) -> models.Filter:
+    return _filter_from_mapping(fingerprint.to_payload_filter_conditions())
+
+
+def _filter_from_mapping(values: Mapping[str, object]) -> models.Filter:
+    return models.Filter(
+        must=[
+            models.FieldCondition(
+                key=key,
+                match=models.MatchValue(value=value),
+            )
+            for key, value in values.items()
+        ]
+    )
+
+
+def _cache_hit_from_point(point: object, *, score: float) -> CacheHit:
+    payload = getattr(point, "payload", None)
+    if not isinstance(payload, Mapping):
+        raise CachePayloadError("cache payload is missing")
+    if payload.get("schema_version") != SCHEMA_VERSION_QUERY_CACHE_V1:
+        raise CachePayloadError("cache payload schema_version is invalid")
+    try:
+        cache_id = UUID(str(getattr(point, "id", payload.get("cache_id"))))
+        fingerprint = CacheFingerprint(
+            profile_name=str(payload["profile_name"]),
+            embedding_model=str(payload["embedding_model"]),
+            embedding_dim=int(payload["embedding_dim"]),
+            source_collection=str(payload["source_collection"]),
+            corpus_epoch=str(payload["corpus_epoch"]),
+            retrieval_fingerprint=str(payload["retrieval_fingerprint"]),
+            schema_version=str(payload["schema_version"]),
+        )
+        doc_ids = tuple(str(item) for item in _sequence_payload(payload, "result_doc_ids"))
+        scores = tuple(float(item) for item in _sequence_payload(payload, "result_scores"))
+        created_at = _parse_datetime(payload["created_at"], "created_at")
+        expires_at_raw = payload.get("expires_at")
+        expires_at = (
+            None
+            if expires_at_raw is None
+            else _parse_datetime(expires_at_raw, "expires_at")
+        )
+        return CacheHit(
+            cache_id=cache_id,
+            similarity_score=score,
+            result_doc_ids=doc_ids,
+            result_scores=scores,
+            fusion_backend=cast(Any, payload["fusion_backend"]),
+            fingerprint=fingerprint,
+            created_at=created_at,
+            expires_at=expires_at,
+            hit_count=int(payload.get("hit_count", 0)),
+        )
+    except CachePayloadError:
+        raise
+    except Exception as exc:
+        raise CachePayloadError("cache payload is malformed") from exc
+
+
+def _sequence_payload(payload: Mapping[str, object], key: str) -> Sequence[object]:
+    value = payload.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise CachePayloadError("cache payload sequence field is malformed")
+    return value
+
+
+def _parse_datetime(value: object, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise CachePayloadError(f"cache payload {field_name} is malformed")
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CachePayloadError(f"cache payload {field_name} is timezone-naive")
+    return parsed
+
+
+def _is_hit_expired(hit: CacheHit) -> bool:
+    return hit.expires_at is not None and hit.expires_at <= datetime.now(UTC)

--- a/backend/rag/cache/cache_models.py
+++ b/backend/rag/cache/cache_models.py
@@ -1,0 +1,242 @@
+"""Immutable models for the HybridRAG semantic retrieval cache."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import UUID
+
+
+SCHEMA_VERSION_QUERY_CACHE_V1 = "query-cache-v1"
+FusionBackend = Literal["python_rrf", "qdrant_rrf"]
+CacheDistance = Literal["Cosine", "Dot", "Euclid", "Manhattan"]
+FORBIDDEN_CACHE_PAYLOAD_KEYS = frozenset(
+    {
+        "prompt",
+        "raw_prompt",
+        "query_text",
+        "raw_query",
+        "answer",
+        "response",
+        "chunks",
+        "chunk_text",
+        "secret",
+        "api_key",
+        "token",
+        "embedding",
+        "vector",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CacheFingerprint:
+    """Versioned retrieval-cache fingerprint."""
+
+    profile_name: str
+    embedding_model: str
+    embedding_dim: int
+    source_collection: str
+    corpus_epoch: str
+    retrieval_fingerprint: str
+    schema_version: str = SCHEMA_VERSION_QUERY_CACHE_V1
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "profile_name",
+            "embedding_model",
+            "source_collection",
+            "corpus_epoch",
+            "retrieval_fingerprint",
+        ):
+            _require_non_empty(getattr(self, field_name), field_name)
+        if self.embedding_dim <= 0:
+            raise ValueError("embedding_dim must be > 0")
+        if self.schema_version != SCHEMA_VERSION_QUERY_CACHE_V1:
+            raise ValueError("schema_version must be query-cache-v1")
+
+    def to_payload_filter_conditions(self) -> dict[str, object]:
+        """Return payload fields that must match this fingerprint."""
+
+        return {
+            "schema_version": self.schema_version,
+            "profile_name": self.profile_name,
+            "embedding_model": self.embedding_model,
+            "embedding_dim": self.embedding_dim,
+            "source_collection": self.source_collection,
+            "corpus_epoch": self.corpus_epoch,
+            "retrieval_fingerprint": self.retrieval_fingerprint,
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RetrievalResult:
+    """Safe retrieval result value that may be cached."""
+
+    doc_ids: tuple[str, ...]
+    scores: tuple[float, ...]
+    fusion_backend: FusionBackend
+    profile_name: str
+    retrieval_fingerprint: str
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.doc_ids:
+            raise ValueError("doc_ids cannot be empty")
+        if not self.scores:
+            raise ValueError("scores cannot be empty")
+        if len(self.doc_ids) != len(self.scores):
+            raise ValueError("doc_ids and scores must have the same length")
+        for doc_id in self.doc_ids:
+            _require_non_empty(doc_id, "doc_ids")
+        for score in self.scores:
+            _require_finite_number(score, "scores")
+        if self.fusion_backend not in ("python_rrf", "qdrant_rrf"):
+            raise ValueError("fusion_backend must be python_rrf or qdrant_rrf")
+        _require_non_empty(self.profile_name, "profile_name")
+        _require_non_empty(self.retrieval_fingerprint, "retrieval_fingerprint")
+        if self.metadata is not None:
+            _validate_safe_mapping(self.metadata, "metadata")
+            object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CacheEntry:
+    """Record stored in Qdrant cache collection."""
+
+    cache_id: UUID
+    query_vector: tuple[float, ...]
+    result_doc_ids: tuple[str, ...]
+    result_scores: tuple[float, ...]
+    fusion_backend: FusionBackend
+    fingerprint: CacheFingerprint
+    created_at: datetime
+    expires_at: datetime | None = None
+    hit_count: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cache_id, UUID):
+            raise TypeError("cache_id must be a UUID")
+        _validate_vector(self.query_vector, "query_vector")
+        _validate_result_lists(self.result_doc_ids, self.result_scores)
+        if self.fusion_backend not in ("python_rrf", "qdrant_rrf"):
+            raise ValueError("fusion_backend must be python_rrf or qdrant_rrf")
+        if not isinstance(self.fingerprint, CacheFingerprint):
+            raise TypeError("fingerprint must be CacheFingerprint")
+        _require_tzaware(self.created_at, "created_at")
+        if self.expires_at is not None:
+            _require_tzaware(self.expires_at, "expires_at")
+            if self.expires_at <= self.created_at:
+                raise ValueError("expires_at must be greater than created_at")
+        if self.hit_count < 0:
+            raise ValueError("hit_count must be >= 0")
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        """Return whether the entry has expired."""
+
+        if self.expires_at is None:
+            return False
+        resolved_now = now or datetime.now(UTC)
+        _require_tzaware(resolved_now, "now")
+        return self.expires_at <= resolved_now
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CacheHit:
+    """Lightweight cache lookup hit."""
+
+    cache_id: UUID
+    similarity_score: float
+    result_doc_ids: tuple[str, ...]
+    result_scores: tuple[float, ...]
+    fusion_backend: FusionBackend
+    fingerprint: CacheFingerprint
+    created_at: datetime
+    expires_at: datetime | None
+    hit_count: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cache_id, UUID):
+            raise TypeError("cache_id must be a UUID")
+        if not 0.0 <= self.similarity_score <= 1.0:
+            raise ValueError("similarity_score must be between 0.0 and 1.0")
+        _validate_result_lists(self.result_doc_ids, self.result_scores)
+        _require_tzaware(self.created_at, "created_at")
+        if self.expires_at is not None:
+            _require_tzaware(self.expires_at, "expires_at")
+        if self.hit_count < 0:
+            raise ValueError("hit_count must be >= 0")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CacheInvalidationResult:
+    """Result of a cache invalidation operation."""
+
+    matched_count: int | None
+    deleted_count: int | None
+    selector_kind: str
+    dry_run: bool
+
+    def __post_init__(self) -> None:
+        if self.matched_count is not None and self.matched_count < 0:
+            raise ValueError("matched_count must be >= 0")
+        if self.deleted_count is not None and self.deleted_count < 0:
+            raise ValueError("deleted_count must be >= 0")
+        _require_non_empty(self.selector_kind, "selector_kind")
+
+
+def sanitize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a shallow safe metadata dict."""
+
+    if metadata is None:
+        return {}
+    _validate_safe_mapping(metadata, "metadata")
+    return dict(metadata)
+
+
+def _validate_result_lists(doc_ids: tuple[str, ...], scores: tuple[float, ...]) -> None:
+    if not doc_ids:
+        raise ValueError("result_doc_ids cannot be empty")
+    if len(doc_ids) != len(scores):
+        raise ValueError("result_doc_ids and result_scores must have the same length")
+    for doc_id in doc_ids:
+        _require_non_empty(doc_id, "result_doc_ids")
+    for score in scores:
+        _require_finite_number(score, "result_scores")
+
+
+def _validate_vector(vector: tuple[float, ...], field_name: str) -> None:
+    if not vector:
+        raise ValueError(f"{field_name} cannot be empty")
+    for item in vector:
+        _require_finite_number(item, field_name)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+
+
+def _require_finite_number(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field_name} must be numeric")
+    if not math.isfinite(float(value)):
+        raise ValueError(f"{field_name} must contain only finite values")
+
+
+def _require_tzaware(value: datetime, field_name: str) -> None:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+def _validate_safe_mapping(value: Mapping[str, Any], field_name: str) -> None:
+    for key in value:
+        if str(key).casefold() in FORBIDDEN_CACHE_PAYLOAD_KEYS:
+            raise ValueError(f"{field_name} contains sensitive cache payload key")

--- a/backend/rag/cache/cache_models.py
+++ b/backend/rag/cache/cache_models.py
@@ -9,6 +9,8 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 from uuid import UUID
 
+from backend.rag.cache.types import CacheFilterValue
+
 
 SCHEMA_VERSION_QUERY_CACHE_V1 = "query-cache-v1"
 FusionBackend = Literal["python_rrf", "qdrant_rrf"]
@@ -58,7 +60,7 @@ class CacheFingerprint:
         if self.schema_version != SCHEMA_VERSION_QUERY_CACHE_V1:
             raise ValueError("schema_version must be query-cache-v1")
 
-    def to_payload_filter_conditions(self) -> dict[str, object]:
+    def to_payload_filter_conditions(self) -> dict[str, CacheFilterValue]:
         """Return payload fields that must match this fingerprint."""
 
         return {

--- a/backend/rag/cache/errors.py
+++ b/backend/rag/cache/errors.py
@@ -1,0 +1,25 @@
+"""Errors raised by the HybridRAG semantic cache layer."""
+
+
+class CacheError(RuntimeError):
+    """Base cache error."""
+
+
+class CacheDisabled(CacheError):
+    """Raised when a write is attempted while cache is disabled."""
+
+
+class CacheCollectionMismatchError(CacheError):
+    """Raised when an existing cache collection does not match settings."""
+
+
+class CachePayloadError(CacheError):
+    """Raised when a Qdrant payload cannot be safely parsed."""
+
+
+class CacheVectorDimensionError(CacheError):
+    """Raised when a query vector does not match configured dimensions."""
+
+
+class CacheSafetyError(CacheError):
+    """Raised when sensitive fields are detected in cache metadata."""

--- a/backend/rag/cache/types.py
+++ b/backend/rag/cache/types.py
@@ -3,10 +3,37 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Any, Literal, Protocol
 
 
 CachePayloadValue = bool | int | float | str | None | Sequence[str] | Sequence[float]
 CacheFilterValue = bool | int | str
 CacheFusionBackend = Literal["python_rrf", "qdrant_rrf"]
 
+
+class CacheCollectionClient(Protocol):
+    """Minimum async Qdrant surface used by CacheCollectionManager."""
+
+    async def collection_exists(self, collection_name: str) -> bool: ...
+
+    async def create_collection(self, **kwargs: Any) -> Any: ...
+
+    async def get_collection(self, collection_name: str) -> Any: ...
+
+    async def create_payload_index(self, **kwargs: Any) -> Any: ...
+
+
+class CacheLayerClient(Protocol):
+    """Minimum async Qdrant surface used by CacheLayer."""
+
+    async def query_points(self, **kwargs: Any) -> Any: ...
+
+    async def upsert(self, **kwargs: Any) -> Any: ...
+
+    async def count(self, **kwargs: Any) -> Any: ...
+
+    async def delete(self, **kwargs: Any) -> Any: ...
+
+    async def scroll(self, **kwargs: Any) -> Any: ...
+
+    async def set_payload(self, **kwargs: Any) -> Any: ...

--- a/backend/rag/cache/types.py
+++ b/backend/rag/cache/types.py
@@ -1,0 +1,12 @@
+"""Shared type contracts for the semantic retrieval cache."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+
+CachePayloadValue = bool | int | float | str | None | Sequence[str] | Sequence[float]
+CacheFilterValue = bool | int | str
+CacheFusionBackend = Literal["python_rrf", "qdrant_rrf"]
+

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -13,7 +13,7 @@
 
 Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
 Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
-HEAD: `d7014ffe0544c45aa1895c33150ed2586b8a532b`
+Implementation commit: `d7014ffe0544c45aa1895c33150ed2586b8a532b`
 
 Local and remote branch are aligned (`HEAD...origin/rag-01b/pr-03-hybridrag-cache-qdrant`
 is `0 0`).

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -13,7 +13,7 @@
 
 Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
 Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
-Implementation commit: `d7014ffe0544c45aa1895c33150ed2586b8a532b`
+Implementation series: `414bf28..HEAD` on the draft PR branch.
 
 Local and remote branch are aligned (`HEAD...origin/rag-01b/pr-03-hybridrag-cache-qdrant`
 is `0 0`).

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,24 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-03 RC-01 cache hardening
+**Updated by:** Codex — RAG-01B PR-03 ready for COWORK review
+
+---
+
+## RAG-01B PR-03 Review Gate
+
+Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
+PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
+Status: ready for review, not merged.
+
+Rito status:
+
+- Local branch pulled with `--ff-only`: already up to date.
+- Local Qdrant checked healthy at `http://127.0.0.1:6333`.
+- Live Qdrant integration now executed with
+  `TEST_QDRANT_URL=http://127.0.0.1:6333`: 3 passed.
+- PR was converted from draft to ready for review.
+- Merge/prune are blocked until COWORK/human approval.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,35 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-03 ready for COWORK review
+**Updated by:** Codex — RAG-01B PR-03 RC-02 corrupted payload hardening
+
+---
+
+## RAG-01B PR-03 RC-02 — Corrupted Cache Payload Handling
+
+Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
+PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
+
+Implemented RC-02 fixes:
+
+- `CacheLayer.lookup` now treats corrupted Qdrant cache payload as a safe cache
+  miss, logs `cache_lookup_bad_payload_skipped` at DEBUG, and returns `None`.
+- Added unit coverage proving corrupted cache payload does not raise
+  `CachePayloadError` to callers.
+- `hmac_query_hash` docstring now explicitly warns never to log `query_text`
+  alongside the returned hash.
+
+Validation:
+
+- `test_cache_layer.py`: 9 passed.
+- `test_cache_fingerprint.py`: 8 passed.
+- PR-03 + observability focused tests: 52 passed.
+- Full unit suite: 1590 passed / 253 subtests passed.
+- Live Qdrant integration with `TEST_QDRANT_URL=http://127.0.0.1:6333`: 3 passed.
+- `uv run mypy --strict .`: success.
+- `uv run pyright`: 0 errors.
+- `git diff --check`: clean.
+- Cache module scope scans: no forbidden imports or destructive collection calls.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,40 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-01 RC-03 TimescaleDB/Qlib/Kronos temporal memory addendum
+**Updated by:** Codex — RAG-01B PR-03 HybridRAG semantic cache draft PR
+
+---
+
+## RAG-01B PR-03 — HybridRAG Semantic Cache Layer (Qdrant)
+
+Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
+Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
+HEAD: `d7014ffe0544c45aa1895c33150ed2586b8a532b`
+
+Local and remote branch are aligned (`HEAD...origin/rag-01b/pr-03-hybridrag-cache-qdrant`
+is `0 0`).
+
+Implemented:
+
+- SDD for PR-03 semantic retrieval cache.
+- `backend/rag/cache/*` settings, models, fingerprint helpers, Qdrant collection
+  manager, async `CacheLayer`, errors and shared types.
+- Unit tests with fake Qdrant clients.
+- Optional live Qdrant integration tests guarded by environment configuration.
+
+Validation:
+
+- PR-03 focused unit tests: 44 passed.
+- Optional Qdrant integration tests: 3 skipped cleanly when live integration env
+  is not set.
+- Full unit suite: 1587 passed / 253 subtests passed.
+- `uv run mypy --strict .`: success.
+- `uv run pyright`: 0 errors.
+- `git diff --check`: clean.
+
+Explicitly not implemented in PR-03: response cache, raw query/prompt/final
+answer/full chunk storage, LLM calls, embedding generation, MCP/API/gRPC,
+PostgreSQL/TimescaleDB changes, Qdrant knowledge collection mutation or ORM.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,37 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-03 HybridRAG semantic cache draft PR
+**Updated by:** Codex — RAG-01B PR-03 RC-01 cache hardening
+
+---
+
+## RAG-01B PR-03 RC-01 — Semantic Cache Hardening
+
+Current branch: `rag-01b/pr-03-hybridrag-cache-qdrant`
+Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/106>
+
+Implemented RC-01 fixes:
+
+- `CacheSettings` now rejects `collection_name == source_collection`.
+- `invalidate_by_schema_version` rejects empty/blank version values.
+- `invalidate_by_corpus_epoch` rejects empty/blank corpus epoch values.
+- `test_rag_observability_config` no longer writes to a fixed file under
+  `tests/`; it uses an isolated temporary directory, resolving the pre-existing
+  PermissionError/carry-over artifact risk.
+- `hmac_query_hash` is documented as a caller-side helper whose raw query input
+  must never be persisted; only the returned hash may be stored.
+- `record_hit` remains best-effort but now emits a safe DEBUG log on failure.
+
+Validation:
+
+- RC focused tests: 37 passed.
+- PR-03 + observability focused tests: 51 passed.
+- Full unit suite: 1589 passed / 253 subtests passed.
+- Optional Qdrant integration tests: 3 skipped cleanly when live integration env
+  is not set.
+- `uv run mypy --strict .`: success.
+- `uv run pyright`: 0 errors.
+- `git diff --check`: clean.
 
 ---
 

--- a/docs/specs/rag-01b/pr-03-hybridrag-cache-qdrant.md
+++ b/docs/specs/rag-01b/pr-03-hybridrag-cache-qdrant.md
@@ -1,0 +1,124 @@
+# RAG-01B-PR-03 - HybridRAG Semantic Cache Layer (Qdrant)
+
+## Objetivo
+
+Criar uma camada assíncrona de cache semântico para resultados de retrieval do
+HybridRAG, usando Qdrant em uma coleção separada da coleção de conhecimento.
+
+Este PR cria apenas uma camada plugável. Ele não altera o pipeline HybridRAG
+principal.
+
+## Contexto
+
+Qdrant continua sendo a memória vetorial do QUIMERA. PostgreSQL 18.4 +
+TimescaleDB guarda memória temporal estruturada. A coleção de cache é separada
+da coleção de conhecimento para evitar mistura entre conteúdo canônico e
+resultados derivados de retrieval.
+
+## Decisão: retrieval cache, não response cache
+
+O cache armazena:
+
+- vetor já calculado da query;
+- ids de documentos recuperados;
+- scores;
+- metadados seguros;
+- fingerprint do perfil de retrieval.
+
+O cache não armazena query bruta, prompt bruto, resposta final do LLM, chunks
+inteiros, embeddings no payload ou secrets.
+
+## Qdrant collection separada
+
+Default: `quimera_query_cache`.
+
+Coleção de conhecimento e coleção de cache devem permanecer separadas. A
+camada nunca usa `recreate_collection`, nunca apaga coleção inteira e nunca
+recria coleção incompatível automaticamente.
+
+## Cache fingerprint
+
+O fingerprint amarra cache a:
+
+- profile name;
+- embedding model;
+- embedding dimension;
+- source collection;
+- corpus epoch;
+- retrieval fingerprint;
+- schema version.
+
+## Payload permitido
+
+- `result_doc_ids`
+- `result_scores`
+- `fusion_backend`
+- `profile_name`
+- `embedding_model`
+- `embedding_dim`
+- `source_collection`
+- `corpus_epoch`
+- `retrieval_fingerprint`
+- `schema_version`
+- `created_at`
+- `expires_at`
+- `hit_count`
+- `metadata` sanitizada
+
+## Payload proibido
+
+Não armazenar query bruta, prompt, resposta, chunks, chunk text, secrets, API
+keys, tokens, embeddings ou vectors no payload.
+
+## Settings/env vars
+
+Configuração via `CacheSettings` com prefixo `QUIMERA_CACHE_`. O PR usa injeção
+explícita de settings no `CacheLayer`.
+
+## Contratos Python
+
+Modelos imutáveis:
+
+- `CacheFingerprint`
+- `RetrievalResult`
+- `CacheEntry`
+- `CacheHit`
+- `CacheInvalidationResult`
+
+## CacheLayer semantics
+
+`lookup` retorna `CacheHit | None`. `store` retorna `CacheEntry | None`; quando
+cache está desabilitado, retorna `None` sem chamar Qdrant.
+
+## Collection management
+
+`CacheCollectionManager` cria a collection quando ausente, valida dimensão e
+distância quando existente e cria payload indexes idempotentes.
+
+## Invalidation strategy
+
+Invalidation é sempre por filtro restritivo: schema version, fingerprint,
+corpus epoch ou expiração. Dry-run conta sem deletar.
+
+## Test plan
+
+Unitários usam `FakeQdrantClient`. Integrações rodam apenas com
+`TEST_QDRANT_URL` ou `QUIMERA_QDRANT_URL` e usam collection temporária
+`quimera_query_cache_test_<uuid>`.
+
+## Security/privacy
+
+Sem query bruta, prompt, chunks inteiros, resposta final, secrets, API keys ou
+tokens. Exceções devem ser úteis sem despejar payload bruto.
+
+## Escopo negativo
+
+Sem geração de embeddings, LLM call, RRF, reranker, MCP, API, gRPC,
+PostgreSQL, TimescaleDB, Qlib, Kronos, response cache, prompt cache ou
+mutation da knowledge collection.
+
+## PRs futuros
+
+- Integrar seam no pipeline HybridRAG principal.
+- Adicionar métricas/observabilidade segura.
+- Avaliar políticas de TTL/hot cache em produção local.

--- a/docs/specs/rag-01b/pr-03-hybridrag-cache-qdrant.md
+++ b/docs/specs/rag-01b/pr-03-hybridrag-cache-qdrant.md
@@ -36,6 +36,9 @@ Coleção de conhecimento e coleção de cache devem permanecer separadas. A
 camada nunca usa `recreate_collection`, nunca apaga coleção inteira e nunca
 recria coleção incompatível automaticamente.
 
+`CacheSettings` rejeita configuração em que `collection_name` e
+`source_collection` apontem para a mesma collection.
+
 ## Cache fingerprint
 
 O fingerprint amarra cache a:
@@ -47,6 +50,10 @@ O fingerprint amarra cache a:
 - corpus epoch;
 - retrieval fingerprint;
 - schema version.
+
+Se callers futuros usarem HMAC para derivar identidade semântica a partir de
+texto de query, somente o hash resultante pode ser armazenado. O texto original
+da query nunca deve entrar em payload, logs ou metadados persistidos.
 
 ## Payload permitido
 

--- a/tests/integration/test_qdrant_cache_collection.py
+++ b/tests/integration/test_qdrant_cache_collection.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http import models
+
+from backend.rag.cache.cache_collection import CacheCollectionManager
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.errors import CacheCollectionMismatchError
+
+
+pytestmark = pytest.mark.integration
+
+
+def _qdrant_url() -> str | None:
+    return os.environ.get("TEST_QDRANT_URL") or os.environ.get("QUIMERA_QDRANT_URL")
+
+
+@pytest.fixture
+async def qdrant_client() -> AsyncGenerator[tuple[AsyncQdrantClient, str], None]:
+    url = _qdrant_url()
+    if not url:
+        pytest.skip("TEST_QDRANT_URL or QUIMERA_QDRANT_URL is required")
+    collection = f"quimera_query_cache_test_{uuid4().hex}"
+    client = AsyncQdrantClient(url=url)
+    try:
+        yield client, collection
+    finally:
+        if collection.startswith("quimera_query_cache_test_"):
+            exists = await client.collection_exists(collection)
+            if exists:
+                await client.delete_collection(collection)
+        await client.close()
+
+
+async def test_qdrant_cache_collection_lifecycle(
+    qdrant_client: tuple[AsyncQdrantClient, str],
+) -> None:
+    client, collection = qdrant_client
+    settings = CacheSettings(collection_name=collection, vector_size=4)
+    manager = CacheCollectionManager(client, settings)
+
+    await manager.ensure_collection()
+    await manager.ensure_collection()
+    await manager.ensure_payload_indexes()
+    info = await client.get_collection(collection)
+
+    assert info is not None
+
+
+async def test_qdrant_cache_collection_mismatch_fails(
+    qdrant_client: tuple[AsyncQdrantClient, str],
+) -> None:
+    client, collection = qdrant_client
+    await client.create_collection(
+        collection_name=collection,
+        vectors_config=models.VectorParams(size=3, distance=models.Distance.DOT),
+    )
+    manager = CacheCollectionManager(
+        client,
+        CacheSettings(collection_name=collection, vector_size=4),
+    )
+
+    with pytest.raises(CacheCollectionMismatchError):
+        await manager.ensure_collection()

--- a/tests/integration/test_qdrant_cache_layer_roundtrip.py
+++ b/tests/integration/test_qdrant_cache_layer_roundtrip.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+from qdrant_client import AsyncQdrantClient
+
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.cache_layer import CacheLayer
+from backend.rag.cache.cache_models import CacheFingerprint, RetrievalResult
+
+
+pytestmark = pytest.mark.integration
+
+
+def _qdrant_url() -> str | None:
+    return os.environ.get("TEST_QDRANT_URL") or os.environ.get("QUIMERA_QDRANT_URL")
+
+
+@pytest.fixture
+async def cache_layer() -> AsyncGenerator[CacheLayer, None]:
+    url = _qdrant_url()
+    if not url:
+        pytest.skip("TEST_QDRANT_URL or QUIMERA_QDRANT_URL is required")
+    collection = f"quimera_query_cache_test_{uuid4().hex}"
+    client = AsyncQdrantClient(url=url)
+    settings = CacheSettings(collection_name=collection, vector_size=4, threshold=0.9)
+    layer = CacheLayer(client, settings)
+    try:
+        await layer.ensure_ready()
+        yield layer
+    finally:
+        if collection.startswith("quimera_query_cache_test_"):
+            exists = await client.collection_exists(collection)
+            if exists:
+                await client.delete_collection(collection)
+        await client.close()
+
+
+def _fingerprint(epoch: str = "dev") -> CacheFingerprint:
+    return CacheFingerprint(
+        profile_name="default",
+        embedding_model="qwen3-embedding",
+        embedding_dim=4,
+        source_collection="quimera_knowledge",
+        corpus_epoch=epoch,
+        retrieval_fingerprint="a" * 64,
+    )
+
+
+def _result() -> RetrievalResult:
+    return RetrievalResult(
+        doc_ids=("doc-1",),
+        scores=(0.9,),
+        fusion_backend="python_rrf",
+        profile_name="default",
+        retrieval_fingerprint="a" * 64,
+        metadata={"safe": True},
+    )
+
+
+async def test_qdrant_cache_layer_roundtrip(cache_layer: CacheLayer) -> None:
+    vector = (0.1, 0.2, 0.3, 0.4)
+    fingerprint = _fingerprint()
+
+    entry = await cache_layer.store(
+        query_vector=vector,
+        result=_result(),
+        fingerprint=fingerprint,
+    )
+    hit = await cache_layer.lookup(query_vector=vector, fingerprint=fingerprint)
+    miss = await cache_layer.lookup(query_vector=vector, fingerprint=_fingerprint("dev2"))
+    dry = await cache_layer.invalidate_by_fingerprint(fingerprint, dry_run=True)
+    deleted = await cache_layer.invalidate_by_fingerprint(fingerprint)
+    after_delete = await cache_layer.lookup(query_vector=vector, fingerprint=fingerprint)
+
+    assert entry is not None
+    assert hit is not None
+    assert miss is None
+    assert dry.matched_count is not None
+    assert deleted.deleted_count is not None
+    assert after_delete is None

--- a/tests/unit/test_cache_collection_contract.py
+++ b/tests/unit/test_cache_collection_contract.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.rag.cache.cache_collection import (
+    CACHE_PAYLOAD_INDEXES,
+    CacheCollectionManager,
+    qdrant_distance,
+)
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.errors import CacheCollectionMismatchError
+
+
+class FakeQdrantClient:
+    def __init__(self) -> None:
+        self.exists = False
+        self.collection_info: dict[str, object] = {}
+        self.created: list[dict[str, object]] = []
+        self.indexes: list[tuple[str, object]] = []
+        self.recreated = False
+        self.deleted = False
+
+    async def collection_exists(self, collection_name: str) -> bool:
+        return self.exists
+
+    async def create_collection(self, **kwargs: object) -> None:
+        self.created.append(dict(kwargs))
+        self.exists = True
+        self.collection_info = {"size": 1024, "distance": "Cosine"}
+
+    async def get_collection(self, collection_name: str) -> dict[str, object]:
+        return self.collection_info
+
+    async def create_payload_index(self, **kwargs: object) -> None:
+        self.indexes.append((str(kwargs["field_name"]), kwargs["field_schema"]))
+
+    async def recreate_collection(self, *args: object, **kwargs: object) -> None:
+        self.recreated = True
+
+    async def delete_collection(self, *args: object, **kwargs: object) -> None:
+        self.deleted = True
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_creates_when_absent() -> None:
+    client = FakeQdrantClient()
+    manager = CacheCollectionManager(client, CacheSettings())
+
+    await manager.ensure_collection()
+
+    assert client.created
+    assert client.created[0]["collection_name"] == "quimera_query_cache"
+    assert client.recreated is False
+    assert client.deleted is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_validates_existing_collection() -> None:
+    client = FakeQdrantClient()
+    client.exists = True
+    client.collection_info = {"size": 1024, "distance": "Cosine"}
+    manager = CacheCollectionManager(client, CacheSettings())
+
+    await manager.ensure_collection()
+
+    assert client.created == []
+
+
+@pytest.mark.asyncio
+async def test_collection_mismatch_fails_closed() -> None:
+    client = FakeQdrantClient()
+    client.exists = True
+    client.collection_info = {"size": 768, "distance": "Dot"}
+    manager = CacheCollectionManager(client, CacheSettings())
+
+    with pytest.raises(CacheCollectionMismatchError):
+        await manager.ensure_collection()
+
+
+@pytest.mark.asyncio
+async def test_payload_indexes_are_created() -> None:
+    client = FakeQdrantClient()
+    manager = CacheCollectionManager(client, CacheSettings())
+
+    await manager.ensure_payload_indexes()
+
+    assert {name for name, _ in client.indexes} == set(CACHE_PAYLOAD_INDEXES)
+
+
+def test_distance_mapping() -> None:
+    assert qdrant_distance("Cosine").value == "Cosine"
+    assert qdrant_distance("Dot").value == "Dot"
+    with pytest.raises(ValueError):
+        qdrant_distance("Bad")  # type: ignore[arg-type]

--- a/tests/unit/test_cache_config.py
+++ b/tests/unit/test_cache_config.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.rag.cache.cache_config import CacheSettings
+
+
+def test_cache_settings_defaults() -> None:
+    settings = CacheSettings()
+
+    assert settings.enabled is True
+    assert settings.collection_name == "quimera_query_cache"
+    assert settings.threshold == 0.92
+    assert settings.vector_size == 1024
+    assert settings.distance == "Cosine"
+    assert settings.similarity_threshold == settings.threshold
+
+
+def test_cache_settings_reads_quimera_cache_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUIMERA_CACHE_ENABLED", "0")
+    monkeypatch.setenv("QUIMERA_CACHE_COLLECTION_NAME", "cache_test")
+    monkeypatch.setenv("QUIMERA_CACHE_THRESHOLD", "0.7")
+    monkeypatch.setenv("QUIMERA_CACHE_VECTOR_SIZE", "768")
+    monkeypatch.setenv("QUIMERA_CACHE_DEFAULT_TTL_SECONDS", "60")
+    monkeypatch.setenv("QUIMERA_CACHE_MAX_RESULT_DOCS", "10")
+
+    settings = CacheSettings()
+
+    assert settings.enabled is False
+    assert settings.collection_name == "cache_test"
+    assert settings.threshold == 0.7
+    assert settings.vector_size == 768
+    assert settings.default_ttl_seconds == 60
+    assert settings.max_result_docs == 10
+
+
+def test_cache_settings_ignores_unprefixed_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLED", "0")
+
+    assert CacheSettings().enabled is True
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("threshold", -0.1),
+        ("threshold", 1.1),
+        ("vector_size", 0),
+        ("collection_name", " "),
+        ("embedding_model", " "),
+        ("profile_name", " "),
+        ("source_collection", " "),
+        ("corpus_epoch", " "),
+        ("default_ttl_seconds", 0),
+        ("max_result_docs", 0),
+        ("hot_entries_oversample_factor", 0),
+    ],
+)
+def test_cache_settings_validation(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        CacheSettings(**{field: value})
+
+
+def test_cache_settings_does_not_use_field_aliases() -> None:
+    fields = CacheSettings.model_fields
+
+    assert all(field.alias is None for field in fields.values())

--- a/tests/unit/test_cache_config.py
+++ b/tests/unit/test_cache_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from backend.rag.cache.cache_config import CacheSettings
@@ -58,7 +60,7 @@ def test_cache_settings_ignores_unprefixed_enabled(monkeypatch: pytest.MonkeyPat
 )
 def test_cache_settings_validation(field: str, value: object) -> None:
     with pytest.raises(ValueError):
-        CacheSettings(**{field: value})
+        CacheSettings(**cast(Any, {field: value}))
 
 
 def test_cache_settings_does_not_use_field_aliases() -> None:

--- a/tests/unit/test_cache_config.py
+++ b/tests/unit/test_cache_config.py
@@ -63,6 +63,17 @@ def test_cache_settings_validation(field: str, value: object) -> None:
         CacheSettings(**cast(Any, {field: value}))
 
 
+def test_cache_settings_rejects_cache_collection_as_source_collection() -> None:
+    with pytest.raises(
+        ValueError,
+        match="collection_name and source_collection must differ",
+    ):
+        CacheSettings(
+            collection_name="quimera_query_cache",
+            source_collection="quimera_query_cache",
+        )
+
+
 def test_cache_settings_does_not_use_field_aliases() -> None:
     fields = CacheSettings.model_fields
 

--- a/tests/unit/test_cache_fingerprint.py
+++ b/tests/unit/test_cache_fingerprint.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.rag.cache.cache_fingerprint import (
+    build_retrieval_fingerprint,
+    sha256_hex,
+    stable_json_dumps,
+)
+
+
+def test_stable_json_dumps_is_deterministic() -> None:
+    assert stable_json_dumps({"b": 2, "a": 1}) == stable_json_dumps({"a": 1, "b": 2})
+
+
+def test_sha256_hex_shape() -> None:
+    digest = sha256_hex("hello")
+
+    assert len(digest) == 64
+    assert all(char in "0123456789abcdef" for char in digest)
+
+
+def test_retrieval_fingerprint_is_stable_and_sensitive_to_versions() -> None:
+    first = build_retrieval_fingerprint(
+        embedding_model="qwen3",
+        embedding_dim=1024,
+        source_collection="knowledge",
+        corpus_epoch="dev",
+        profile_name="default",
+        extra={"b": 2, "a": 1},
+    )
+    second = build_retrieval_fingerprint(
+        embedding_model="qwen3",
+        embedding_dim=1024,
+        source_collection="knowledge",
+        corpus_epoch="dev",
+        profile_name="default",
+        extra={"a": 1, "b": 2},
+    )
+    changed = build_retrieval_fingerprint(
+        embedding_model="qwen3-v2",
+        embedding_dim=1024,
+        source_collection="knowledge",
+        corpus_epoch="dev2",
+        profile_name="default",
+    )
+
+    assert first == second
+    assert first != changed
+    assert len(first) == 64
+
+
+@pytest.mark.parametrize("key", ["prompt", "query_text", "answer", "chunks", "secret"])
+def test_retrieval_fingerprint_rejects_sensitive_extra(key: str) -> None:
+    with pytest.raises(ValueError, match="sensitive"):
+        build_retrieval_fingerprint(
+            embedding_model="qwen3",
+            embedding_dim=1024,
+            source_collection="knowledge",
+            corpus_epoch="dev",
+            profile_name="default",
+            extra={key: "bad"},
+        )

--- a/tests/unit/test_cache_layer.py
+++ b/tests/unit/test_cache_layer.py
@@ -207,6 +207,16 @@ async def test_invalidation_hot_entries_and_record_hit() -> None:
     assert client.deletes
 
 
+@pytest.mark.asyncio
+async def test_invalidate_rejects_empty_version_and_corpus_epoch() -> None:
+    layer = CacheLayer(FakeQdrantClient(), _settings())
+
+    with pytest.raises(ValueError, match="version cannot be empty"):
+        await layer.invalidate_by_schema_version(" ")
+    with pytest.raises(ValueError, match="corpus_epoch cannot be empty"):
+        await layer.invalidate_by_corpus_epoch("")
+
+
 def _payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
         "result_doc_ids": ["doc-1", "doc-2"],

--- a/tests/unit/test_cache_layer.py
+++ b/tests/unit/test_cache_layer.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.cache_layer import CacheLayer
+from backend.rag.cache.cache_models import CacheFingerprint, RetrievalResult
+from backend.rag.cache.errors import CachePayloadError, CacheVectorDimensionError
+
+
+NOW = datetime(2026, 6, 4, 12, 0, tzinfo=UTC)
+
+
+class FakePoint:
+    def __init__(self, *, point_id: str, score: float, payload: dict[str, object]) -> None:
+        self.id = point_id
+        self.score = score
+        self.payload = payload
+
+
+class FakeQueryResult:
+    def __init__(self, points: list[FakePoint]) -> None:
+        self.points = points
+
+
+class FakeCountResult:
+    def __init__(self, count: int) -> None:
+        self.count = count
+
+
+class FakeQdrantClient:
+    def __init__(self) -> None:
+        self.points: dict[str, dict[str, object]] = {}
+        self.query_calls: list[dict[str, object]] = []
+        self.upserts: list[object] = []
+        self.deletes: list[object] = []
+        self.set_payload_fail = False
+
+    async def query_points(self, **kwargs: object) -> FakeQueryResult:
+        self.query_calls.append(dict(kwargs))
+        points = [
+            FakePoint(
+                point_id=point_id,
+                score=float(payload.get("_score", 0.99)),
+                payload={key: value for key, value in payload.items() if key != "_score"},
+            )
+            for point_id, payload in self.points.items()
+        ]
+        return FakeQueryResult(points[: int(kwargs["limit"])])
+
+    async def upsert(self, **kwargs: object) -> None:
+        self.upserts.append(kwargs["points"])
+
+    async def count(self, **kwargs: object) -> FakeCountResult:
+        return FakeCountResult(len(self.points))
+
+    async def delete(self, **kwargs: object) -> None:
+        self.deletes.append(kwargs["points_selector"])
+
+    async def scroll(self, **kwargs: object) -> tuple[list[FakePoint], None]:
+        points = [
+            FakePoint(point_id=point_id, score=0.99, payload=payload)
+            for point_id, payload in self.points.items()
+        ]
+        return points, None
+
+    async def set_payload(self, **kwargs: object) -> None:
+        if self.set_payload_fail:
+            raise RuntimeError("boom")
+
+
+def _fingerprint() -> CacheFingerprint:
+    return CacheFingerprint(
+        profile_name="default",
+        embedding_model="qwen3-embedding",
+        embedding_dim=4,
+        source_collection="quimera_knowledge",
+        corpus_epoch="dev",
+        retrieval_fingerprint="a" * 64,
+    )
+
+
+def _result(**overrides: object) -> RetrievalResult:
+    values = {
+        "doc_ids": ("doc-1", "doc-2"),
+        "scores": (0.9, 0.8),
+        "fusion_backend": "python_rrf",
+        "profile_name": "default",
+        "retrieval_fingerprint": "a" * 64,
+        "metadata": {"safe": True},
+    }
+    values.update(overrides)
+    return RetrievalResult(**values)  # type: ignore[arg-type]
+
+
+def _settings(**overrides: object) -> CacheSettings:
+    values = {"vector_size": 4, "threshold": 0.9}
+    values.update(overrides)
+    return CacheSettings(**values)
+
+
+@pytest.mark.asyncio
+async def test_disabled_lookup_returns_none_without_qdrant_call() -> None:
+    client = FakeQdrantClient()
+    layer = CacheLayer(client, _settings(enabled=False))
+
+    assert await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint()) is None
+    assert client.query_calls == []
+
+
+@pytest.mark.asyncio
+async def test_lookup_miss_and_below_threshold_return_none() -> None:
+    client = FakeQdrantClient()
+    layer = CacheLayer(client, _settings())
+
+    assert await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint()) is None
+    client.points[str(uuid4())] = _payload(_score=0.5)
+    assert await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint()) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_hit_uses_filter_and_no_vectors() -> None:
+    cache_id = uuid4()
+    client = FakeQdrantClient()
+    client.points[str(cache_id)] = _payload(_score=0.95)
+    layer = CacheLayer(client, _settings())
+
+    hit = await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint())
+
+    assert hit is not None
+    assert hit.cache_id == cache_id
+    call = client.query_calls[-1]
+    assert call["with_payload"] is True
+    assert call["with_vectors"] is False
+    assert call["query_filter"] is not None
+
+
+@pytest.mark.asyncio
+async def test_lookup_rejects_bad_payload_and_expired_payload() -> None:
+    client = FakeQdrantClient()
+    client.points[str(uuid4())] = {"schema_version": "wrong", "_score": 0.95}
+    layer = CacheLayer(client, _settings())
+    with pytest.raises(CachePayloadError):
+        await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint())
+
+    client.points = {str(uuid4()): _payload(expires_at=(NOW - timedelta(seconds=1)).isoformat(), _score=0.95)}
+    assert await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint()) is None
+
+
+@pytest.mark.asyncio
+async def test_store_writes_vector_not_payload_and_validates_size() -> None:
+    client = FakeQdrantClient()
+    layer = CacheLayer(client, _settings(default_ttl_seconds=60))
+
+    entry = await layer.store(
+        query_vector=(0.1, 0.2, 0.3, 0.4),
+        result=_result(),
+        fingerprint=_fingerprint(),
+    )
+
+    assert entry is not None
+    points = client.upserts[-1]
+    point = points[0]  # type: ignore[index]
+    assert point.vector == [0.1, 0.2, 0.3, 0.4]
+    assert "query_vector" not in point.payload
+    assert "vector" not in point.payload
+    assert point.payload["schema_version"] == "query-cache-v1"
+    with pytest.raises(CacheVectorDimensionError):
+        await layer.store(query_vector=(0.1,), result=_result(), fingerprint=_fingerprint())
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_too_many_docs_and_sensitive_metadata() -> None:
+    layer = CacheLayer(FakeQdrantClient(), _settings(max_result_docs=1))
+
+    with pytest.raises(ValueError, match="max_result_docs"):
+        await layer.store(query_vector=(0.1, 0.2, 0.3, 0.4), result=_result(), fingerprint=_fingerprint())
+    with pytest.raises(ValueError, match="metadata"):
+        _result(metadata={"secret": "bad"})
+
+
+@pytest.mark.asyncio
+async def test_invalidation_hot_entries_and_record_hit() -> None:
+    cache_id = uuid4()
+    client = FakeQdrantClient()
+    client.points[str(cache_id)] = _payload(hit_count=5, _score=0.99)
+    client.points[str(uuid4())] = _payload(hit_count=2, _score=0.99)
+    layer = CacheLayer(client, _settings())
+
+    dry = await layer.invalidate_by_schema_version("query-cache-v1", dry_run=True)
+    deleted = await layer.invalidate_by_fingerprint(_fingerprint())
+    entries = await layer.get_hot_entries(top_n=2)
+    await layer.record_hit(cache_id=cache_id, current_hit_count=5)
+    client.set_payload_fail = True
+    await layer.record_hit(cache_id=cache_id, current_hit_count=5)
+
+    assert dry.dry_run is True
+    assert dry.matched_count == 2
+    assert deleted.dry_run is False
+    assert entries[0].hit_count >= entries[1].hit_count
+    assert client.deletes
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "result_doc_ids": ["doc-1", "doc-2"],
+        "result_scores": [0.9, 0.8],
+        "fusion_backend": "python_rrf",
+        "profile_name": "default",
+        "embedding_model": "qwen3-embedding",
+        "embedding_dim": 4,
+        "source_collection": "quimera_knowledge",
+        "corpus_epoch": "dev",
+        "retrieval_fingerprint": "a" * 64,
+        "schema_version": "query-cache-v1",
+        "created_at": NOW.isoformat(),
+        "expires_at": None,
+        "hit_count": 0,
+        "metadata": {"safe": True},
+    }
+    payload.update(overrides)
+    return payload

--- a/tests/unit/test_cache_layer.py
+++ b/tests/unit/test_cache_layer.py
@@ -142,14 +142,23 @@ async def test_lookup_hit_uses_filter_and_no_vectors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_lookup_rejects_bad_payload_and_expired_payload() -> None:
+async def test_lookup_corrupted_payload_returns_none_not_raises() -> None:
     client = FakeQdrantClient()
     client.points[str(uuid4())] = {"schema_version": "wrong", "_score": 0.95}
     layer = CacheLayer(client, _settings())
-    with pytest.raises(CachePayloadError):
-        await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint())
 
+    assert (
+        await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint())
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_lookup_expired_payload_returns_none() -> None:
+    client = FakeQdrantClient()
+    layer = CacheLayer(client, _settings())
     client.points = {str(uuid4()): _payload(expires_at=(NOW - timedelta(seconds=1)).isoformat(), _score=0.95)}
+
     assert await layer.lookup(query_vector=(0.1, 0.2, 0.3, 0.4), fingerprint=_fingerprint()) is None
 
 

--- a/tests/unit/test_cache_layer.py
+++ b/tests/unit/test_cache_layer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import UUID, uuid4
 
 import pytest
@@ -44,12 +45,14 @@ class FakeQdrantClient:
         points = [
             FakePoint(
                 point_id=point_id,
-                score=float(payload.get("_score", 0.99)),
+                score=_float_payload_value(payload.get("_score", 0.99)),
                 payload={key: value for key, value in payload.items() if key != "_score"},
             )
             for point_id, payload in self.points.items()
         ]
-        return FakeQueryResult(points[: int(kwargs["limit"])])
+        limit = kwargs["limit"]
+        assert isinstance(limit, int)
+        return FakeQueryResult(points[:limit])
 
     async def upsert(self, **kwargs: object) -> None:
         self.upserts.append(kwargs["points"])
@@ -83,8 +86,8 @@ def _fingerprint() -> CacheFingerprint:
     )
 
 
-def _result(**overrides: object) -> RetrievalResult:
-    values = {
+def _result(**overrides: Any) -> RetrievalResult:
+    values: dict[str, Any] = {
         "doc_ids": ("doc-1", "doc-2"),
         "scores": (0.9, 0.8),
         "fusion_backend": "python_rrf",
@@ -93,11 +96,11 @@ def _result(**overrides: object) -> RetrievalResult:
         "metadata": {"safe": True},
     }
     values.update(overrides)
-    return RetrievalResult(**values)  # type: ignore[arg-type]
+    return RetrievalResult(**values)
 
 
-def _settings(**overrides: object) -> CacheSettings:
-    values = {"vector_size": 4, "threshold": 0.9}
+def _settings(**overrides: Any) -> CacheSettings:
+    values: dict[str, Any] = {"vector_size": 4, "threshold": 0.9}
     values.update(overrides)
     return CacheSettings(**values)
 
@@ -223,3 +226,8 @@ def _payload(**overrides: object) -> dict[str, object]:
     }
     payload.update(overrides)
     return payload
+
+
+def _float_payload_value(value: object) -> float:
+    assert isinstance(value, (int, float, str))
+    return float(value)

--- a/tests/unit/test_cache_models.py
+++ b/tests/unit/test_cache_models.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import math
+from dataclasses import FrozenInstanceError, is_dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from backend.rag.cache.cache_models import (
+    SCHEMA_VERSION_QUERY_CACHE_V1,
+    CacheEntry,
+    CacheFingerprint,
+    CacheHit,
+    RetrievalResult,
+)
+
+
+NOW = datetime(2026, 6, 4, 12, 0, tzinfo=UTC)
+
+
+def _fingerprint() -> CacheFingerprint:
+    return CacheFingerprint(
+        profile_name="default",
+        embedding_model="qwen3-embedding",
+        embedding_dim=1024,
+        source_collection="quimera_knowledge",
+        corpus_epoch="dev",
+        retrieval_fingerprint="a" * 64,
+    )
+
+
+def _result(**overrides: object) -> RetrievalResult:
+    values = {
+        "doc_ids": ("doc-1", "doc-2"),
+        "scores": (0.9, 0.8),
+        "fusion_backend": "python_rrf",
+        "profile_name": "default",
+        "retrieval_fingerprint": "a" * 64,
+        "metadata": {"safe": True},
+    }
+    values.update(overrides)
+    return RetrievalResult(**values)  # type: ignore[arg-type]
+
+
+def _entry(**overrides: object) -> CacheEntry:
+    values = {
+        "cache_id": uuid4(),
+        "query_vector": (0.1, 0.2),
+        "result_doc_ids": ("doc-1",),
+        "result_scores": (0.9,),
+        "fusion_backend": "python_rrf",
+        "fingerprint": _fingerprint(),
+        "created_at": NOW,
+    }
+    values.update(overrides)
+    return CacheEntry(**values)  # type: ignore[arg-type]
+
+
+def test_cache_dataclasses_are_frozen_and_slots() -> None:
+    entry = _entry()
+
+    assert is_dataclass(entry)
+    assert hasattr(CacheEntry, "__slots__")
+    assert hasattr(CacheHit, "__slots__")
+    with pytest.raises(FrozenInstanceError):
+        entry.hit_count = 10  # type: ignore[misc]
+
+
+def test_cache_fingerprint_validation() -> None:
+    with pytest.raises(ValueError, match="profile_name"):
+        CacheFingerprint(
+            profile_name=" ",
+            embedding_model="qwen3",
+            embedding_dim=1024,
+            source_collection="source",
+            corpus_epoch="dev",
+            retrieval_fingerprint="hash",
+        )
+    with pytest.raises(ValueError, match="embedding_dim"):
+        CacheFingerprint(
+            profile_name="default",
+            embedding_model="qwen3",
+            embedding_dim=0,
+            source_collection="source",
+            corpus_epoch="dev",
+            retrieval_fingerprint="hash",
+        )
+    with pytest.raises(ValueError, match="schema_version"):
+        CacheFingerprint(
+            profile_name="default",
+            embedding_model="qwen3",
+            embedding_dim=1024,
+            source_collection="source",
+            corpus_epoch="dev",
+            retrieval_fingerprint="hash",
+            schema_version="v2",
+        )
+
+
+def test_retrieval_result_validation() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        _result(scores=(0.1,))
+    with pytest.raises(ValueError, match="doc_ids"):
+        _result(doc_ids=("",))
+    with pytest.raises(ValueError, match="scores"):
+        _result(scores=(math.nan, math.inf))
+    with pytest.raises(ValueError, match="metadata"):
+        _result(metadata={"prompt": "secret"})
+
+
+def test_cache_entry_validation_and_expiry() -> None:
+    with pytest.raises(ValueError, match="query_vector"):
+        _entry(query_vector=())
+    with pytest.raises(ValueError, match="query_vector"):
+        _entry(query_vector=(math.nan,))
+    with pytest.raises(ValueError, match="created_at"):
+        _entry(created_at=datetime(2026, 6, 4))
+    with pytest.raises(ValueError, match="expires_at"):
+        _entry(expires_at=NOW)
+
+    entry = _entry(expires_at=NOW + timedelta(seconds=1))
+    assert entry.is_expired(NOW) is False
+    assert entry.is_expired(NOW + timedelta(seconds=2)) is True
+
+
+def test_cache_hit_validation() -> None:
+    entry = _entry()
+    hit = CacheHit(
+        cache_id=entry.cache_id,
+        similarity_score=0.95,
+        result_doc_ids=entry.result_doc_ids,
+        result_scores=entry.result_scores,
+        fusion_backend=entry.fusion_backend,
+        fingerprint=entry.fingerprint,
+        created_at=entry.created_at,
+        expires_at=entry.expires_at,
+        hit_count=entry.hit_count,
+    )
+
+    assert hit.fingerprint.schema_version == SCHEMA_VERSION_QUERY_CACHE_V1
+    with pytest.raises(ValueError, match="similarity_score"):
+        CacheHit(
+            cache_id=entry.cache_id,
+            similarity_score=1.5,
+            result_doc_ids=entry.result_doc_ids,
+            result_scores=entry.result_scores,
+            fusion_backend=entry.fusion_backend,
+            fingerprint=entry.fingerprint,
+            created_at=entry.created_at,
+            expires_at=entry.expires_at,
+            hit_count=entry.hit_count,
+        )

--- a/tests/unit/test_cache_models.py
+++ b/tests/unit/test_cache_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from dataclasses import FrozenInstanceError, is_dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -30,8 +31,8 @@ def _fingerprint() -> CacheFingerprint:
     )
 
 
-def _result(**overrides: object) -> RetrievalResult:
-    values = {
+def _result(**overrides: Any) -> RetrievalResult:
+    values: dict[str, Any] = {
         "doc_ids": ("doc-1", "doc-2"),
         "scores": (0.9, 0.8),
         "fusion_backend": "python_rrf",
@@ -40,11 +41,11 @@ def _result(**overrides: object) -> RetrievalResult:
         "metadata": {"safe": True},
     }
     values.update(overrides)
-    return RetrievalResult(**values)  # type: ignore[arg-type]
+    return RetrievalResult(**values)
 
 
-def _entry(**overrides: object) -> CacheEntry:
-    values = {
+def _entry(**overrides: Any) -> CacheEntry:
+    values: dict[str, Any] = {
         "cache_id": uuid4(),
         "query_vector": (0.1, 0.2),
         "result_doc_ids": ("doc-1",),
@@ -54,7 +55,7 @@ def _entry(**overrides: object) -> CacheEntry:
         "created_at": NOW,
     }
     values.update(overrides)
-    return CacheEntry(**values)  # type: ignore[arg-type]
+    return CacheEntry(**values)
 
 
 def test_cache_dataclasses_are_frozen_and_slots() -> None:

--- a/tests/unit/test_cache_repository_sql_noop.py
+++ b/tests/unit/test_cache_repository_sql_noop.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+CACHE_ROOT = Path("backend/rag/cache")
+
+
+def _imported_roots() -> set[str]:
+    roots: set[str] = set()
+    for path in CACHE_ROOT.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                roots.update(alias.name.split(".")[0] for alias in node.names)
+            if isinstance(node, ast.ImportFrom) and node.module:
+                roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_cache_module_has_no_sql_or_runtime_service_imports() -> None:
+    forbidden = {
+        "sqlalchemy",
+        "django",
+        "peewee",
+        "tortoise",
+        "pony",
+        "asyncpg",
+        "fastapi",
+        "grpc",
+        "mcp",
+        "torch",
+        "transformers",
+        "langchain",
+        "llama_index",
+        "openai",
+    }
+
+    assert _imported_roots().isdisjoint(forbidden)
+
+
+def test_cache_layer_uses_qdrant_async_client_contract() -> None:
+    source = (CACHE_ROOT / "cache_layer.py").read_text(encoding="utf-8")
+
+    assert "AsyncQdrantClient" in source
+    assert "query_points" in source

--- a/tests/unit/test_cache_safety_contract.py
+++ b/tests/unit/test_cache_safety_contract.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from backend.rag.cache.cache_config import CacheSettings
+from backend.rag.cache.cache_layer import build_cache_payload
+from backend.rag.cache.cache_models import CacheFingerprint, RetrievalResult
+
+
+def _fingerprint() -> CacheFingerprint:
+    return CacheFingerprint(
+        profile_name="default",
+        embedding_model="qwen3-embedding",
+        embedding_dim=4,
+        source_collection="quimera_knowledge",
+        corpus_epoch="dev",
+        retrieval_fingerprint="a" * 64,
+    )
+
+
+def test_cache_payload_excludes_sensitive_fields() -> None:
+    result = RetrievalResult(
+        doc_ids=("doc-1",),
+        scores=(0.9,),
+        fusion_backend="python_rrf",
+        profile_name="default",
+        retrieval_fingerprint="a" * 64,
+        metadata={"safe": True},
+    )
+    entry_payload = build_cache_payload(
+        cache_id=uuid4(),
+        result=result,
+        fingerprint=_fingerprint(),
+        settings=CacheSettings(vector_size=4),
+    )
+    forbidden = {
+        "query_text",
+        "raw_query",
+        "answer",
+        "response",
+        "prompt",
+        "chunks",
+        "chunk_text",
+        "secret",
+        "api_key",
+        "token",
+        "embedding",
+        "vector",
+    }
+
+    assert forbidden.isdisjoint(entry_payload)
+    assert forbidden.isdisjoint(entry_payload["metadata"])
+
+
+def test_settings_repr_does_not_leak_api_key() -> None:
+    settings = CacheSettings()
+
+    assert "api_key" not in repr(settings).lower()

--- a/tests/unit/test_rag_observability_config.py
+++ b/tests/unit/test_rag_observability_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from loguru import logger
@@ -26,9 +27,10 @@ class RagObservabilityConfigTests(unittest.TestCase):
             RagObservabilityConfig(log_level="TRACE").validated()
 
     def test_load_config_reads_rag_observability_yaml(self) -> None:
-        config_path = Path("tests/tmp_rag_observability_config.yaml")
-        config_path.write_text(
-            """
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "rag_observability_config.yaml"
+            config_path.write_text(
+                """
 rag:
   observability:
     enabled: true
@@ -38,12 +40,9 @@ rag:
     generation_events_enabled: true
     collection_guard_events_enabled: false
 """,
-            encoding="utf-8",
-        )
-        try:
+                encoding="utf-8",
+            )
             config = load_rag_observability_config(config_path)
-        finally:
-            config_path.unlink()
 
         self.assertTrue(config.enabled)
         self.assertEqual(config.log_level, "DEBUG")


### PR DESCRIPTION
## Summary

Implements RAG-01B-PR-03: a plug-in async semantic retrieval cache layer backed by a dedicated Qdrant collection. The cache stores retrieval results keyed by an already-computed query vector and fingerprint. It does not alter the main HybridRAG pipeline.

## Scope

- Adds the PR-03 SDD.
- Adds cache settings via `QUIMERA_CACHE_*`.
- Adds immutable cache models and fingerprint helpers.
- Adds Qdrant collection manager with compatibility checks and payload indexes.
- Adds async `CacheLayer` using `query_points`, restrictive filters, TTL handling, invalidation, hot-entry reads, and best-effort hit recording.
- Adds unit tests with fake Qdrant clients and optional live Qdrant integration tests.

## Explicitly Out Of Scope

- No response cache.
- No raw query, raw prompt, final answer, full chunks, secrets, embeddings, or vectors in Qdrant payload.
- No LLM calls.
- No embedding generation.
- No MCP/API/gRPC.
- No PostgreSQL/TimescaleDB changes.
- No Qdrant knowledge collection mutation.
- No ORM.

## Validation

- `uv run pytest tests/unit/test_cache_config.py tests/unit/test_cache_models.py tests/unit/test_cache_fingerprint.py tests/unit/test_cache_collection_contract.py tests/unit/test_cache_layer.py tests/unit/test_cache_safety_contract.py tests/unit/test_cache_repository_sql_noop.py -q` -> 44 passed
- `uv run pytest -m integration tests/integration/test_qdrant_cache_collection.py tests/integration/test_qdrant_cache_layer_roundtrip.py -q` -> 3 skipped cleanly because live Qdrant integration env was not set
- `uv run pytest tests/unit -q` -> 1587 passed, 253 subtests passed
- `uv run mypy --strict .` -> success
- `uv run pyright` -> 0 errors
- `git diff --check` -> clean

## Reviewer Notes

This is intentionally a draft PR for adversarial review. Integration tests are opt-in and use a `quimera_query_cache_test_<uuid>` collection only.