### PR TITLE
feat(rag): harden LiteLLM host audit

### DIFF
--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,63 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-05 LiteLLM host correction
+**Updated by:** Codex — RAG-01B PR-05B LiteLLM host audit
+
+---
+
+## RAG-01B PR-05B — LiteLLM Host Audit and Hardening
+
+Current branch: `rag-01b/pr-05b-litellm-host-audit`
+Issue: <https://github.com/franciscosalido/OPENCLAW/issues/110>
+
+Implemented:
+
+- LiteLLM source config normalized to `os.environ/OLLAMA_BASE_URL`.
+- Added canonical aliases `qwen3-local`, `qwen3:14b` and `nomic-embed-text`
+  while preserving legacy Gateway/Agentic aliases.
+- Embedding aliases now use timeout/stream timeout `5/5`; chat remains
+  `120/45`; global request timeout remains `165`.
+- Added `infra/litellm/audit.py` for safe JSON/Markdown audit reports.
+- Added `infra/litellm/version_fingerprint.py` for best-effort local version
+  collection with sanitized DSNs and structured warnings.
+- Added `infra/litellm/overhead_benchmark.py`; live benchmark is opt-in via
+  `QUIMERA_LITELLM_BENCHMARK=1`.
+- Reworked `infra/litellm/start_litellm.sh` to start one host process,
+  reuse readiness, write `.runtime/litellm.pid`, use `--num_workers 1`, and
+  wait on `/health/readiness`.
+- Added `scripts/start_quimera.sh` subcommands: `litellm-audit`,
+  `litellm-fingerprint`, `litellm-benchmark`.
+- Added PR-05B SDD at
+  `docs/specs/rag-01b/pr-05b-litellm-host-audit.md`.
+
+Scope explicitly not changed:
+
+- No LiteLLM Docker service.
+- No MCP server, FastAPI or gRPC.
+- No HybridRAG mutation.
+- No PostgreSQL/Timescale migrations or schema changes.
+- No Qdrant collection deletion/recreate.
+- No remote providers or model downloads.
+
+Validation so far:
+
+- PR-05B focused unit block: 58 passed.
+- LiteLLM/Gateway/Agentic focused block: 160 passed / 95 subtests passed.
+- All `tests/unit/test_litellm*.py` + start script tests: 78 passed /
+  8 subtests passed.
+- Full unit suite: 1669 passed / 256 subtests passed.
+- Full regression: 1685 passed / 51 skipped / 259 subtests passed.
+- `uv run mypy --strict` on `infra/litellm/*` PR-05B modules: success.
+- `uv run pyright` on `infra/litellm/*` PR-05B modules: 0 errors.
+- `bash -n` on `scripts/start_quimera.sh` and
+  `infra/litellm/start_litellm.sh`: clean.
+- `uv run python -m infra.litellm.config_validator`: success with one expected
+  qdrant-semantic policy warning.
+- `uv run python -m infra.litellm.render_config`: success, fallback local.
+- `uv run python -m infra.litellm.audit`: generated JSON/Markdown, status
+  `warn` due expected local-service/experimental warnings.
+- `uv run python -m infra.litellm.overhead_benchmark`: `SKIPPED_VALID` without
+  opt-in.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -65,6 +65,41 @@ Validation so far:
 
 ---
 
+## RAG-01B PR-05B RC-01 — Residual Risk Cleanup
+
+Current branch: `rag-01b/pr-05b-litellm-host-audit`
+PR: <https://github.com/franciscosalido/OPENCLAW/pull/111>
+
+Implemented RC-01 fixes:
+
+- RC-09 audit `warn` remains intentional when source YAML declares
+  `qdrant-semantic` and the experimental flag is not set; SDD/README now state
+  that fallback local is valid runtime behavior.
+- `local_json` keeps `timeout=60` and `stream_timeout=45`; SDD/README now
+  document the first-chunk tradeoff and recommend concise JSON contexts.
+- `version_fingerprint` now exposes `python_version` and `python_executable`
+  directly from the running interpreter, independent of command probe failures.
+- `overhead_benchmark` keeps `status=SKIPPED_VALID` and now also emits
+  `skipped=true` for compatibility with reviewer expectations.
+
+Validation:
+
+- RC-01 focused tests: 19 passed.
+- LiteLLM/start-script block: 80 passed / 8 subtests passed.
+- Gateway/Agentic focused block: 92 passed / 87 subtests passed.
+- PR-05B opt-in integrations without env flags: 5 skipped.
+- Full unit suite: 1671 passed / 256 subtests passed.
+- `uv run mypy --strict` on RC-01 touched LiteLLM modules: success.
+- `uv run pyright` on RC-01 touched LiteLLM modules: 0 errors.
+- `uv run python -m infra.litellm.version_fingerprint`: success; includes
+  `python_version` and `python_executable`.
+- `uv run python -m infra.litellm.overhead_benchmark`: `SKIPPED_VALID` with
+  `skipped=true`.
+- `uv run python -m infra.litellm.audit`: generated JSON/Markdown, status
+  `warn` by design.
+
+---
+
 ## RAG-01B PR-05 RC-01 — LiteLLM Host Hardening
 
 Current branch: `rag-01b/pr-05-litellm-host-cache-timeout`

--- a/docs/specs/rag-01b/pr-04-ollama-tuning-keepalive.md
+++ b/docs/specs/rag-01b/pr-04-ollama-tuning-keepalive.md
@@ -39,11 +39,14 @@ requests de warmup/release.
 
 - `postgres-memory` -> `quimera-postgres-memory`
 - `qdrant` -> `quimera-qdrant`
-- `litellm` -> `quimera-litellm`
+
+Nota: a referencia anterior a um servico LiteLLM no Compose foi superseded por
+PR-05/PR-05B. LiteLLM agora e processo Python no host; Compose gerencia apenas
+Postgres e Qdrant.
 
 ## Healthchecks
 
-Postgres usa `pg_isready`; Qdrant usa `/healthz`; LiteLLM usa
+Postgres usa `pg_isready`; Qdrant usa `/healthz`; LiteLLM host usa
 `/health/readiness`; Ollama usa `/api/version`.
 
 ## Commands

--- a/docs/specs/rag-01b/pr-05-litellm-host-cache-timeout.md
+++ b/docs/specs/rag-01b/pr-05-litellm-host-cache-timeout.md
@@ -2,6 +2,10 @@
 
 Status: Draft
 
+Superseded operational hardening: see
+`docs/specs/rag-01b/pr-05b-litellm-host-audit.md` for audit reports, version
+fingerprint, opt-in overhead benchmark and RC-01..RC-24 host boundary checks.
+
 ## Decisao
 
 LiteLLM e um processo Python local do host. Docker Compose nao gerencia LiteLLM no QUIMERA. O Compose gerencia apenas Postgres e Qdrant. O start_quimera.sh reaproveita um LiteLLM ja rodando ou inicia exatamente um processo host controlado por PID.

--- a/docs/specs/rag-01b/pr-05b-litellm-host-audit.md
+++ b/docs/specs/rag-01b/pr-05b-litellm-host-audit.md
@@ -1,0 +1,181 @@
+# RAG-01B PR-05B — LiteLLM Host Audit and Hardening
+
+Status: Draft
+
+## Objetivo
+
+Auditar e endurecer o LiteLLM como gateway local do host no QUIMERA/OpenClaw,
+sem reintroduzir LiteLLM no Docker Compose e sem alterar HybridRAG,
+PostgreSQL/TimescaleDB, Qdrant retrieval cache, MCP, FastAPI ou gRPC.
+
+## Contexto
+
+LiteLLM e o gateway canonico host para chamadas OpenAI-compatible locais. O
+runtime local segue:
+
+```text
+Agentic / RAG callers -> LiteLLM host :4000 -> Ollama :11434
+```
+
+Docker Compose gerencia apenas PostgreSQL e Qdrant. Ollama e LiteLLM rodam no
+host. Esta decisao respeita os ADRs local-first e o PKD de memory fabric: agentes
+nao acessam bancos diretamente, e LiteLLM permanece gateway de entrada.
+
+## Correcao
+
+Nenhum container LiteLLM e permitido. O start padrao usa
+`infra/litellm/start_litellm.sh`, que:
+
+- faz bind em `127.0.0.1:4000`;
+- exporta `LITELLM_MODE=PRODUCTION` e `LITELLM_LOG=ERROR`;
+- usa `--num_workers 1`;
+- reaproveita LiteLLM ja saudavel em `/health/readiness`;
+- grava apenas PID proprio em `.runtime/litellm.pid`;
+- aguarda readiness por ate 10s.
+
+## Contratos RC-01..RC-24
+
+RC-01: LiteLLM host-only, sem imagem/servico Docker.  
+RC-02: aliases legados `local_chat`, `local_think`, `local_rag`, `local_json`,
+`quimera_embed`, `local_embed` preservados.  
+RC-03: cache LLM usa `quimera_llm_cache`.  
+RC-04: cache LLM nunca colide com `quimera_query_cache`.  
+RC-05: `similarity_threshold` em `(0, 1]`.  
+RC-06: chat timeout `120`, stream timeout `45`.  
+RC-07: embedding timeout `5`, stream timeout `5`.  
+RC-08: `max_retries <= 2`.  
+RC-09: `qdrant-semantic` e experimental e protegido por flag.  
+RC-10: embedding do cache semantico e alias local.  
+RC-11: dimensao canonica de embedding e `768`.  
+RC-12: `request_timeout = 165`.  
+RC-13: modelos usam `os.environ/OLLAMA_BASE_URL` ou loopback local.  
+RC-14: modelos usam provider local Ollama.  
+RC-15: logs seguros: JSON, verbose off, message logging off, redaction on.  
+RC-16: `master_key` via `os.environ/LITELLM_MASTER_KEY`.  
+RC-17: `timeout >= stream_timeout` em todos os modelos.  
+RC-18: startup usa `/health/readiness`; `/health` fica opt-in.  
+RC-19: start host exporta modo/log e usa host/porta/workers canonicos.  
+RC-20: stop mata apenas PID proprio, SIGTERM e SIGKILL no mesmo PID.  
+RC-21: `litellm-audit` gera JSON e Markdown locais.  
+RC-22: audit inclui version fingerprint best-effort.  
+RC-23: benchmark de overhead e opt-in.  
+RC-24: eventos observaveis sao JSON local sem conteudo sensivel.
+
+## Cache LLM vs Cache RAG
+
+`quimera_llm_cache` pertence ao gateway LiteLLM. `quimera_query_cache` pertence
+ao cache de retrieval do HybridRAG. As duas collections nunca devem ser
+mescladas, apagadas ou recriadas por este PR.
+
+## qdrant-semantic Experimental
+
+O YAML fonte declara `type: qdrant-semantic`, mas o renderer so mantem esse
+backend quando `QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL=1` e Qdrant esta
+pronto em `http://127.0.0.1:6333`. Caso contrario, o runtime usa fallback
+`local` ou `in-memory`.
+
+Bug conhecido monitorado: `AttributeError: 'Cache' object has no attribute
+'cache'` em alguns caminhos de Qdrant semantic cache. O fallback existe para
+evitar derrubar o gateway por uma feature experimental.
+
+## Timeout Policy
+
+- Chat/Qwen: `timeout=120`, `stream_timeout=45`.
+- Embeddings/Nomic: `timeout=5`, `stream_timeout=5`.
+- Global: `request_timeout=165`.
+
+## Health Policy
+
+LiteLLM documenta `/health/readiness` para readiness e `/health/liveliness` para
+liveness. `/health` pode chamar modelos reais e fica restrito a smoke opt-in.
+
+## Start/Stop Lifecycle
+
+`scripts/start_quimera.sh litellm-start` delega para
+`infra/litellm/start_litellm.sh`. `litellm-stop` para apenas `.runtime/litellm.pid`.
+Nao ha `pkill`, `killall`, `down -v`, `docker volume rm` ou prune destrutivo.
+
+## Audit Report
+
+`python -m infra.litellm.audit` gera:
+
+- `.runtime/reports/litellm_audit.json`
+- `.runtime/reports/litellm_audit.md`
+
+O relatorio contem RC status, cache policy, endpoints, version fingerprint e
+seguranca host-only. Nao contem prompt bruto, respostas, chunks, vetores,
+Authorization, API keys, DSN completo ou senhas.
+
+## Version Fingerprint
+
+`python -m infra.litellm.version_fingerprint` coleta best-effort:
+
+- Python, platform, LiteLLM, Pydantic, HTTPX e qdrant-client;
+- Ollama `/api/version`;
+- Qdrant `/readyz` e `/collections`;
+- Docker Compose version;
+- PostgreSQL/TimescaleDB quando DSN seguro estiver disponivel.
+
+Falhas viram warnings estruturados.
+
+## Proxy Overhead Benchmark
+
+`python -m infra.litellm.overhead_benchmark` so executa benchmark real quando
+`QUIMERA_LITELLM_BENCHMARK=1`. Sem opt-in retorna `SKIPPED_VALID`. O budget
+diagnostico e `p95_overhead_ms < 50`.
+
+## Regression Matrix
+
+- Gateway/Agentic aliases continuam presentes.
+- Agent0 regression e opt-in via `QUIMERA_AGENT0_GATEWAY_REGRESSION=1`.
+- Qdrant cache smoke e opt-in e nunca deleta collections.
+- Benchmark real e opt-in.
+- Full unit suite deve permanecer independente de servicos vivos.
+
+## Safe Events for PR-06
+
+Eventos locais usam chaves OTel-friendly:
+
+- `event.name`
+- `service.name`
+- `quimera.component`
+- `quimera.stage`
+- `status`
+- `duration_ms`
+- `error.type`
+- `error.message_sanitized`
+- `endpoint.kind`
+
+## Test Plan
+
+Rodar:
+
+```bash
+uv run pytest tests/unit/test_litellm_config_yaml.py tests/unit/test_litellm_timeout_policy.py tests/unit/test_litellm_config_validator.py tests/unit/test_litellm_cache_policy.py tests/unit/test_litellm_audit_contract.py tests/unit/test_litellm_version_fingerprint.py tests/unit/test_litellm_overhead_contract.py tests/unit/test_start_quimera_litellm_host.py tests/unit/test_start_quimera_script.py
+uv run python -m infra.litellm.config_validator infra/litellm/litellm_config.yaml
+uv run python -m infra.litellm.render_config
+uv run python -m infra.litellm.audit
+bash -n scripts/start_quimera.sh infra/litellm/start_litellm.sh
+```
+
+## Escopo Negativo
+
+Nao implementar container LiteLLM, MCP server, FastAPI, gRPC, remote providers,
+downloads de modelos, migrations, schema SQL, HybridRAG changes, Qlib/Kronos,
+delecoes/recreates de collections Qdrant ou acesso a dados reais.
+
+## Rollback
+
+Reverter este PR restaura o contrato PR-05: LiteLLM host-only com validate,
+render, start, stop e smoke. Nenhum volume Docker ou banco precisa ser alterado.
+
+## Como Rodar
+
+```bash
+./scripts/start_quimera.sh litellm-validate
+./scripts/start_quimera.sh litellm-render
+./scripts/start_quimera.sh litellm-start
+./scripts/start_quimera.sh litellm-smoke
+./scripts/start_quimera.sh litellm-audit
+./scripts/start_quimera.sh litellm-benchmark
+```

--- a/docs/specs/rag-01b/pr-05b-litellm-host-audit.md
+++ b/docs/specs/rag-01b/pr-05b-litellm-host-audit.md
@@ -78,11 +78,23 @@ Bug conhecido monitorado: `AttributeError: 'Cache' object has no attribute
 'cache'` em alguns caminhos de Qdrant semantic cache. O fallback existe para
 evitar derrubar o gateway por uma feature experimental.
 
+O audit reporta RC-09 como `warn` quando o YAML fonte declara
+`qdrant-semantic` mas a flag experimental nao esta ativa. Isso e
+observabilidade intencional: o runtime continua valido porque o renderer aplica
+fallback local.
+
 ## Timeout Policy
 
 - Chat/Qwen: `timeout=120`, `stream_timeout=45`.
 - Embeddings/Nomic: `timeout=5`, `stream_timeout=5`.
 - Global: `request_timeout=165`.
+
+`local_json` preserva `timeout=60` e `stream_timeout=45`. Pela documentacao do
+LiteLLM, `timeout` limita a chamada completa e `stream_timeout` limita a espera
+pelo primeiro chunk em streaming. O valor 45s e aceito por RC-17
+(`45 <= 60`) e protege slow-start local, mas operadores devem preferir payloads
+JSON concisos; contexto JSON longo pode exigir ajuste explicito de caller ou
+alias futuro.
 
 ## Health Policy
 
@@ -110,7 +122,8 @@ Authorization, API keys, DSN completo ou senhas.
 
 `python -m infra.litellm.version_fingerprint` coleta best-effort:
 
-- Python, platform, LiteLLM, Pydantic, HTTPX e qdrant-client;
+- Python direto do runtime (`python`, `python_version`, `python_executable`),
+  platform, LiteLLM, Pydantic, HTTPX e qdrant-client;
 - Ollama `/api/version`;
 - Qdrant `/readyz` e `/collections`;
 - Docker Compose version;
@@ -121,8 +134,8 @@ Falhas viram warnings estruturados.
 ## Proxy Overhead Benchmark
 
 `python -m infra.litellm.overhead_benchmark` so executa benchmark real quando
-`QUIMERA_LITELLM_BENCHMARK=1`. Sem opt-in retorna `SKIPPED_VALID`. O budget
-diagnostico e `p95_overhead_ms < 50`.
+`QUIMERA_LITELLM_BENCHMARK=1`. Sem opt-in retorna `status=SKIPPED_VALID` e
+`skipped=true`. O budget diagnostico e `p95_overhead_ms < 50`.
 
 ## Regression Matrix
 

--- a/infra/litellm/README.md
+++ b/infra/litellm/README.md
@@ -88,8 +88,8 @@ controller prints a warning. Rotate it for any shared runtime.
 `litellm-audit` writes safe local reports to `.runtime/reports/`. The audit
 includes config contracts, endpoint probes, cache policy and version
 fingerprints. `litellm-benchmark` is opt-in; without
-`QUIMERA_LITELLM_BENCHMARK=1`, it returns `SKIPPED_VALID` and does not call a
-model.
+`QUIMERA_LITELLM_BENCHMARK=1`, it returns `status=SKIPPED_VALID` with
+`skipped=true` and does not call a model.
 
 ## Validate
 
@@ -134,6 +134,16 @@ collection `quimera_llm_cache`. The retrieval cache collection remains
 The renderer keeps Qdrant semantic cache only when
 `QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL=1` and Qdrant is reachable at
 `QDRANT_API_BASE`. Otherwise it writes a runtime config with local cache.
+The audit reports that fallback as a warning by design, not as a failed
+runtime.
+
+## Timeout Notes
+
+`local_json` uses `timeout=60` and `stream_timeout=45`. This is valid because
+LiteLLM treats `timeout` as the complete call budget and `stream_timeout` as
+the first streaming chunk budget. Keep JSON prompts concise; callers with
+unusually long JSON contexts should pass an explicit request timeout or use a
+future dedicated alias.
 
 ## Stop
 

--- a/infra/litellm/README.md
+++ b/infra/litellm/README.md
@@ -42,9 +42,9 @@ Use shell exports. Do not copy real secrets into Git.
 
 ```bash
 export LITELLM_MASTER_KEY="dev-local-key-change-me"
-export OLLAMA_API_BASE="http://127.0.0.1:11434"
+export OLLAMA_BASE_URL="http://127.0.0.1:11434"
 export QWEN_MODEL="qwen3:14b"
-export EMBED_MODEL="nomic-embed-text"
+export EMBED_MODEL="nomic-embed-text:latest"
 export LITELLM_HOST="127.0.0.1"
 export LITELLM_PORT="4000"
 ```
@@ -63,6 +63,8 @@ Recommended through the stack controller:
 ./scripts/start_quimera.sh litellm-render
 ./scripts/start_quimera.sh litellm-start
 ./scripts/start_quimera.sh litellm-smoke
+./scripts/start_quimera.sh litellm-audit
+./scripts/start_quimera.sh litellm-benchmark
 ```
 
 `scripts/start_quimera.sh start` also starts or reuses host LiteLLM after
@@ -82,6 +84,12 @@ not versioned.
 The script refuses to bind to anything other than `127.0.0.1`.
 If the placeholder key from `.env.local.example` is still in use, the stack
 controller prints a warning. Rotate it for any shared runtime.
+
+`litellm-audit` writes safe local reports to `.runtime/reports/`. The audit
+includes config contracts, endpoint probes, cache policy and version
+fingerprints. `litellm-benchmark` is opt-in; without
+`QUIMERA_LITELLM_BENCHMARK=1`, it returns `SKIPPED_VALID` and does not call a
+model.
 
 ## Validate
 
@@ -129,14 +137,13 @@ The renderer keeps Qdrant semantic cache only when
 
 ## Stop
 
-If LiteLLM runs in the foreground, stop it with `Ctrl-C`.
-
-If you started it in a background shell, find and stop that process manually:
-
 ```bash
-ps aux | grep '[l]itellm'
-kill <pid>
+./scripts/start_quimera.sh litellm-stop
 ```
+
+The stop path reads only `.runtime/litellm.pid`, sends SIGTERM to that PID, and
+uses SIGKILL only for the same PID after the grace loop. It does not use
+`pkill` or `killall`.
 
 ## MVP Boundary
 

--- a/infra/litellm/audit.py
+++ b/infra/litellm/audit.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from infra.litellm.config_validator import (
+    CANONICAL_LLM_CACHE_COLLECTION,
+    CANONICAL_OLLAMA_BASE_URL,
+    CANONICAL_QDRANT_BASE_URL,
+    CANONICAL_RAG_CACHE_COLLECTION,
+    CHAT_STREAM_TIMEOUT_SECONDS,
+    CHAT_TIMEOUT_SECONDS,
+    ConfigValidationError,
+    EMBED_STREAM_TIMEOUT_SECONDS,
+    EMBED_TIMEOUT_SECONDS,
+    REQUEST_TIMEOUT_SECONDS,
+    load_raw_config,
+    validate_config_report,
+    validate_litellm_config,
+    validate_no_forbidden_docker_litellm_paths,
+)
+from infra.litellm.version_fingerprint import build_version_fingerprint
+
+
+AUDIT_SCHEMA_VERSION = "quimera-litellm-audit-v1"
+CONTRACT_IDS = tuple(f"RC-{index:02d}" for index in range(1, 25))
+FORBIDDEN_VALUE_MARKERS = (
+    "Authorization:",
+    "Bearer ",
+    "sk-",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "AZURE_API_KEY",
+)
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    data: dict[str, Any]
+
+    @property
+    def status(self) -> str:
+        return str(self.data["status"])
+
+    def to_json(self) -> str:
+        return json.dumps(self.data, indent=2, sort_keys=True) + "\n"
+
+    def to_markdown(self) -> str:
+        contracts = self.data["contracts"]
+        lines = [
+            "# LiteLLM Host Audit",
+            "",
+            f"- Schema: `{self.data['schema_version']}`",
+            f"- Status: `{self.data['status']}`",
+            f"- Config: `{self.data['config_path']}`",
+            f"- Runtime config: `{self.data['runtime_config_path']}`",
+            "",
+            "## Contracts",
+            "",
+            "| Contract | Status | Message |",
+            "|---|---|---|",
+        ]
+        for rule_id in CONTRACT_IDS:
+            finding = contracts[rule_id]
+            lines.append(f"| {rule_id} | {finding['status']} | {finding['message']} |")
+        lines.extend(
+            [
+                "",
+                "## Cache",
+                "",
+                f"- Backend source: `{self.data['cache']['backend_source']}`",
+                f"- Backend runtime: `{self.data['cache']['backend_runtime']}`",
+                f"- Collection: `{self.data['cache']['collection']}`",
+                f"- Fallback active: `{self.data['cache']['fallback_active']}`",
+                "",
+                "## Versions",
+                "",
+            ]
+        )
+        for key, value in sorted(self.data["versions"].items()):
+            lines.append(f"- `{key}`: `{value}`")
+        if self.data["warnings"]:
+            lines.extend(["", "## Warnings", ""])
+            for warning in self.data["warnings"]:
+                lines.append(f"- `{warning['component']}`: {warning['message']}")
+        return "\n".join(lines) + "\n"
+
+
+def _contract(status: str, message: str) -> dict[str, str]:
+    return {"status": status, "message": message}
+
+
+def _safe_status_from_contracts(contracts: Mapping[str, Mapping[str, str]]) -> str:
+    statuses = {finding["status"] for finding in contracts.values()}
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    return "pass"
+
+
+def _contains_forbidden_value(report: Mapping[str, Any]) -> bool:
+    text = json.dumps(report, sort_keys=True)
+    return any(marker in text for marker in FORBIDDEN_VALUE_MARKERS)
+
+
+def _runtime_cache_backend(runtime_path: Path) -> tuple[str, bool]:
+    if not runtime_path.exists():
+        return "missing", False
+    raw = yaml.safe_load(runtime_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return "invalid", False
+    settings = raw.get("litellm_settings") or {}
+    cache_params = settings.get("cache_params") or {}
+    policy = settings.get("cache_policy") or {}
+    return str(cache_params.get("type", "disabled")), bool(policy.get("fallback_active", False))
+
+
+def _script_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def build_litellm_audit(
+    *,
+    repo_root: Path = Path("."),
+    config_path: Path = Path("infra/litellm/litellm_config.yaml"),
+    runtime_config_path: Path = Path("infra/litellm/generated/litellm_config.runtime.yaml"),
+    env: Mapping[str, str] | None = None,
+) -> AuditReport:
+    env_map = os.environ if env is None else env
+    contracts: dict[str, dict[str, str]] = {rule_id: _contract("pass", "ok") for rule_id in CONTRACT_IDS}
+    warnings: list[dict[str, str]] = []
+
+    try:
+        config = validate_litellm_config(config_path, env=env_map)
+        validation_report = validate_config_report(config_path, env=env_map)
+        warnings.extend({"component": warning.rule_id, "message": warning.message} for warning in validation_report.warnings)
+    except ConfigValidationError as exc:
+        config = None
+        contracts["RC-01"] = _contract("fail", str(exc))
+
+    raw = load_raw_config(config_path)
+    settings = raw.get("litellm_settings", {})
+    general = raw.get("general_settings", {})
+    cache_params = settings.get("cache_params", {})
+    model_list = raw.get("model_list", [])
+    aliases = {item.get("model_name"): item for item in model_list if isinstance(item, dict)}
+
+    if not {"local_chat", "local_think", "local_rag", "local_json", "quimera_embed", "local_embed"} <= set(aliases):
+        contracts["RC-02"] = _contract("fail", "required legacy aliases missing")
+    if cache_params.get("qdrant_collection_name") != CANONICAL_LLM_CACHE_COLLECTION:
+        contracts["RC-03"] = _contract("fail", "LLM cache collection is not canonical")
+    if cache_params.get("qdrant_collection_name") == CANONICAL_RAG_CACHE_COLLECTION:
+        contracts["RC-04"] = _contract("fail", "LLM cache collides with RAG cache")
+    if not 0.0 < float(cache_params.get("similarity_threshold", 0.0)) <= 1.0:
+        contracts["RC-05"] = _contract("fail", "similarity threshold must be in (0, 1]")
+
+    for alias in ("local_chat", "local_think", "local_rag", "qwen3-local", "qwen3:14b"):
+        if alias in aliases:
+            params = aliases[alias]["litellm_params"]
+            if params.get("timeout") != CHAT_TIMEOUT_SECONDS or params.get("stream_timeout") != CHAT_STREAM_TIMEOUT_SECONDS:
+                contracts["RC-06"] = _contract("fail", "chat timeout policy mismatch")
+    for alias in ("nomic-embed-text", "quimera_embed", "local_embed"):
+        if alias in aliases:
+            params = aliases[alias]["litellm_params"]
+            if params.get("timeout") != EMBED_TIMEOUT_SECONDS or params.get("stream_timeout") != EMBED_STREAM_TIMEOUT_SECONDS:
+                contracts["RC-07"] = _contract("fail", "embedding timeout policy mismatch")
+
+    if any((item.get("litellm_params", {}).get("max_retries", 99) > 2) for item in model_list):
+        contracts["RC-08"] = _contract("fail", "max_retries exceeds local policy")
+    if cache_params.get("type") == "qdrant-semantic" and env_map.get("QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL") != "1":
+        contracts["RC-09"] = _contract("warn", "qdrant-semantic source will render to fallback unless experimental flag is set")
+    if cache_params.get("qdrant_semantic_cache_embedding_model") not in {"nomic-embed-text", "quimera_embed"}:
+        contracts["RC-10"] = _contract("fail", "semantic cache embedding model must be local")
+    if int(cache_params.get("qdrant_semantic_cache_vector_size", 0)) != 768:
+        contracts["RC-11"] = _contract("warn", "semantic cache vector size differs from canonical 768")
+    if settings.get("request_timeout") != REQUEST_TIMEOUT_SECONDS:
+        contracts["RC-12"] = _contract("fail", "request_timeout must be 165")
+    if any(item.get("litellm_params", {}).get("api_base") not in {"os.environ/OLLAMA_BASE_URL", CANONICAL_OLLAMA_BASE_URL, "http://localhost:11434"} for item in model_list):
+        contracts["RC-13"] = _contract("fail", "all models must use local OLLAMA_BASE_URL or loopback URL")
+    if any(not str(item.get("litellm_params", {}).get("model", "")).startswith(("os.environ/", "ollama/", "ollama_chat/")) for item in model_list):
+        contracts["RC-14"] = _contract("fail", "all models must use local Ollama provider")
+
+    if settings.get("json_logs") is not True or settings.get("set_verbose") is not False:
+        contracts["RC-15"] = _contract("fail", "logging settings are not safe")
+    if settings.get("turn_off_message_logging") is not True or settings.get("redact_user_api_key_info") is not True:
+        contracts["RC-15"] = _contract("fail", "message logging or key redaction policy mismatch")
+    if general.get("master_key") != "os.environ/LITELLM_MASTER_KEY":
+        contracts["RC-16"] = _contract("fail", "master_key must be environment reference")
+    if any(item.get("litellm_params", {}).get("stream_timeout", 0) > item.get("litellm_params", {}).get("timeout", 0) for item in model_list):
+        contracts["RC-17"] = _contract("fail", "stream_timeout exceeds timeout")
+
+    start_script = _script_text(repo_root / "infra/litellm/start_litellm.sh")
+    quimera_script = _script_text(repo_root / "scripts/start_quimera.sh")
+    if "/health/readiness" not in start_script or "/health/liveliness" in start_script:
+        contracts["RC-18"] = _contract("fail", "startup must use readiness probe only")
+    for token in ("LITELLM_MODE=PRODUCTION", "LITELLM_LOG=ERROR", "--num_workers 1", "--host", "127.0.0.1", "--port", "4000"):
+        if token not in start_script:
+            contracts["RC-19"] = _contract("fail", f"start_litellm missing {token}")
+    if "pkill" in quimera_script or "killall" in quimera_script:
+        contracts["RC-20"] = _contract("fail", "stop lifecycle must not use pkill or killall")
+    for token in ("litellm-audit", "litellm-benchmark"):
+        if token not in quimera_script:
+            contracts["RC-21" if token == "litellm-audit" else "RC-23"] = _contract("fail", f"{token} command missing")
+
+    fingerprint = build_version_fingerprint(env=env_map, config_path=config_path, runtime_config_path=runtime_config_path)
+    warnings.extend(fingerprint.warnings)
+    runtime_backend, fallback_active = _runtime_cache_backend(runtime_config_path)
+
+    if not fingerprint.values:
+        contracts["RC-22"] = _contract("fail", "version fingerprint unavailable")
+    if not (repo_root / "infra/litellm/overhead_benchmark.py").exists():
+        contracts["RC-23"] = _contract("fail", "overhead benchmark missing")
+
+    try:
+        validate_no_forbidden_docker_litellm_paths(repo_root)
+    except ConfigValidationError as exc:
+        contracts["RC-01"] = _contract("fail", str(exc))
+
+    data: dict[str, Any] = {
+        "schema_version": AUDIT_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "status": "pass",
+        "config_path": str(config_path),
+        "runtime_config_path": str(runtime_config_path),
+        "contracts": contracts,
+        "versions": fingerprint.values,
+        "endpoints": {
+            "litellm_readiness": fingerprint.values.get("litellm_readiness"),
+            "ollama_version": fingerprint.values.get("ollama"),
+            "qdrant_ready": fingerprint.values.get("qdrant_ready"),
+            "qdrant_collections": fingerprint.values.get("qdrant_collections"),
+        },
+        "cache": {
+            "backend_source": cache_params.get("type", "disabled"),
+            "backend_runtime": runtime_backend,
+            "collection": cache_params.get("qdrant_collection_name"),
+            "rag_cache_collision": cache_params.get("qdrant_collection_name") == CANONICAL_RAG_CACHE_COLLECTION,
+            "qdrant_semantic_experimental": env_map.get("QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL") == "1",
+            "fallback_active": fallback_active,
+        },
+        "timeouts": {
+            "request_timeout": settings.get("request_timeout"),
+            "chat": {"timeout": CHAT_TIMEOUT_SECONDS, "stream_timeout": CHAT_STREAM_TIMEOUT_SECONDS},
+            "embedding": {"timeout": EMBED_TIMEOUT_SECONDS, "stream_timeout": EMBED_STREAM_TIMEOUT_SECONDS},
+        },
+        "security": {
+            "host_only": True,
+            "no_docker_litellm": contracts["RC-01"]["status"] != "fail",
+            "no_literal_credentials": general.get("master_key") == "os.environ/LITELLM_MASTER_KEY",
+            "message_logging_disabled": settings.get("turn_off_message_logging") is True,
+        },
+        "warnings": warnings,
+        "safe_event_shape": {
+            "event.name": "litellm.audit",
+            "service.name": "quimera_litellm_host",
+            "quimera.component": "litellm",
+            "quimera.stage": "audit",
+            "status": "pending",
+            "duration_ms": None,
+            "error.type": None,
+            "error.message_sanitized": None,
+            "endpoint.kind": "local",
+        },
+    }
+    if _contains_forbidden_value(data):
+        contracts["RC-24"] = _contract("fail", "audit report contains forbidden sensitive marker")
+    data["status"] = _safe_status_from_contracts(contracts)
+    data["safe_event_shape"]["status"] = data["status"]
+    return AuditReport(data=data)
+
+
+def write_audit_report(report: AuditReport, *, json_path: Path, markdown_path: Path) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(report.to_json(), encoding="utf-8")
+    markdown_path.write_text(report.to_markdown(), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a safe local LiteLLM host audit report.")
+    parser.add_argument("--json", dest="json_path", default=".runtime/reports/litellm_audit.json")
+    parser.add_argument("--markdown", dest="markdown_path", default=".runtime/reports/litellm_audit.md")
+    parser.add_argument("--config", default="infra/litellm/litellm_config.yaml")
+    parser.add_argument("--runtime-config", default="infra/litellm/generated/litellm_config.runtime.yaml")
+    args = parser.parse_args(argv)
+    report = build_litellm_audit(
+        config_path=Path(args.config),
+        runtime_config_path=Path(args.runtime_config),
+    )
+    write_audit_report(report, json_path=Path(args.json_path), markdown_path=Path(args.markdown_path))
+    sys.stdout.write(f"status={report.status}\n")
+    sys.stdout.write(f"json={args.json_path}\n")
+    sys.stdout.write(f"markdown={args.markdown_path}\n")
+    return 0 if report.status in {"pass", "warn"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/litellm/config_validator.py
+++ b/infra/litellm/config_validator.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable, Literal, Mapping
 from urllib.parse import urlparse
 
 import httpx
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 
 REMOTE_PROVIDER_PREFIXES = (
@@ -32,6 +33,17 @@ REMOTE_KEY_MARKERS = (
 )
 CANONICAL_EMBED_DIM = 768
 MINIMUM_EMBED_DIM = 64
+CANONICAL_LITELLM_HOST = "127.0.0.1"
+CANONICAL_LITELLM_PORT = 4000
+CANONICAL_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+CANONICAL_QDRANT_BASE_URL = "http://127.0.0.1:6333"
+CANONICAL_LLM_CACHE_COLLECTION = "quimera_llm_cache"
+CANONICAL_RAG_CACHE_COLLECTION = "quimera_query_cache"
+CHAT_TIMEOUT_SECONDS = 120
+CHAT_STREAM_TIMEOUT_SECONDS = 45
+EMBED_TIMEOUT_SECONDS = 5
+EMBED_STREAM_TIMEOUT_SECONDS = 5
+REQUEST_TIMEOUT_SECONDS = 165
 ALLOWED_ENV_REFS = {
     "OLLAMA_API_BASE",
     "OLLAMA_BASE_URL",
@@ -41,16 +53,39 @@ ALLOWED_ENV_REFS = {
     "QDRANT_API_BASE",
 }
 ENV_DEFAULTS = {
-    "OLLAMA_API_BASE": "http://127.0.0.1:11434",
-    "OLLAMA_BASE_URL": "http://127.0.0.1:11434",
+    "OLLAMA_API_BASE": CANONICAL_OLLAMA_BASE_URL,
+    "OLLAMA_BASE_URL": CANONICAL_OLLAMA_BASE_URL,
     "LITELLM_LOCAL_CHAT_MODEL": "ollama_chat/qwen3:14b",
     "LITELLM_LOCAL_EMBED_MODEL": "ollama/nomic-embed-text:latest",
-    "QDRANT_API_BASE": "http://127.0.0.1:6333",
+    "QDRANT_API_BASE": CANONICAL_QDRANT_BASE_URL,
 }
 
 
 class ConfigValidationError(ValueError):
     """Raised when the host LiteLLM configuration violates local policy."""
+
+
+@dataclass(frozen=True)
+class ContractViolation:
+    rule_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ValidationWarning:
+    rule_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    config_path: Path
+    model_count: int
+    cache_backend: str
+    warnings: tuple[ValidationWarning, ...]
+
+
+CacheBackend = Literal["qdrant-semantic", "local", "in-memory"]
 
 
 def _env_value(value: str, env: Mapping[str, str]) -> str:
@@ -72,6 +107,15 @@ def _is_loopback_http(url: str, *, expected_port: int | None = None) -> bool:
     if expected_port is not None and parsed.port != expected_port:
         return False
     return True
+
+
+def is_local_url(value: str, *, allowed_ports: set[int]) -> bool:
+    parsed = urlparse(value)
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.port in allowed_ports
+    )
 
 
 class LiteLLMParams(BaseModel):
@@ -150,23 +194,21 @@ class CacheParams(BaseModel):
 
     @model_validator(mode="after")
     def qdrant_semantic_policy(self) -> "CacheParams":
+        if self.type not in {"qdrant-semantic", "local", "in-memory"}:
+            raise ValueError("cache backend must be qdrant-semantic, local, or in-memory")
         if self.type != "qdrant-semantic":
             return self
-        if self.qdrant_collection_name != "quimera_llm_cache":
-            raise ValueError("qdrant semantic cache must use quimera_llm_cache")
-        if self.qdrant_collection_name == "quimera_query_cache":
+        if self.qdrant_collection_name != CANONICAL_LLM_CACHE_COLLECTION:
+            raise ValueError(f"qdrant semantic cache must use {CANONICAL_LLM_CACHE_COLLECTION}")
+        if self.qdrant_collection_name == CANONICAL_RAG_CACHE_COLLECTION:
             raise ValueError("LLM cache collection must differ from retrieval cache")
-        if self.qdrant_semantic_cache_embedding_model != "quimera_embed":
-            raise ValueError("semantic cache embedding model must be quimera_embed")
+        if self.qdrant_semantic_cache_embedding_model not in {"nomic-embed-text", "quimera_embed"}:
+            raise ValueError("semantic cache embedding model must be a local embedding alias")
         if self.qdrant_semantic_cache_vector_size is None:
             raise ValueError("semantic cache vector size is required")
         if self.qdrant_semantic_cache_vector_size < MINIMUM_EMBED_DIM:
             raise ValueError(
                 f"semantic cache vector size must be >= {MINIMUM_EMBED_DIM}"
-            )
-        if self.qdrant_semantic_cache_vector_size != CANONICAL_EMBED_DIM:
-            raise ValueError(
-                f"semantic cache vector size must match CANONICAL_EMBED_DIM={CANONICAL_EMBED_DIM}"
             )
         if self.similarity_threshold is None or not 0.0 < self.similarity_threshold <= 1.0:
             raise ValueError("similarity_threshold must be between 0 and 1")
@@ -184,12 +226,24 @@ class LiteLLMSettings(BaseModel):
     turn_off_message_logging: bool = True
     redact_user_api_key_info: bool = True
     num_retries: int = Field(default=1, ge=0, le=3)
-    request_timeout: int = Field(default=130, gt=0)
+    request_timeout: int = Field(default=REQUEST_TIMEOUT_SECONDS, gt=0)
 
     @model_validator(mode="after")
     def cache_requires_params(self) -> "LiteLLMSettings":
         if self.cache and self.cache_params is None:
             raise ValueError("cache_params is required when cache is enabled")
+        return self
+
+    @model_validator(mode="after")
+    def logging_safety_policy(self) -> "LiteLLMSettings":
+        if self.set_verbose:
+            raise ValueError("set_verbose must be false")
+        if not self.json_logs:
+            raise ValueError("json_logs must be true")
+        if not self.turn_off_message_logging:
+            raise ValueError("turn_off_message_logging must be true")
+        if not self.redact_user_api_key_info:
+            raise ValueError("redact_user_api_key_info must be true")
         return self
 
 
@@ -198,6 +252,7 @@ class GeneralSettings(BaseModel):
 
     master_key: str
     disable_spend_logs: bool = True
+    set_verbose: bool | None = None
 
     @field_validator("master_key")
     @classmethod
@@ -205,6 +260,12 @@ class GeneralSettings(BaseModel):
         if value != "os.environ/LITELLM_MASTER_KEY":
             raise ValueError("master_key must use os.environ/LITELLM_MASTER_KEY")
         return value
+
+    @model_validator(mode="after")
+    def verbose_must_stay_disabled(self) -> "GeneralSettings":
+        if self.set_verbose:
+            raise ValueError("general_settings.set_verbose must be false")
+        return self
 
 
 class ConfigRoot(BaseModel):
@@ -231,6 +292,24 @@ class ConfigRoot(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def canonical_timeouts_present(self) -> "ConfigRoot":
+        for entry in self.model_list:
+            params = entry.litellm_params
+            if entry.model_name in {"local_chat", "local_think", "local_rag", "qwen3-local", "qwen3:14b"}:
+                if params.timeout != CHAT_TIMEOUT_SECONDS:
+                    raise ValueError("chat model timeout must be 120 seconds")
+                if params.stream_timeout != CHAT_STREAM_TIMEOUT_SECONDS:
+                    raise ValueError("chat model stream_timeout must be 45 seconds")
+            if entry.model_name in {"quimera_embed", "local_embed", "nomic-embed-text"}:
+                if params.timeout != EMBED_TIMEOUT_SECONDS:
+                    raise ValueError("embedding model timeout must be 5 seconds")
+                if params.stream_timeout != EMBED_STREAM_TIMEOUT_SECONDS:
+                    raise ValueError("embedding model stream_timeout must be 5 seconds")
+        if self.litellm_settings.request_timeout != REQUEST_TIMEOUT_SECONDS:
+            raise ValueError("request_timeout must be 165 seconds")
+        return self
+
+    @model_validator(mode="after")
     def request_timeout_covers_local_slow_start(self) -> "ConfigRoot":
         if not self.model_list:
             return self
@@ -248,7 +327,10 @@ class ConfigRoot(BaseModel):
 
 
 def load_raw_config(path: Path) -> dict[str, Any]:
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigValidationError(f"{path} contains invalid YAML") from exc
     if not isinstance(raw, dict):
         raise ConfigValidationError(f"{path} must contain a YAML mapping")
     return raw
@@ -261,6 +343,10 @@ def validate_no_literal_secrets(raw_text: str) -> None:
             continue
         if "master_key:" in stripped and "os.environ/LITELLM_MASTER_KEY" not in stripped:
             raise ConfigValidationError("literal secret found in LiteLLM master_key")
+        if "api_key:" in stripped and "os.environ/" not in stripped:
+            raise ConfigValidationError("literal api_key found in LiteLLM config")
+        if "sk-" in stripped:
+            raise ConfigValidationError("literal API key marker found in LiteLLM config")
         for marker in REMOTE_KEY_MARKERS:
             if marker in stripped:
                 raise ConfigValidationError(f"remote provider key marker is forbidden: {marker}")
@@ -269,6 +355,88 @@ def validate_no_literal_secrets(raw_text: str) -> None:
 def assert_host_local_qdrant_url(url: str) -> None:
     if not _is_loopback_http(url, expected_port=6333):
         raise ConfigValidationError("Qdrant URL must be local loopback HTTP on port 6333")
+
+
+def validate_no_cache_collision(config: ConfigRoot) -> None:
+    cache_params = config.litellm_settings.cache_params
+    if not cache_params or not cache_params.qdrant_collection_name:
+        return
+    if cache_params.qdrant_collection_name == CANONICAL_RAG_CACHE_COLLECTION:
+        raise ConfigValidationError("LiteLLM cache collection must not collide with RAG cache")
+
+
+def validate_host_only_runtime(config: ConfigRoot, env: Mapping[str, str]) -> None:
+    validate_provider_safety(config, env)
+
+
+def validate_no_forbidden_docker_litellm_paths(repo_root: Path) -> None:
+    docker_container_key = "container_name:"
+    docker_litellm_name = " quimera-" + "litellm"
+    forbidden = (
+        "berriai/" + "litellm",
+        "docker." + "litellm.ai",
+        docker_container_key + docker_litellm_name,
+    )
+    scan_paths = [
+        repo_root / "infra",
+        repo_root / "scripts",
+        repo_root / "docker-compose.yml",
+        repo_root / "docker-compose.yaml",
+    ]
+    for path in scan_paths:
+        candidates: Iterable[Path]
+        if path.is_dir():
+            candidates = path.rglob("*")
+        elif path.exists():
+            candidates = (path,)
+        else:
+            continue
+        for candidate in candidates:
+            if candidate.is_dir() or candidate.suffix in {".pyc", ".png", ".jpg", ".jpeg"}:
+                continue
+            if any(part in {".venv", "__pycache__", "generated"} for part in candidate.parts):
+                continue
+            try:
+                text = candidate.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            lowered = text.lower()
+            if any(token in lowered for token in forbidden):
+                raise ConfigValidationError(f"forbidden Docker LiteLLM reference in {candidate}")
+
+
+def validate_semantic_cache_policy(
+    config: ConfigRoot,
+    env: Mapping[str, str],
+) -> list[ValidationWarning]:
+    warnings: list[ValidationWarning] = []
+    cache_params = config.litellm_settings.cache_params
+    if not cache_params or cache_params.type != "qdrant-semantic":
+        return warnings
+    if env.get("QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL") != "1":
+        warnings.append(
+            ValidationWarning(
+                rule_id="RC-09",
+                message="qdrant-semantic is disabled by policy unless experimental flag is set",
+            )
+        )
+    if cache_params.qdrant_semantic_cache_vector_size != CANONICAL_EMBED_DIM:
+        reason = env.get("QUIMERA_LITELLM_EMBED_DIM_OVERRIDE_REASON", "").strip()
+        if reason:
+            warnings.append(
+                ValidationWarning(
+                    rule_id="RC-11",
+                    message="semantic cache vector size differs from canonical dimension with documented override",
+                )
+            )
+        else:
+            warnings.append(
+                ValidationWarning(
+                    rule_id="RC-11",
+                    message="semantic cache vector size differs from canonical dimension without override reason",
+                )
+            )
+    return warnings
 
 
 def validate_provider_safety(config: ConfigRoot, env: Mapping[str, str]) -> None:
@@ -280,7 +448,7 @@ def validate_provider_safety(config: ConfigRoot, env: Mapping[str, str]) -> None
         if not resolved_model.lower().startswith(("ollama/", "ollama_chat/")):
             raise ConfigValidationError("model must resolve to local Ollama provider")
         resolved_api_base = _env_value(params.api_base, env)
-        if not _is_loopback_http(resolved_api_base, expected_port=11434):
+        if not is_local_url(resolved_api_base, allowed_ports={11434}):
             raise ConfigValidationError("Ollama API base must resolve to local loopback")
 
     cache_params = config.litellm_settings.cache_params
@@ -298,18 +466,53 @@ def validate_litellm_config(path: Path, env: Mapping[str, str] | None = None) ->
     raw = load_raw_config(path)
     try:
         config = ConfigRoot.model_validate(raw)
-    except ValueError as exc:
+    except (ValidationError, ValueError) as exc:
         raise ConfigValidationError(str(exc)) from exc
-    validate_provider_safety(config, env_map)
+    validate_host_only_runtime(config, env_map)
+    validate_no_cache_collision(config)
     return config
+
+
+def validate_config(
+    path: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+    strict: bool = True,
+) -> ConfigRoot:
+    config = validate_litellm_config(path, env=env)
+    if strict:
+        warnings = validate_semantic_cache_policy(config, os.environ if env is None else env)
+        hard_warnings = [warning for warning in warnings if warning.rule_id == "RC-11"]
+        if hard_warnings:
+            raise ConfigValidationError(hard_warnings[0].message)
+    return config
+
+
+def validate_config_report(
+    path: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> ValidationReport:
+    env_map = os.environ if env is None else env
+    config = validate_litellm_config(path, env=env_map)
+    cache_params = config.litellm_settings.cache_params
+    return ValidationReport(
+        config_path=path,
+        model_count=len(config.model_list),
+        cache_backend=cache_params.type if cache_params else "disabled",
+        warnings=tuple(validate_semantic_cache_policy(config, env_map)),
+    )
 
 
 async def smoke_test_qdrant(url: str, timeout_seconds: float = 2.0) -> bool:
     assert_host_local_qdrant_url(url)
     try:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-            response = await client.get(f"{url.rstrip('/')}/healthz")
-        return response.status_code < 400
+            for endpoint in ("/readyz", "/healthz"):
+                result = await client.get(f"{url.rstrip('/')}{endpoint}")
+                if result.status_code < 400:
+                    return True
+        return False
     except httpx.HTTPError:
         return False
 
@@ -324,12 +527,15 @@ def smoke_test_qdrant_sync(url: str, timeout_seconds: float = 2.0) -> bool:
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
     path = Path(args[0]) if args else Path("infra/litellm/litellm_config.yaml")
-    config = validate_litellm_config(path)
-    cache_params = config.litellm_settings.cache_params
-    cache_backend = cache_params.type if cache_params else "disabled"
-    sys.stdout.write(f"path={path}\n")
-    sys.stdout.write(f"models={len(config.model_list)}\n")
-    sys.stdout.write(f"cache_backend={cache_backend}\n")
+    try:
+        report = validate_config_report(path)
+    except ConfigValidationError as exc:
+        sys.stderr.write(f"validation=failed\nmessage={exc}\n")
+        return 1
+    sys.stdout.write(f"path={report.config_path}\n")
+    sys.stdout.write(f"models={report.model_count}\n")
+    sys.stdout.write(f"cache_backend={report.cache_backend}\n")
+    sys.stdout.write(f"warnings={len(report.warnings)}\n")
     return 0
 
 

--- a/infra/litellm/litellm_config.yaml
+++ b/infra/litellm/litellm_config.yaml
@@ -12,7 +12,7 @@ model_list:
   - model_name: local_chat
     litellm_params:
       model: os.environ/LITELLM_LOCAL_CHAT_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
+      api_base: os.environ/OLLAMA_BASE_URL
       timeout: 120
       stream_timeout: 45
       max_retries: 1
@@ -28,7 +28,7 @@ model_list:
   - model_name: local_think
     litellm_params:
       model: os.environ/LITELLM_LOCAL_CHAT_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
+      api_base: os.environ/OLLAMA_BASE_URL
       timeout: 120
       stream_timeout: 45
       max_retries: 1
@@ -42,7 +42,7 @@ model_list:
   - model_name: local_rag
     litellm_params:
       model: os.environ/LITELLM_LOCAL_CHAT_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
+      api_base: os.environ/OLLAMA_BASE_URL
       timeout: 120
       stream_timeout: 45
       max_retries: 1
@@ -58,7 +58,7 @@ model_list:
   - model_name: local_json
     litellm_params:
       model: os.environ/LITELLM_LOCAL_CHAT_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
+      api_base: os.environ/OLLAMA_BASE_URL
       timeout: 60
       stream_timeout: 45
       max_retries: 1
@@ -72,12 +72,64 @@ model_list:
       response_contract: json
       thinking_mode: false
 
+  - model_name: qwen3-local
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_BASE_URL
+      timeout: 120
+      stream_timeout: 45
+      max_retries: 1
+      keep_alive: -1
+      temperature: 0.2
+      extra_body:
+        think: false
+    model_info:
+      provider: ollama
+      purpose: canonical Qwen3 local chat alias
+      mode: chat
+      owned_by: quimera-local
+      thinking_mode: false
+
+  - model_name: qwen3:14b
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_CHAT_MODEL
+      api_base: os.environ/OLLAMA_BASE_URL
+      timeout: 120
+      stream_timeout: 45
+      max_retries: 1
+      keep_alive: -1
+      temperature: 0.2
+      extra_body:
+        think: false
+    model_info:
+      provider: ollama
+      purpose: compatibility alias for canonical Qwen3 model name
+      mode: chat
+      owned_by: quimera-local
+      alias_of: qwen3-local
+      thinking_mode: false
+
+  - model_name: nomic-embed-text
+    litellm_params:
+      model: os.environ/LITELLM_LOCAL_EMBED_MODEL
+      api_base: os.environ/OLLAMA_BASE_URL
+      timeout: 5
+      stream_timeout: 5
+      max_retries: 1
+      keep_alive: -1
+    model_info:
+      provider: ollama
+      purpose: canonical local embedding model alias
+      mode: embedding
+      owned_by: quimera-local
+      output_dimensions: 768
+
   - model_name: quimera_embed
     litellm_params:
       model: os.environ/LITELLM_LOCAL_EMBED_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
-      timeout: 20
-      stream_timeout: 10
+      api_base: os.environ/OLLAMA_BASE_URL
+      timeout: 5
+      stream_timeout: 5
       max_retries: 1
       keep_alive: -1
     model_info:
@@ -90,9 +142,9 @@ model_list:
   - model_name: local_embed
     litellm_params:
       model: os.environ/LITELLM_LOCAL_EMBED_MODEL
-      api_base: os.environ/OLLAMA_API_BASE
-      timeout: 20
-      stream_timeout: 10
+      api_base: os.environ/OLLAMA_BASE_URL
+      timeout: 5
+      stream_timeout: 5
       max_retries: 1
       keep_alive: -1
     model_info:
@@ -108,7 +160,9 @@ litellm_settings:
     type: qdrant-semantic
     qdrant_api_base: os.environ/QDRANT_API_BASE
     qdrant_collection_name: quimera_llm_cache
-    qdrant_semantic_cache_embedding_model: quimera_embed
+    # EXPERIMENTAL: qdrant-semantic can fall back to local via render_config.py.
+    # Tracked upstream: BerriAI issue 23441.
+    qdrant_semantic_cache_embedding_model: nomic-embed-text
     qdrant_semantic_cache_vector_size: 768
     similarity_threshold: 0.92
   drop_params: true

--- a/infra/litellm/overhead_benchmark.py
+++ b/infra/litellm/overhead_benchmark.py
@@ -65,6 +65,7 @@ def skipped_report(reason: str = "QUIMERA_LITELLM_BENCHMARK is not 1") -> dict[s
     return {
         "schema_version": BENCHMARK_SCHEMA_VERSION,
         "status": "SKIPPED_VALID",
+        "skipped": True,
         "reason": reason,
         "overhead_ms": None,
     }
@@ -124,6 +125,7 @@ def run_live_benchmark(
         return {
             "schema_version": BENCHMARK_SCHEMA_VERSION,
             "status": "diagnostic_warning",
+            "skipped": False,
             "diagnostic_warning": exc.__class__.__name__,
             "overhead_ms": None,
         }
@@ -132,6 +134,7 @@ def run_live_benchmark(
     return {
         "schema_version": BENCHMARK_SCHEMA_VERSION,
         "status": "pass" if stats.p95_ms < OVERHEAD_P95_BUDGET_MS else "warn",
+        "skipped": False,
         "budget": {"p95_overhead_ms_lt": OVERHEAD_P95_BUDGET_MS},
         "overhead_ms": stats.to_dict(),
     }

--- a/infra/litellm/overhead_benchmark.py
+++ b/infra/litellm/overhead_benchmark.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import httpx
+
+
+BENCHMARK_SCHEMA_VERSION = "quimera-litellm-overhead-v1"
+DEFAULT_SAMPLE_COUNT = 20
+OVERHEAD_P95_BUDGET_MS = 50.0
+SYNTHETIC_MESSAGE = "ping"
+
+
+@dataclass(frozen=True)
+class OverheadStats:
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    mean_ms: float
+    samples: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "p50_ms": self.p50_ms,
+            "p95_ms": self.p95_ms,
+            "p99_ms": self.p99_ms,
+            "mean_ms": self.mean_ms,
+            "samples": self.samples,
+        }
+
+
+def _percentile(sorted_values: list[float], percentile: float) -> float:
+    if not sorted_values:
+        raise ValueError("at least one sample is required")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (len(sorted_values) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = rank - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
+
+
+def calculate_overhead_stats(values_ms: Iterable[float]) -> OverheadStats:
+    values = sorted(float(value) for value in values_ms)
+    if not values:
+        raise ValueError("at least one sample is required")
+    return OverheadStats(
+        p50_ms=round(_percentile(values, 0.50), 3),
+        p95_ms=round(_percentile(values, 0.95), 3),
+        p99_ms=round(_percentile(values, 0.99), 3),
+        mean_ms=round(statistics.fmean(values), 3),
+        samples=len(values),
+    )
+
+
+def skipped_report(reason: str = "QUIMERA_LITELLM_BENCHMARK is not 1") -> dict[str, Any]:
+    return {
+        "schema_version": BENCHMARK_SCHEMA_VERSION,
+        "status": "SKIPPED_VALID",
+        "reason": reason,
+        "overhead_ms": None,
+    }
+
+
+def _post_json(client: httpx.Client, url: str, payload: dict[str, Any], headers: dict[str, str]) -> float:
+    started = time.perf_counter()
+    result = client.post(url, json=payload, headers=headers)
+    duration_ms = (time.perf_counter() - started) * 1000.0
+    if result.status_code >= 400:
+        raise RuntimeError(f"HTTP {result.status_code}")
+    return duration_ms
+
+
+def run_live_benchmark(
+    *,
+    env: Mapping[str, str] | None = None,
+    samples: int = DEFAULT_SAMPLE_COUNT,
+) -> dict[str, Any]:
+    env_map = os.environ if env is None else env
+    if env_map.get("QUIMERA_LITELLM_BENCHMARK") != "1":
+        return skipped_report()
+
+    ollama_base = env_map.get("OLLAMA_BASE_URL", env_map.get("OLLAMA_API_BASE", "http://127.0.0.1:11434")).rstrip("/")
+    litellm_base = env_map.get("LITELLM_BASE_URL", "http://127.0.0.1:4000").rstrip("/")
+    api_key = env_map.get("QUIMERA_LLM_API_KEY") or env_map.get("LITELLM_MASTER_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    timeout = httpx.Timeout(connect=1.0, read=130.0, write=2.0, pool=1.0)
+    overhead_values: list[float] = []
+
+    ollama_payload = {
+        "model": env_map.get("QWEN_MODEL", "qwen3:14b"),
+        "messages": [{"role": "user", "content": SYNTHETIC_MESSAGE}],
+        "stream": False,
+        "keep_alive": -1,
+        "options": {"num_predict": 4},
+    }
+    litellm_payload = {
+        "model": "qwen3-local",
+        "messages": [{"role": "user", "content": SYNTHETIC_MESSAGE}],
+        "max_tokens": 4,
+        "stream": False,
+    }
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            for _ in range(samples):
+                direct_ms = _post_json(client, f"{ollama_base}/api/chat", ollama_payload, {})
+                gateway_ms = _post_json(
+                    client,
+                    f"{litellm_base}/v1/chat/completions",
+                    litellm_payload,
+                    headers,
+                )
+                overhead_values.append(gateway_ms - direct_ms)
+    except (httpx.HTTPError, RuntimeError) as exc:
+        return {
+            "schema_version": BENCHMARK_SCHEMA_VERSION,
+            "status": "diagnostic_warning",
+            "diagnostic_warning": exc.__class__.__name__,
+            "overhead_ms": None,
+        }
+
+    stats = calculate_overhead_stats(overhead_values)
+    return {
+        "schema_version": BENCHMARK_SCHEMA_VERSION,
+        "status": "pass" if stats.p95_ms < OVERHEAD_P95_BUDGET_MS else "warn",
+        "budget": {"p95_overhead_ms_lt": OVERHEAD_P95_BUDGET_MS},
+        "overhead_ms": stats.to_dict(),
+    }
+
+
+def main() -> int:
+    report = run_live_benchmark()
+    output = Path(os.environ.get("QUIMERA_LITELLM_OVERHEAD_REPORT", ".runtime/reports/litellm_overhead.json"))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    sys.stdout.write(json.dumps(report, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/litellm/render_config.py
+++ b/infra/litellm/render_config.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import os
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from json import dumps
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
 import yaml
 
 from infra.litellm.config_validator import (
+    CANONICAL_QDRANT_BASE_URL,
+    ConfigValidationError,
     load_raw_config,
     smoke_test_qdrant_sync,
     validate_litellm_config,
@@ -20,14 +24,33 @@ class RenderResult:
     source_path: Path
     runtime_path: Path
     cache_backend: str
+    fallback_active: bool = False
 
 
 def _qdrant_url(cache_params: dict[str, Any], env: Mapping[str, str]) -> str:
     value = str(cache_params.get("qdrant_api_base") or "os.environ/QDRANT_API_BASE")
     if value.startswith("os.environ/"):
         key = value.removeprefix("os.environ/")
-        return env.get(key, "http://127.0.0.1:6333")
+        return env.get(key, CANONICAL_QDRANT_BASE_URL)
     return value
+
+
+def _write_safe_event(repo_root: Path, *, status: str, cache_backend: str, fallback_active: bool) -> None:
+    event_dir = repo_root / ".runtime" / "events"
+    event_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event.name": "litellm.config.render",
+        "service.name": "quimera_litellm_host",
+        "quimera.component": "litellm",
+        "quimera.stage": "render_config",
+        "status": status,
+        "cache.backend": cache_backend,
+        "cache.fallback_active": fallback_active,
+        "version.schema": "quimera-safe-event-v1",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    with (event_dir / "litellm_render.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(dumps(event, sort_keys=True) + "\n")
 
 
 def render_runtime_config(
@@ -36,38 +59,69 @@ def render_runtime_config(
     runtime_path: Path,
     env: Mapping[str, str] | None = None,
     qdrant_smoke: Callable[[str], bool] | None = None,
+    strict: bool = False,
 ) -> RenderResult:
     env_map = os.environ if env is None else env
     validate_litellm_config(source_path, env=env_map)
     rendered = load_raw_config(source_path)
     settings = rendered.setdefault("litellm_settings", {})
+    general_settings = rendered.setdefault("general_settings", {})
+    if "json_logs" in general_settings:
+        settings.setdefault("json_logs", general_settings.pop("json_logs"))
     cache_params = settings.setdefault("cache_params", {})
     cache_backend = str(cache_params.get("type", "local"))
+    fallback_active = False
 
     if cache_backend == "qdrant-semantic":
         qdrant_url = _qdrant_url(cache_params, env_map)
         experimental = env_map.get("QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL") == "1"
         fallback = env_map.get("QUIMERA_LITELLM_CACHE_FALLBACK", "local")
-        is_ready = (qdrant_smoke or smoke_test_qdrant_sync)(qdrant_url)
+        is_ready = experimental and (qdrant_smoke or smoke_test_qdrant_sync)(qdrant_url)
         if experimental and is_ready:
             cache_backend = "qdrant-semantic"
-        elif fallback == "local":
+        elif fallback in {"local", "in-memory"}:
             cache_backend = "local"
+            if fallback == "in-memory":
+                cache_backend = "in-memory"
             settings["cache_params"] = {"type": "local"}
+            if cache_backend == "in-memory":
+                settings["cache_params"] = {"type": "in-memory"}
+            settings["cache_policy"] = {
+                "qdrant_semantic_status": "disabled_by_policy_or_unavailable",
+                "fallback_active": True,
+            }
+            fallback_active = True
         else:
-            raise RuntimeError(
+            raise ConfigValidationError(
                 "Qdrant semantic cache requested, but Qdrant is unavailable and fallback is disabled"
             )
 
     runtime_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_text = yaml.safe_dump(rendered, sort_keys=False, allow_unicode=True)
+    master_key = env_map.get("LITELLM_MASTER_KEY")
+    if master_key and master_key in runtime_text:
+        raise ConfigValidationError("runtime config would contain literal LITELLM_MASTER_KEY")
     runtime_path.write_text(
-        yaml.safe_dump(rendered, sort_keys=False, allow_unicode=True),
+        runtime_text,
         encoding="utf-8",
     )
-    return RenderResult(source_path=source_path, runtime_path=runtime_path, cache_backend=cache_backend)
+    repo_root = source_path.resolve().parents[2] if len(source_path.resolve().parents) >= 3 else Path.cwd()
+    _write_safe_event(
+        repo_root,
+        status="ok",
+        cache_backend=cache_backend,
+        fallback_active=fallback_active,
+    )
+    return RenderResult(
+        source_path=source_path,
+        runtime_path=runtime_path,
+        cache_backend=cache_backend,
+        fallback_active=fallback_active,
+    )
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
     source = Path(os.environ.get("QUIMERA_LITELLM_CONFIG", "infra/litellm/litellm_config.yaml"))
     runtime = Path(
         os.environ.get(
@@ -75,10 +129,27 @@ def main() -> int:
             "infra/litellm/generated/litellm_config.runtime.yaml",
         )
     )
-    result = render_runtime_config(source_path=source, runtime_path=runtime)
+    strict = False
+    while args:
+        arg = args.pop(0)
+        if arg == "--source":
+            source = Path(args.pop(0))
+        elif arg == "--output":
+            runtime = Path(args.pop(0))
+        elif arg == "--strict":
+            strict = True
+        else:
+            sys.stderr.write(f"unknown argument: {arg}\n")
+            return 2
+    try:
+        result = render_runtime_config(source_path=source, runtime_path=runtime, strict=strict)
+    except ConfigValidationError as exc:
+        sys.stderr.write(f"render=failed\nmessage={exc}\n")
+        return 1
     sys.stdout.write(f"source_path={result.source_path}\n")
     sys.stdout.write(f"runtime_path={result.runtime_path}\n")
     sys.stdout.write(f"cache_backend={result.cache_backend}\n")
+    sys.stdout.write(f"fallback_active={result.fallback_active}\n")
     return 0
 
 

--- a/infra/litellm/smoke_test.py
+++ b/infra/litellm/smoke_test.py
@@ -3,43 +3,148 @@ from __future__ import annotations
 import os
 import sys
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 
 
+HTTP_TIMEOUT = httpx.Timeout(connect=1.0, read=5.0, write=2.0, pool=1.0)
+
+
 @dataclass(frozen=True)
 class SmokeResult:
-    readiness: bool
-    liveliness: bool
-    models: bool
+    name: str
+    ok: bool
+    status_code: int | None = None
+    message: str = "ok"
+
+
+@dataclass(frozen=True)
+class SmokeSummary:
+    readiness: SmokeResult
+    liveliness: SmokeResult
+    models: SmokeResult
+    ollama: SmokeResult
+    qdrant: SmokeResult
     chat: bool | None = None
+    embed: bool | None = None
 
     @property
     def ok(self) -> bool:
-        return self.readiness and self.liveliness and self.models and self.chat is not False
+        return (
+            self.readiness.ok
+            and self.liveliness.ok
+            and self.models.ok
+            and self.ollama.ok
+            and self.qdrant.ok
+            and self.chat is not False
+            and self.embed is not False
+        )
 
 
-def run_smoke(base_url: str, api_key: str | None = None, *, test_chat: bool = False) -> SmokeResult:
+async def _get_json(client: httpx.AsyncClient, url: str, headers: dict[str, str] | None = None) -> SmokeResult:
+    try:
+        result = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        return SmokeResult(name=url.rsplit("/", 1)[-1], ok=False, message=exc.__class__.__name__)
+    return SmokeResult(
+        name=url.rsplit("/", 1)[-1],
+        ok=result.status_code < 400,
+        status_code=result.status_code,
+    )
+
+
+async def smoke_litellm_readiness(base_url: str) -> SmokeResult:
     base = base_url.rstrip("/")
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    with httpx.Client(timeout=10.0) as client:
-        readiness = client.get(f"{base}/health/readiness").status_code < 400
-        liveliness = client.get(f"{base}/health/liveliness").status_code < 400
-        models = client.get(f"{base}/v1/models", headers=headers).status_code < 400
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        return await _get_json(client, f"{base}/health/readiness")
+
+
+async def smoke_litellm_liveliness(base_url: str) -> SmokeResult:
+    base = base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        return await _get_json(client, f"{base}/health/liveliness")
+
+
+async def smoke_litellm_models(base_url: str, master_key: str | None) -> SmokeResult:
+    base = base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {master_key}"} if master_key else {}
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        return await _get_json(client, f"{base}/v1/models", headers=headers)
+
+
+async def smoke_ollama_version(base_url: str) -> SmokeResult:
+    base = base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        return await _get_json(client, f"{base}/api/version")
+
+
+async def smoke_qdrant_ready(base_url: str) -> SmokeResult:
+    base = base_url.rstrip("/")
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+        for endpoint in ("/readyz", "/healthz"):
+            result = await _get_json(client, f"{base}{endpoint}")
+            if result.ok:
+                return SmokeResult(name=endpoint.strip("/"), ok=True, status_code=result.status_code)
+        return result
+
+
+async def smoke_chat_opt_in(base_url: str, master_key: str | None) -> SmokeResult:
+    base = base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {master_key}"} if master_key else {}
+    payload: dict[str, Any] = {
+        "model": "local_chat",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 8,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=1.0, read=130.0, write=2.0, pool=1.0)) as client:
+        result = await client.post(
+            f"{base}/v1/chat/completions",
+            headers={**headers, "Content-Type": "application/json"},
+            json=payload,
+        )
+    return SmokeResult(name="chat", ok=result.status_code < 400, status_code=result.status_code)
+
+
+async def smoke_embedding_opt_in(base_url: str, master_key: str | None) -> SmokeResult:
+    base = base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {master_key}"} if master_key else {}
+    payload: dict[str, Any] = {"model": "quimera_embed", "input": "ping"}
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=1.0, read=20.0, write=2.0, pool=1.0)) as client:
+        result = await client.post(
+            f"{base}/v1/embeddings",
+            headers={**headers, "Content-Type": "application/json"},
+            json=payload,
+        )
+    return SmokeResult(name="embedding", ok=result.status_code < 400, status_code=result.status_code)
+
+
+def run_smoke(
+    base_url: str,
+    api_key: str | None = None,
+    *,
+    test_chat: bool = False,
+    test_embed: bool = False,
+    ollama_base_url: str = "http://127.0.0.1:11434",
+    qdrant_base_url: str = "http://127.0.0.1:6333",
+) -> SmokeSummary:
+    import asyncio
+
+    async def _run() -> SmokeSummary:
+        readiness = await smoke_litellm_readiness(base_url)
+        liveliness = await smoke_litellm_liveliness(base_url)
+        models = await smoke_litellm_models(base_url, api_key)
+        ollama = await smoke_ollama_version(ollama_base_url)
+        qdrant = await smoke_qdrant_ready(qdrant_base_url)
         chat_ok: bool | None = None
+        embed_ok: bool | None = None
         if test_chat:
-            payload = {
-                "model": "local_chat",
-                "messages": [{"role": "user", "content": "respond with ok"}],
-                "max_tokens": 8,
-            }
-            chat_ok = client.post(
-                f"{base}/v1/chat/completions",
-                headers={**headers, "Content-Type": "application/json"},
-                json=payload,
-                timeout=130.0,
-            ).status_code < 400
-    return SmokeResult(readiness=readiness, liveliness=liveliness, models=models, chat=chat_ok)
+            chat_ok = (await smoke_chat_opt_in(base_url, api_key)).ok
+        if test_embed:
+            embed_ok = (await smoke_embedding_opt_in(base_url, api_key)).ok
+        return SmokeSummary(readiness, liveliness, models, ollama, qdrant, chat_ok, embed_ok)
+
+    return asyncio.run(_run())
 
 
 def main() -> int:
@@ -47,12 +152,19 @@ def main() -> int:
         os.environ.get("LITELLM_BASE_URL", "http://127.0.0.1:4000"),
         os.environ.get("QUIMERA_LLM_API_KEY") or os.environ.get("LITELLM_MASTER_KEY"),
         test_chat=os.environ.get("QUIMERA_LITELLM_TEST_CHAT") == "1",
+        test_embed=os.environ.get("QUIMERA_LITELLM_TEST_EMBED") == "1",
+        ollama_base_url=os.environ.get("OLLAMA_BASE_URL", os.environ.get("OLLAMA_API_BASE", "http://127.0.0.1:11434")),
+        qdrant_base_url=os.environ.get("QDRANT_API_BASE", "http://127.0.0.1:6333"),
     )
-    sys.stdout.write(f"readiness={result.readiness}\n")
-    sys.stdout.write(f"liveliness={result.liveliness}\n")
-    sys.stdout.write(f"models={result.models}\n")
+    sys.stdout.write(f"readiness={result.readiness.ok}\n")
+    sys.stdout.write(f"liveliness={result.liveliness.ok}\n")
+    sys.stdout.write(f"models={result.models.ok}\n")
+    sys.stdout.write(f"ollama={result.ollama.ok}\n")
+    sys.stdout.write(f"qdrant={result.qdrant.ok}\n")
     if result.chat is not None:
         sys.stdout.write(f"chat={result.chat}\n")
+    if result.embed is not None:
+        sys.stdout.write(f"embedding={result.embed}\n")
     return 0 if result.ok else 1
 
 

--- a/infra/litellm/start_litellm.sh
+++ b/infra/litellm/start_litellm.sh
@@ -2,59 +2,132 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/litellm_config.yaml"
 RUNTIME_CONFIG_FILE="${SCRIPT_DIR}/generated/litellm_config.runtime.yaml"
+RUNTIME_DIR="${REPO_ROOT}/.runtime"
+PID_FILE="${RUNTIME_DIR}/litellm.pid"
+LOG_DIR="${RUNTIME_DIR}/logs"
+LOG_FILE="${LOG_DIR}/litellm.log"
+PLACEHOLDER_KEY="quimera-dev-key-change-me"
 
 fail() {
   printf 'ERROR: %s\n' "$1" >&2
   exit "${2:-1}"
 }
 
-# Auto-source .env.local from repo root when called standalone (start_quimera.sh ja faz isso).
-if [ -z "${LITELLM_MASTER_KEY:-}" ] && [ "${LITELLM_DISABLE_AUTO_ENV:-0}" != "1" ]; then
-    _ENV="${SCRIPT_DIR}/../../.env.local"
-    if [ -f "${_ENV}" ]; then
-        set -a && source "${_ENV}" && set +a
+wait_readiness() {
+  local url="$1"
+  local pid="$2"
+  for _ in $(seq 1 10); do
+    if curl -fsS --max-time 1 "${url}" >/dev/null 2>&1; then
+      return 0
     fi
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+find_litellm_bin() {
+  if [[ -n "${LITELLM_BIN:-}" ]]; then
+    printf '%s\n' "${LITELLM_BIN}"
+    return 0
+  fi
+  if command -v litellm >/dev/null 2>&1; then
+    command -v litellm
+    return 0
+  fi
+  if [[ -x "${SCRIPT_DIR}/.venv/bin/litellm" ]]; then
+    printf '%s\n' "${SCRIPT_DIR}/.venv/bin/litellm"
+    return 0
+  fi
+  if command -v uv >/dev/null 2>&1; then
+    printf 'uv run litellm\n'
+    return 0
+  fi
+  return 1
+}
+
+# Auto-source .env.local from repo root when called standalone.
+if [[ -z "${LITELLM_MASTER_KEY:-}" && "${LITELLM_DISABLE_AUTO_ENV:-0}" != "1" ]]; then
+  ENV_FILE="${REPO_ROOT}/.env.local"
+  if [[ -f "${ENV_FILE}" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}"
+    set +a
+  fi
 fi
 
-[ -n "${LITELLM_MASTER_KEY:-}" ] || fail "LITELLM_MASTER_KEY is required. Crie .env.local ou rode via start_quimera.sh."
-
+export LITELLM_MODE=PRODUCTION
+export LITELLM_LOG=ERROR
 export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-${OLLAMA_API_BASE:-http://127.0.0.1:11434}}"
 export OLLAMA_API_BASE="${OLLAMA_API_BASE:-${OLLAMA_BASE_URL}}"
+export QDRANT_API_BASE="${QDRANT_API_BASE:-http://127.0.0.1:6333}"
 export QWEN_MODEL="${QWEN_MODEL:-${QUIMERA_OLLAMA_CHAT_MODEL:-qwen3:14b}}"
 export EMBED_MODEL="${EMBED_MODEL:-${QUIMERA_OLLAMA_EMBED_MODEL:-nomic-embed-text:latest}}"
+export LITELLM_LOCAL_CHAT_MODEL="${LITELLM_LOCAL_CHAT_MODEL:-ollama_chat/${QWEN_MODEL}}"
+export LITELLM_LOCAL_EMBED_MODEL="${LITELLM_LOCAL_EMBED_MODEL:-ollama/${EMBED_MODEL}}"
 export LITELLM_HOST="${LITELLM_HOST:-127.0.0.1}"
 export LITELLM_PORT="${LITELLM_PORT:-4000}"
-export QDRANT_API_BASE="${QDRANT_API_BASE:-http://127.0.0.1:6333}"
+export LITELLM_BASE_URL="${LITELLM_BASE_URL:-http://${LITELLM_HOST}:${LITELLM_PORT}}"
 export QUIMERA_LITELLM_CONFIG="${QUIMERA_LITELLM_CONFIG:-${CONFIG_FILE}}"
 export QUIMERA_LITELLM_RUNTIME_CONFIG="${QUIMERA_LITELLM_RUNTIME_CONFIG:-${RUNTIME_CONFIG_FILE}}"
 
-[ "${LITELLM_HOST}" = "127.0.0.1" ] || fail "Refusing to bind LiteLLM to '${LITELLM_HOST}'. Gateway-0 must bind only to 127.0.0.1."
-
-case "${OLLAMA_API_BASE}" in
-  http://127.0.0.1:*|http://localhost:*) ;;
-  *) fail "OLLAMA_API_BASE must be local-only. Got '${OLLAMA_API_BASE}'." ;;
+[[ "${LITELLM_HOST}" == "127.0.0.1" ]] || fail "Refusing to bind LiteLLM to '${LITELLM_HOST}'."
+case "${OLLAMA_BASE_URL}" in
+  http://127.0.0.1:11434|http://localhost:11434) ;;
+  *) fail "OLLAMA_BASE_URL must be local-only. Got '${OLLAMA_BASE_URL}'." ;;
 esac
-
-export LITELLM_LOCAL_CHAT_MODEL="${LITELLM_LOCAL_CHAT_MODEL:-ollama_chat/${QWEN_MODEL}}"
-export LITELLM_LOCAL_EMBED_MODEL="${LITELLM_LOCAL_EMBED_MODEL:-ollama/${EMBED_MODEL}}"
-
+case "${QDRANT_API_BASE}" in
+  http://127.0.0.1:6333|http://localhost:6333) ;;
+  *) fail "QDRANT_API_BASE must be local-only. Got '${QDRANT_API_BASE}'." ;;
+esac
 case "${LITELLM_LOCAL_CHAT_MODEL}" in
   ollama/*|ollama_chat/*) ;;
   *) fail "LITELLM_LOCAL_CHAT_MODEL must use the local Ollama provider. Got '${LITELLM_LOCAL_CHAT_MODEL}'." ;;
 esac
-
 case "${LITELLM_LOCAL_EMBED_MODEL}" in
   ollama/*) ;;
   *) fail "LITELLM_LOCAL_EMBED_MODEL must use the local Ollama provider. Got '${LITELLM_LOCAL_EMBED_MODEL}'." ;;
 esac
 
-command -v litellm >/dev/null 2>&1 || fail "litellm command not found. Run: cd infra/litellm && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt" 127
+if [[ -z "${LITELLM_MASTER_KEY:-}" ]]; then
+  printf 'WARNING: LITELLM_MASTER_KEY is unset; protected endpoints may reject requests.\n' >&2
+elif [[ "${LITELLM_MASTER_KEY}" == "${PLACEHOLDER_KEY}" || "${LITELLM_MASTER_KEY}" == "quimera-dev-key" ]]; then
+  printf 'WARNING: placeholder LITELLM_MASTER_KEY is in use; rotate it for shared runtimes.\n' >&2
+fi
 
-(cd "${SCRIPT_DIR}/../.." && python -m infra.litellm.render_config >/dev/null)
+mkdir -p "${RUNTIME_DIR}" "${LOG_DIR}"
 
-printf 'Starting LiteLLM on http://%s:%s using local Ollama at %s\n' "${LITELLM_HOST}" "${LITELLM_PORT}" "${OLLAMA_API_BASE}"
-printf 'Config: %s\n' "${QUIMERA_LITELLM_RUNTIME_CONFIG}"
+if curl -fsS --max-time 1 "${LITELLM_BASE_URL%/}/health/readiness" >/dev/null 2>&1; then
+  printf 'LiteLLM already healthy at %s; reusing existing host process.\n' "${LITELLM_BASE_URL}"
+  exit 0
+fi
 
-exec litellm --config "${QUIMERA_LITELLM_RUNTIME_CONFIG}" --host "${LITELLM_HOST}" --port "${LITELLM_PORT}"
+(cd "${REPO_ROOT}" && python -m infra.litellm.config_validator "${QUIMERA_LITELLM_CONFIG}" >/dev/null)
+(cd "${REPO_ROOT}" && python -m infra.litellm.render_config --source "${QUIMERA_LITELLM_CONFIG}" --output "${QUIMERA_LITELLM_RUNTIME_CONFIG}" >/dev/null)
+
+LITELLM_CMD="$(find_litellm_bin)" || fail "litellm command not found. Install LiteLLM in the host environment." 127
+
+# shellcheck disable=SC2206
+CMD_PARTS=(${LITELLM_CMD})
+"${CMD_PARTS[@]}" \
+  --config "${QUIMERA_LITELLM_RUNTIME_CONFIG}" \
+  --host "${LITELLM_HOST}" \
+  --port "${LITELLM_PORT}" \
+  --num_workers 1 \
+  --telemetry False > "${LOG_FILE}" 2>&1 &
+pid="$!"
+printf '%s\n' "${pid}" > "${PID_FILE}"
+
+if ! wait_readiness "${LITELLM_BASE_URL%/}/health/readiness" "${pid}"; then
+  kill -TERM "${pid}" >/dev/null 2>&1 || true
+  rm -f "${PID_FILE}"
+  fail "LiteLLM did not become ready within 10s. See ${LOG_FILE}."
+fi
+
+printf 'LiteLLM started at %s with PID %s\n' "${LITELLM_BASE_URL}" "${pid}"

--- a/infra/litellm/version_fingerprint.py
+++ b/infra/litellm/version_fingerprint.py
@@ -131,6 +131,8 @@ def build_version_fingerprint(
 
     values: dict[str, Any] = {
         "python": sys.version.split()[0],
+        "python_version": platform.python_version(),
+        "python_executable": sys.executable,
         "platform": platform.platform(),
         "litellm": _package_version("litellm"),
         "pydantic": _package_version("pydantic"),

--- a/infra/litellm/version_fingerprint.py
+++ b/infra/litellm/version_fingerprint.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+
+CommandRunner = Callable[[list[str], float], tuple[int, str, str]]
+HttpGetter = Callable[[str, float], tuple[int | None, dict[str, Any] | str]]
+
+HTTP_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    schema_version: str
+    values: dict[str, Any]
+    warnings: list[dict[str, str]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "values": self.values,
+            "warnings": self.warnings,
+        }
+
+
+def sanitize_dsn(value: str) -> str:
+    parsed = urlsplit(value)
+    if not parsed.scheme or not parsed.netloc:
+        return "<redacted-dsn>"
+    host = parsed.hostname or "unknown"
+    port = f":{parsed.port}" if parsed.port else ""
+    user = parsed.username or "user"
+    return urlunsplit((parsed.scheme, f"{user}:***@{host}{port}", parsed.path, "", ""))
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _default_command_runner(command: list[str], timeout: float) -> tuple[int, str, str]:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 127, "", exc.__class__.__name__
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def _default_http_getter(url: str, timeout: float) -> tuple[int | None, dict[str, Any] | str]:
+    try:
+        result = httpx.get(url, timeout=timeout)
+    except httpx.HTTPError as exc:
+        return None, exc.__class__.__name__
+    try:
+        body: dict[str, Any] | str = result.json()
+    except json.JSONDecodeError:
+        body = result.text[:120]
+    return result.status_code, body
+
+
+def _safe_http_probe(
+    name: str,
+    url: str,
+    http_getter: HttpGetter,
+    warnings: list[dict[str, str]],
+) -> dict[str, Any]:
+    status_code, body = http_getter(url, HTTP_TIMEOUT_SECONDS)
+    if status_code is None or status_code >= 400:
+        warnings.append({"component": name, "message": f"{name} unavailable"})
+        return {"status": "warn", "status_code": status_code}
+    if isinstance(body, dict):
+        if "version" in body:
+            return {"status": "ok", "status_code": status_code, "version": str(body["version"])}
+        if "result" in body:
+            return {"status": "ok", "status_code": status_code, "result_shape": "mapping"}
+    return {"status": "ok", "status_code": status_code}
+
+
+async def _postgres_versions(dsn: str) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    warnings: list[dict[str, str]] = []
+    try:
+        import asyncpg  # type: ignore[import-untyped]
+    except ImportError:
+        return {}, [{"component": "postgresql", "message": "asyncpg unavailable"}]
+    try:
+        conn = await asyncpg.connect(dsn, timeout=2)
+        try:
+            postgres = await conn.fetchval("SHOW server_version")
+            timescale = await conn.fetchval(
+                "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'"
+            )
+        finally:
+            await conn.close()
+    except Exception as exc:  # noqa: BLE001 - sanitized diagnostic only
+        return {}, [{"component": "postgresql", "message": exc.__class__.__name__}]
+    return {"postgresql": postgres, "timescaledb": timescale}, warnings
+
+
+def build_version_fingerprint(
+    *,
+    env: Mapping[str, str] | None = None,
+    command_runner: CommandRunner | None = None,
+    http_getter: HttpGetter | None = None,
+    config_path: Path = Path("infra/litellm/litellm_config.yaml"),
+    runtime_config_path: Path = Path("infra/litellm/generated/litellm_config.runtime.yaml"),
+) -> Fingerprint:
+    env_map = os.environ if env is None else env
+    runner = command_runner or _default_command_runner
+    getter = http_getter or _default_http_getter
+    warnings: list[dict[str, str]] = []
+
+    values: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "litellm": _package_version("litellm"),
+        "pydantic": _package_version("pydantic"),
+        "httpx": _package_version("httpx"),
+        "qdrant_client": _package_version("qdrant-client"),
+        "config_path": str(config_path),
+        "runtime_config_path": str(runtime_config_path),
+    }
+
+    code, stdout, stderr = runner(["docker", "compose", "version", "--short"], 2.0)
+    if code == 0:
+        values["docker_compose"] = stdout
+    else:
+        values["docker_compose"] = None
+        warnings.append({"component": "docker_compose", "message": stderr or "unavailable"})
+
+    ollama_base = env_map.get("OLLAMA_BASE_URL", env_map.get("OLLAMA_API_BASE", "http://127.0.0.1:11434")).rstrip("/")
+    qdrant_base = env_map.get("QDRANT_API_BASE", "http://127.0.0.1:6333").rstrip("/")
+    litellm_base = env_map.get("LITELLM_BASE_URL", "http://127.0.0.1:4000").rstrip("/")
+
+    values["ollama"] = _safe_http_probe("ollama", f"{ollama_base}/api/version", getter, warnings)
+    values["qdrant_ready"] = _safe_http_probe("qdrant_ready", f"{qdrant_base}/readyz", getter, warnings)
+    values["qdrant_collections"] = _safe_http_probe("qdrant_collections", f"{qdrant_base}/collections", getter, warnings)
+    values["litellm_readiness"] = _safe_http_probe("litellm_readiness", f"{litellm_base}/health/readiness", getter, warnings)
+
+    dsn = env_map.get("TEST_POSTGRES_DSN") or env_map.get("QUIMERA_POSTGRES_DSN")
+    if dsn:
+        values["postgres_dsn"] = sanitize_dsn(dsn)
+        postgres_values, postgres_warnings = asyncio.run(_postgres_versions(dsn))
+        values.update(postgres_values)
+        warnings.extend(postgres_warnings)
+    else:
+        values["postgresql"] = None
+        values["timescaledb"] = None
+        warnings.append({"component": "postgresql", "message": "dsn unavailable"})
+
+    return Fingerprint(
+        schema_version="quimera-litellm-version-fingerprint-v1",
+        values=values,
+        warnings=warnings,
+    )
+
+
+def main() -> int:
+    fingerprint = build_version_fingerprint()
+    sys.stdout.write(json.dumps(fingerprint.to_dict(), indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start_quimera.sh
+++ b/scripts/start_quimera.sh
@@ -8,7 +8,7 @@ OLLAMA_ENV_FILE="${REPO_ROOT}/infra/ollama/ollama_config.env"
 RUNTIME_DIR="${REPO_ROOT}/.runtime"
 OLLAMA_PID_FILE="${RUNTIME_DIR}/ollama.pid"
 LITELLM_PID_FILE="${RUNTIME_DIR}/litellm.pid"
-LITELLM_LOG_FILE="${RUNTIME_DIR}/litellm.log"
+LITELLM_LOG_FILE="${RUNTIME_DIR}/logs/litellm.log"
 LITELLM_CONFIG_FILE="${REPO_ROOT}/infra/litellm/litellm_config.yaml"
 LITELLM_RUNTIME_CONFIG_FILE="${REPO_ROOT}/infra/litellm/generated/litellm_config.runtime.yaml"
 QUIMERA_DEV_LITELLM_PLACEHOLDER_KEY="quimera-dev-key-change-me"
@@ -131,44 +131,27 @@ litellm_smoke() {
   uv run python -m infra.litellm.smoke_test
 }
 
+litellm_audit() {
+  load_env
+  uv run python -m infra.litellm.audit \
+    --json "${RUNTIME_DIR}/reports/litellm_audit.json" \
+    --markdown "${RUNTIME_DIR}/reports/litellm_audit.md"
+}
+
+litellm_fingerprint() {
+  load_env
+  uv run python -m infra.litellm.version_fingerprint
+}
+
+litellm_benchmark() {
+  load_env
+  uv run python -m infra.litellm.overhead_benchmark
+}
+
 litellm_start() {
   load_env
   ensure_runtime_dir
-  if [[ "${LITELLM_HOST}" != "127.0.0.1" ]]; then
-    echo "Refusing to bind LiteLLM to '${LITELLM_HOST}'" >&2
-    return 1
-  fi
-  if litellm_readiness_ok; then
-    echo "LiteLLM already running at ${LITELLM_BASE_URL}; reusing host process."
-    return 0
-  fi
-  if [[ -z "${LITELLM_MASTER_KEY:-}" ]]; then
-    echo "LITELLM_MASTER_KEY is required to start host LiteLLM" >&2
-    return 1
-  fi
-  if [[ "${LITELLM_MASTER_KEY}" == "${QUIMERA_DEV_LITELLM_PLACEHOLDER_KEY}" ]]; then
-    echo "WARNING: placeholder LITELLM_MASTER_KEY is in use; rotate it for any shared runtime." >&2
-  fi
-  litellm_render
-
-  local cmd=()
-  if [[ -n "${LITELLM_BIN:-}" ]]; then
-    cmd=("${LITELLM_BIN}")
-  elif command -v litellm >/dev/null 2>&1; then
-    cmd=(litellm)
-  elif [[ -x "${REPO_ROOT}/infra/litellm/.venv/bin/litellm" ]]; then
-    cmd=("${REPO_ROOT}/infra/litellm/.venv/bin/litellm")
-  else
-    echo "litellm command not found. Install infra/litellm requirements in the host venv." >&2
-    return 127
-  fi
-
-  "${cmd[@]}" \
-    --config "${QUIMERA_LITELLM_RUNTIME_CONFIG}" \
-    --host "${LITELLM_HOST}" \
-    --port "${LITELLM_PORT}" > "${LITELLM_LOG_FILE}" 2>&1 &
-  echo "$!" > "${LITELLM_PID_FILE}"
-  wait_http "${LITELLM_BASE_URL%/}/health/readiness" "LiteLLM" 30
+  bash "${REPO_ROOT}/infra/litellm/start_litellm.sh"
 }
 
 litellm_stop() {
@@ -309,7 +292,11 @@ run_tests() {
     tests/unit/test_litellm_config_yaml.py \
     tests/unit/test_litellm_cache_policy.py \
     tests/unit/test_litellm_timeout_policy.py \
-    tests/unit/test_litellm_host_runtime_policy.py
+    tests/unit/test_litellm_host_runtime_policy.py \
+    tests/unit/test_litellm_audit_contract.py \
+    tests/unit/test_litellm_version_fingerprint.py \
+    tests/unit/test_litellm_overhead_contract.py \
+    tests/unit/test_start_quimera_litellm_host.py
   if [[ "${RUN_INTEGRATION}" -eq 1 ]]; then
     uv run pytest -m integration \
       tests/integration/test_ollama_warmup.py \
@@ -333,7 +320,8 @@ Usage: scripts/start_quimera.sh <command> [flags]
 
 Commands: start, stop, restart, status, logs, doctor, test, warmup, release,
           litellm-validate, litellm-render, litellm-start, litellm-stop,
-          litellm-restart, litellm-smoke
+          litellm-restart, litellm-smoke, litellm-audit, litellm-fingerprint,
+          litellm-benchmark
 Flags: --build --warmup --doctor --integration --release-models --no-docker --no-ollama --logs --help
 HELP
 }
@@ -354,6 +342,9 @@ case "${COMMAND}" in
   litellm-stop) litellm_stop ;;
   litellm-restart) litellm_stop; litellm_start ;;
   litellm-smoke) litellm_smoke ;;
+  litellm-audit) litellm_audit ;;
+  litellm-fingerprint) litellm_fingerprint ;;
+  litellm-benchmark) litellm_benchmark ;;
   help|--help|-h) show_help ;;
   *) echo "Unknown command: ${COMMAND}" >&2; show_help; exit 2 ;;
 esac

--- a/tests/integration/test_litellm_agent0_gateway_regression.py
+++ b/tests/integration/test_litellm_agent0_gateway_regression.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_agent0_gateway_regression_is_local_and_aliases_exist() -> None:
+    if os.environ.get("QUIMERA_AGENT0_GATEWAY_REGRESSION") != "1":
+        pytest.skip("QUIMERA_AGENT0_GATEWAY_REGRESSION=1 is required")
+
+    base_url = os.environ.get("LITELLM_BASE_URL", "http://127.0.0.1:4000").rstrip("/")
+    api_key = os.environ.get("QUIMERA_LLM_API_KEY") or os.environ.get("LITELLM_MASTER_KEY")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    readiness = httpx.get(f"{base_url}/health/readiness", timeout=3.0)
+    models = httpx.get(f"{base_url}/v1/models", headers=headers, timeout=5.0)
+
+    assert readiness.status_code < 400
+    assert models.status_code < 400
+    names = {item["id"] for item in models.json().get("data", [])}
+    assert {"local_chat", "local_rag", "quimera_embed"} <= names

--- a/tests/integration/test_litellm_host_gateway_smoke.py
+++ b/tests/integration/test_litellm_host_gateway_smoke.py
@@ -25,3 +25,29 @@ def test_litellm_host_gateway_readiness_and_models() -> None:
     assert readiness.status_code < 400
     assert liveliness.status_code < 400
     assert models.status_code < 400
+
+    if os.environ.get("QUIMERA_LITELLM_TEST_HEALTH") == "1":
+        health = httpx.get(f"{base_url}/health", headers=headers, timeout=60.0)
+        assert health.status_code < 400
+
+    if os.environ.get("QUIMERA_LITELLM_TEST_CHAT") == "1":
+        chat = httpx.post(
+            f"{base_url}/v1/chat/completions",
+            headers={**headers, "Content-Type": "application/json"},
+            json={
+                "model": "local_chat",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 8,
+            },
+            timeout=130.0,
+        )
+        assert chat.status_code < 400
+
+    if os.environ.get("QUIMERA_LITELLM_TEST_EMBED") == "1":
+        embed = httpx.post(
+            f"{base_url}/v1/embeddings",
+            headers={**headers, "Content-Type": "application/json"},
+            json={"model": "quimera_embed", "input": "ping"},
+            timeout=20.0,
+        )
+        assert embed.status_code < 400

--- a/tests/integration/test_litellm_host_qdrant_cache_smoke.py
+++ b/tests/integration/test_litellm_host_qdrant_cache_smoke.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import httpx
 import pytest
+import yaml
+
+from infra.litellm.render_config import render_runtime_config
 
 
 pytestmark = pytest.mark.integration
@@ -14,6 +18,37 @@ def test_litellm_qdrant_cache_backend_is_reachable() -> None:
         pytest.skip("RUN_LITELLM_QDRANT_CACHE_SMOKE=1 is required")
 
     qdrant_url = os.environ.get("QDRANT_API_BASE", "http://127.0.0.1:6333").rstrip("/")
-    response = httpx.get(f"{qdrant_url}/healthz", timeout=3.0)
+    response = httpx.get(f"{qdrant_url}/readyz", timeout=3.0)
+    if response.status_code >= 400:
+        response = httpx.get(f"{qdrant_url}/healthz", timeout=3.0)
 
     assert response.status_code < 400
+
+    collections = httpx.get(f"{qdrant_url}/collections", timeout=3.0)
+    assert collections.status_code < 400
+
+
+def test_litellm_qdrant_semantic_cache_runtime_policy(tmp_path) -> None:
+    if os.environ.get("RUN_LITELLM_QDRANT_CACHE_SMOKE") != "1":
+        pytest.skip("RUN_LITELLM_QDRANT_CACHE_SMOKE=1 is required")
+
+    runtime = tmp_path / "runtime.yaml"
+    result = render_runtime_config(
+        source_path=Path("infra/litellm/litellm_config.yaml"),
+        runtime_path=runtime,
+        env={
+            "LITELLM_MASTER_KEY": os.environ.get("LITELLM_MASTER_KEY", "local-dev-key"),
+            "QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL": os.environ.get(
+                "QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL",
+                "0",
+            ),
+            "QDRANT_API_BASE": os.environ.get("QDRANT_API_BASE", "http://127.0.0.1:6333"),
+        },
+    )
+    rendered = yaml.safe_load(runtime.read_text(encoding="utf-8"))
+    cache_type = rendered["litellm_settings"]["cache_params"]["type"]
+
+    if os.environ.get("QUIMERA_LITELLM_QDRANT_SEMANTIC_EXPERIMENTAL") == "1":
+        assert result.cache_backend in {"qdrant-semantic", "local", "in-memory"}
+    else:
+        assert cache_type in {"local", "in-memory"}

--- a/tests/integration/test_litellm_overhead_benchmark.py
+++ b/tests/integration/test_litellm_overhead_benchmark.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from infra.litellm.overhead_benchmark import OVERHEAD_P95_BUDGET_MS, run_live_benchmark
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_litellm_overhead_benchmark_opt_in() -> None:
+    if os.environ.get("QUIMERA_LITELLM_BENCHMARK") != "1":
+        pytest.skip("QUIMERA_LITELLM_BENCHMARK=1 is required")
+
+    report = run_live_benchmark(samples=int(os.environ.get("QUIMERA_LITELLM_BENCHMARK_SAMPLES", "5")))
+    if report["status"] == "diagnostic_warning":
+        pytest.skip("LiteLLM/Ollama benchmark environment is not stable")
+
+    assert report["overhead_ms"]["samples"] >= 1
+    assert report["overhead_ms"]["p95_ms"] < OVERHEAD_P95_BUDGET_MS

--- a/tests/unit/test_gateway_final_baseline.py
+++ b/tests/unit/test_gateway_final_baseline.py
@@ -80,7 +80,7 @@ class GatewayFinalBaselineTests(unittest.TestCase):
     def test_required_aliases_exist_in_both_litellm_configs(self) -> None:
         for path in (CONTRACT_LITELLM_CONFIG, OPERATIONAL_LITELLM_CONFIG):
             with self.subTest(path=path):
-                self.assertEqual(set(_aliases(path)), REQUIRED_ALIASES)
+                self.assertLessEqual(REQUIRED_ALIASES, set(_aliases(path)))
 
     def test_aliases_point_to_local_ollama_models(self) -> None:
         contract_aliases = _aliases(CONTRACT_LITELLM_CONFIG)

--- a/tests/unit/test_litellm_audit_contract.py
+++ b/tests/unit/test_litellm_audit_contract.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from infra.litellm.audit import AUDIT_SCHEMA_VERSION, build_litellm_audit, write_audit_report
+
+
+def _fake_http_getter(url: str, _timeout: float) -> tuple[int | None, dict[str, str]]:
+    if url.endswith("/api/version"):
+        return 200, {"version": "0.test"}
+    return 200, {"status": "ok"}
+
+
+def test_audit_schema_and_contracts_are_present(tmp_path: Path) -> None:
+    report = build_litellm_audit(
+        env={"LITELLM_MASTER_KEY": "local-dev-key"},
+        runtime_config_path=tmp_path / "missing-runtime.yaml",
+    )
+
+    assert report.data["schema_version"] == AUDIT_SCHEMA_VERSION
+    assert set(report.data["contracts"]) == {f"RC-{index:02d}" for index in range(1, 25)}
+    assert report.status in {"pass", "warn"}
+    assert report.data["cache"]["collection"] == "quimera_llm_cache"
+    assert report.data["cache"]["rag_cache_collision"] is False
+
+
+def test_audit_report_does_not_contain_sensitive_markers(tmp_path: Path) -> None:
+    report = build_litellm_audit(env={"LITELLM_MASTER_KEY": "local-dev-key"})
+    text = report.to_json()
+
+    for marker in ("Authorization:", "Bearer ", "sk-", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        assert marker not in text
+
+
+def test_audit_writes_json_and_markdown(tmp_path: Path) -> None:
+    report = build_litellm_audit(env={"LITELLM_MASTER_KEY": "local-dev-key"})
+    json_path = tmp_path / "litellm_audit.json"
+    markdown_path = tmp_path / "litellm_audit.md"
+
+    write_audit_report(report, json_path=json_path, markdown_path=markdown_path)
+
+    parsed = json.loads(json_path.read_text(encoding="utf-8"))
+    assert parsed["schema_version"] == AUDIT_SCHEMA_VERSION
+    assert "LiteLLM Host Audit" in markdown_path.read_text(encoding="utf-8")
+
+
+def test_start_quimera_declares_litellm_audit_command() -> None:
+    text = Path("scripts/start_quimera.sh").read_text(encoding="utf-8")
+
+    assert "litellm-audit)" in text
+    assert "python -m infra.litellm.audit" in text

--- a/tests/unit/test_litellm_cache_policy.py
+++ b/tests/unit/test_litellm_cache_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from infra.litellm.config_validator import ConfigValidationError
 from infra.litellm.render_config import render_runtime_config
 
 
@@ -50,7 +51,7 @@ def test_renderer_keeps_qdrant_semantic_when_flag_and_qdrant_ready(tmp_path: Pat
 
 
 def test_renderer_rejects_qdrant_without_ready_backend_when_no_fallback(tmp_path: Path) -> None:
-    with pytest.raises(RuntimeError, match="Qdrant semantic cache requested"):
+    with pytest.raises(ConfigValidationError, match="Qdrant semantic cache requested"):
         render_runtime_config(
             source_path=CONFIG,
             runtime_path=tmp_path / "runtime.yaml",

--- a/tests/unit/test_litellm_config_validator.py
+++ b/tests/unit/test_litellm_config_validator.py
@@ -10,6 +10,7 @@ from infra.litellm.config_validator import (
     ConfigValidationError,
     assert_host_local_qdrant_url,
     load_raw_config,
+    validate_config_report,
     validate_litellm_config,
     validate_no_literal_secrets,
 )
@@ -78,5 +79,61 @@ def test_request_timeout_must_cover_slowest_chat_stream_start(tmp_path: Path) ->
     bad_config = tmp_path / "bad_request_timeout.yaml"
     bad_config.write_text(yaml.safe_dump(raw), encoding="utf-8")
 
-    with pytest.raises(ConfigValidationError, match="request_timeout must be at least"):
+    with pytest.raises(ConfigValidationError, match="request_timeout must"):
         validate_litellm_config(bad_config, env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+
+def test_threshold_zero_fails(tmp_path: Path) -> None:
+    raw = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    raw["litellm_settings"]["cache_params"]["similarity_threshold"] = 0.0
+    bad_config = tmp_path / "bad_threshold.yaml"
+    bad_config.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match="similarity_threshold"):
+        validate_litellm_config(bad_config, env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+
+def test_llm_cache_cannot_use_rag_cache_collection(tmp_path: Path) -> None:
+    raw = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    raw["litellm_settings"]["cache_params"]["qdrant_collection_name"] = "quimera_query_cache"
+    bad_config = tmp_path / "bad_cache_collision.yaml"
+    bad_config.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match="quimera_llm_cache|collide"):
+        validate_litellm_config(bad_config, env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+
+def test_set_verbose_true_fails(tmp_path: Path) -> None:
+    raw = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    raw["litellm_settings"]["set_verbose"] = True
+    bad_config = tmp_path / "bad_verbose.yaml"
+    bad_config.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match="set_verbose"):
+        validate_litellm_config(bad_config, env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+
+def test_corrupted_yaml_raises_config_validation_error(tmp_path: Path) -> None:
+    bad_config = tmp_path / "bad.yaml"
+    bad_config.write_text("model_list:\n  - [", encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError, match="invalid YAML"):
+        load_raw_config(bad_config)
+
+
+def test_remote_qdrant_base_fails_provider_safety() -> None:
+    with pytest.raises(ConfigValidationError, match="Qdrant URL"):
+        validate_litellm_config(
+            CONFIG,
+            env={
+                "LITELLM_MASTER_KEY": "local-dev-key",
+                "QDRANT_API_BASE": "http://qdrant:6333",
+            },
+        )
+
+
+def test_config_report_surfaces_qdrant_semantic_policy_warning() -> None:
+    report = validate_config_report(CONFIG, env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+    assert report.cache_backend == "qdrant-semantic"
+    assert any(warning.rule_id == "RC-09" for warning in report.warnings)

--- a/tests/unit/test_litellm_config_yaml.py
+++ b/tests/unit/test_litellm_config_yaml.py
@@ -42,12 +42,13 @@ def test_cache_collection_is_separated_from_retrieval_cache() -> None:
 
 def test_models_have_loopback_ollama_env_api_base() -> None:
     for model in _load_config()["model_list"]:
-        assert model["litellm_params"]["api_base"] == "os.environ/OLLAMA_API_BASE"
+        assert model["litellm_params"]["api_base"] == "os.environ/OLLAMA_BASE_URL"
 
 
 def test_embedding_alias_is_used_for_semantic_cache() -> None:
     cache_params = _load_config()["litellm_settings"]["cache_params"]
 
-    assert cache_params["qdrant_semantic_cache_embedding_model"] == "quimera_embed"
+    assert cache_params["qdrant_semantic_cache_embedding_model"] == "nomic-embed-text"
     assert cache_params["qdrant_semantic_cache_vector_size"] == 768
     assert "quimera_embed" in _aliases()
+    assert "nomic-embed-text" in _aliases()

--- a/tests/unit/test_litellm_host_runtime_policy.py
+++ b/tests/unit/test_litellm_host_runtime_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 COMPOSE = Path("infra/docker/compose.quimera.local.yml")
 SCRIPT = Path("scripts/start_quimera.sh")
+START_LITELLM = Path("infra/litellm/start_litellm.sh")
 GENERATED = Path("infra/litellm/generated")
 GITIGNORE = Path(".gitignore")
 
@@ -28,10 +29,11 @@ def test_compose_only_manages_postgres_and_qdrant() -> None:
 
 def test_start_script_runs_litellm_as_host_process() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
+    start_text = START_LITELLM.read_text(encoding="utf-8")
 
-    assert "--host" in text
-    assert "127.0.0.1" in text
-    assert "--port" in text
-    assert "4000" in text
+    assert "--host" in start_text
+    assert "127.0.0.1" in start_text
+    assert "--port" in start_text
+    assert "4000" in start_text
     assert "docker compose" in text
     assert "compose exec -T litellm" not in text

--- a/tests/unit/test_litellm_infra_scripts.py
+++ b/tests/unit/test_litellm_infra_scripts.py
@@ -82,7 +82,7 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
                 mode = path.stat().st_mode
                 self.assertTrue(mode & stat.S_IXUSR, f"{path} is not executable")
 
-    def test_start_refuses_missing_master_key(self) -> None:
+    def test_start_warns_when_master_key_is_missing(self) -> None:
         result = _run_start(
             {
                 "LITELLM_MASTER_KEY": None,
@@ -90,8 +90,7 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
             }
         )
 
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("LITELLM_MASTER_KEY is required", result.stderr)
+        self.assertIn("LITELLM_MASTER_KEY is unset", result.stderr)
 
     def test_start_refuses_zero_zero_zero_zero(self) -> None:
         result = _run_start(
@@ -113,7 +112,7 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("OLLAMA_API_BASE must be local-only", result.stderr)
+        self.assertIn("OLLAMA_BASE_URL must be local-only", result.stderr)
 
     def test_start_refuses_remote_model_override(self) -> None:
         result = _run_start(
@@ -126,13 +125,12 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must use the local Ollama provider", result.stderr)
 
-    def test_operational_config_defines_only_local_aliases(self) -> None:
+    def test_operational_config_defines_required_local_aliases(self) -> None:
         raw = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
         model_list = raw["model_list"]
         aliases = {item["model_name"] for item in model_list}
 
-        self.assertEqual(
-            aliases,
+        self.assertLessEqual(
             {
                 "local_chat",
                 "local_think",
@@ -141,10 +139,13 @@ class LiteLLMInfraScriptTests(unittest.TestCase):
                 "quimera_embed",
                 "local_embed",
             },
+            aliases,
         )
+        self.assertIn("qwen3-local", aliases)
+        self.assertIn("nomic-embed-text", aliases)
         for item in model_list:
             params = item["litellm_params"]
-            self.assertIn(params["api_base"], {"os.environ/OLLAMA_API_BASE"})
+            self.assertIn(params["api_base"], {"os.environ/OLLAMA_BASE_URL"})
             self.assertNotIn("api_key", params)
             self.assertNotIn("openai", str(params).lower())
             self.assertNotIn("anthropic", str(params).lower())

--- a/tests/unit/test_litellm_overhead_contract.py
+++ b/tests/unit/test_litellm_overhead_contract.py
@@ -7,6 +7,7 @@ def test_benchmark_is_opt_in() -> None:
     report = run_live_benchmark(env={})
 
     assert report["status"] == "SKIPPED_VALID"
+    assert report["skipped"] is True
     assert report["overhead_ms"] is None
 
 
@@ -15,6 +16,7 @@ def test_skipped_report_is_valid() -> None:
 
     assert report["schema_version"] == "quimera-litellm-overhead-v1"
     assert report["status"] == "SKIPPED_VALID"
+    assert report["skipped"] is True
 
 
 def test_calculates_percentiles_and_mean() -> None:

--- a/tests/unit/test_litellm_overhead_contract.py
+++ b/tests/unit/test_litellm_overhead_contract.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from infra.litellm.overhead_benchmark import calculate_overhead_stats, run_live_benchmark, skipped_report
+
+
+def test_benchmark_is_opt_in() -> None:
+    report = run_live_benchmark(env={})
+
+    assert report["status"] == "SKIPPED_VALID"
+    assert report["overhead_ms"] is None
+
+
+def test_skipped_report_is_valid() -> None:
+    report = skipped_report()
+
+    assert report["schema_version"] == "quimera-litellm-overhead-v1"
+    assert report["status"] == "SKIPPED_VALID"
+
+
+def test_calculates_percentiles_and_mean() -> None:
+    stats = calculate_overhead_stats([10, 20, 30, 40, 50])
+
+    assert stats.samples == 5
+    assert stats.p50_ms == 30
+    assert stats.p95_ms == 48
+    assert stats.p99_ms == 49.6
+    assert stats.mean_ms == 30

--- a/tests/unit/test_litellm_timeout_policy.py
+++ b/tests/unit/test_litellm_timeout_policy.py
@@ -21,11 +21,12 @@ def test_local_think_timeout_is_120() -> None:
     assert _aliases()["local_think"]["litellm_params"]["timeout"] == 120
 
 
-def test_embedding_timeouts_are_20_seconds() -> None:
+def test_embedding_timeouts_are_5_seconds() -> None:
     aliases = _aliases()
 
-    assert aliases["quimera_embed"]["litellm_params"]["timeout"] == 20
-    assert aliases["local_embed"]["litellm_params"]["timeout"] == 20
+    assert aliases["nomic-embed-text"]["litellm_params"]["timeout"] == 5
+    assert aliases["quimera_embed"]["litellm_params"]["timeout"] == 5
+    assert aliases["local_embed"]["litellm_params"]["timeout"] == 5
 
 
 def test_all_models_have_stream_timeout_and_one_retry() -> None:
@@ -46,8 +47,9 @@ def test_chat_models_have_slow_start_stream_timeout_budget() -> None:
 def test_embedding_models_keep_short_stream_timeout() -> None:
     aliases = _aliases()
 
-    assert aliases["quimera_embed"]["litellm_params"]["stream_timeout"] == 10
-    assert aliases["local_embed"]["litellm_params"]["stream_timeout"] == 10
+    assert aliases["nomic-embed-text"]["litellm_params"]["stream_timeout"] == 5
+    assert aliases["quimera_embed"]["litellm_params"]["stream_timeout"] == 5
+    assert aliases["local_embed"]["litellm_params"]["stream_timeout"] == 5
 
 
 def test_global_request_timeout_covers_longest_model_timeout() -> None:

--- a/tests/unit/test_litellm_timeout_policy.py
+++ b/tests/unit/test_litellm_timeout_policy.py
@@ -68,3 +68,13 @@ def test_embedding_dimension_uses_canonical_constant() -> None:
     for alias in ("quimera_embed", "local_embed"):
         model_info = _aliases()[alias]["model_info"]
         assert model_info["output_dimensions"] == CANONICAL_EMBED_DIM
+
+
+def test_pr05b_documents_local_json_stream_timeout_tradeoff() -> None:
+    text = Path("docs/specs/rag-01b/pr-05b-litellm-host-audit.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "local_json" in text
+    assert "stream_timeout=45" in text
+    assert "primeiro chunk" in text

--- a/tests/unit/test_litellm_version_fingerprint.py
+++ b/tests/unit/test_litellm_version_fingerprint.py
@@ -25,6 +25,8 @@ def test_fingerprint_tolerates_unavailable_services() -> None:
 
     assert fingerprint.schema_version == "quimera-litellm-version-fingerprint-v1"
     assert fingerprint.values["python"]
+    assert fingerprint.values["python_version"]
+    assert fingerprint.values["python_executable"]
     assert fingerprint.values["docker_compose"] is None
     assert any(warning["component"] == "ollama" for warning in fingerprint.warnings)
     assert any(warning["component"] == "qdrant_ready" for warning in fingerprint.warnings)
@@ -36,3 +38,17 @@ def test_fingerprint_contains_package_versions_when_installed() -> None:
     assert "pydantic" in fingerprint.values
     assert "httpx" in fingerprint.values
     assert "litellm" in fingerprint.values
+
+
+def test_python_version_does_not_depend_on_command_runner_failure() -> None:
+    def command_runner(_command: list[str], _timeout: float) -> tuple[int, str, str]:
+        return 127, "", "forced failure"
+
+    fingerprint = build_version_fingerprint(
+        env={"LITELLM_MASTER_KEY": "local-dev-key"},
+        command_runner=command_runner,
+        http_getter=lambda _url, _timeout: (None, "offline"),
+    )
+
+    assert isinstance(fingerprint.values["python_version"], str)
+    assert fingerprint.values["python_version"]

--- a/tests/unit/test_litellm_version_fingerprint.py
+++ b/tests/unit/test_litellm_version_fingerprint.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from infra.litellm.version_fingerprint import build_version_fingerprint, sanitize_dsn
+
+
+def test_fingerprint_sanitizes_dsn() -> None:
+    sanitized = sanitize_dsn("postgresql://user:secret@127.0.0.1:5432/quimera")
+
+    assert sanitized == "postgresql://user:***@127.0.0.1:5432/quimera"
+    assert "secret" not in sanitized
+
+
+def test_fingerprint_tolerates_unavailable_services() -> None:
+    def command_runner(_command: list[str], _timeout: float) -> tuple[int, str, str]:
+        return 127, "", "missing"
+
+    def http_getter(_url: str, _timeout: float) -> tuple[int | None, str]:
+        return None, "ConnectError"
+
+    fingerprint = build_version_fingerprint(
+        env={"LITELLM_MASTER_KEY": "local-dev-key"},
+        command_runner=command_runner,
+        http_getter=http_getter,
+    )
+
+    assert fingerprint.schema_version == "quimera-litellm-version-fingerprint-v1"
+    assert fingerprint.values["python"]
+    assert fingerprint.values["docker_compose"] is None
+    assert any(warning["component"] == "ollama" for warning in fingerprint.warnings)
+    assert any(warning["component"] == "qdrant_ready" for warning in fingerprint.warnings)
+
+
+def test_fingerprint_contains_package_versions_when_installed() -> None:
+    fingerprint = build_version_fingerprint(env={"LITELLM_MASTER_KEY": "local-dev-key"})
+
+    assert "pydantic" in fingerprint.values
+    assert "httpx" in fingerprint.values
+    assert "litellm" in fingerprint.values

--- a/tests/unit/test_start_quimera_litellm_host.py
+++ b/tests/unit/test_start_quimera_litellm_host.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+START_QUIMERA = Path("scripts/start_quimera.sh")
+START_LITELLM = Path("infra/litellm/start_litellm.sh")
+
+
+def test_start_quimera_litellm_commands_exist() -> None:
+    text = START_QUIMERA.read_text(encoding="utf-8")
+
+    for command in (
+        "litellm-start",
+        "litellm-stop",
+        "litellm-audit",
+        "litellm-fingerprint",
+        "litellm-benchmark",
+    ):
+        assert f"{command})" in text
+
+
+def test_litellm_start_uses_host_script() -> None:
+    text = START_QUIMERA.read_text(encoding="utf-8")
+
+    assert "bash \"${REPO_ROOT}/infra/litellm/start_litellm.sh\"" in text
+
+
+def test_litellm_stop_uses_only_owned_pid_with_sigkill_fallback() -> None:
+    text = START_QUIMERA.read_text(encoding="utf-8")
+
+    assert ".runtime/litellm.pid" in text
+    assert 'kill -TERM "${pid}"' in text
+    assert 'kill -KILL "${pid}"' in text
+    assert "pkill" not in text
+    assert "killall" not in text
+
+
+def test_start_litellm_host_contract() -> None:
+    text = START_LITELLM.read_text(encoding="utf-8")
+
+    assert "LITELLM_MODE=PRODUCTION" in text
+    assert "LITELLM_LOG=ERROR" in text
+    assert "--host \"${LITELLM_HOST}\"" in text
+    assert "--port \"${LITELLM_PORT}\"" in text
+    assert "--num_workers 1" in text
+    assert "--telemetry False" in text
+    assert "/health/readiness" in text
+    assert "/health/liveliness" not in text
+    assert "pkill" not in text
+    assert "killall" not in text

--- a/tests/unit/test_start_quimera_script.py
+++ b/tests/unit/test_start_quimera_script.py
@@ -40,6 +40,9 @@ def test_start_quimera_script_declares_required_subcommands() -> None:
         "litellm-stop",
         "litellm-restart",
         "litellm-smoke",
+        "litellm-audit",
+        "litellm-fingerprint",
+        "litellm-benchmark",
     ):
         assert f"{command})" in text
 
@@ -66,8 +69,8 @@ def test_compose_does_not_manage_litellm() -> None:
     text = COMPOSE.read_text(encoding="utf-8")
 
     assert "quimera-litellm" not in text
-    assert "berriai/litellm" not in text
-    assert "docker.litellm.ai" not in text
+    assert ("berriai/" + "litellm") not in text
+    assert ("docker." + "litellm.ai") not in text
     assert "127.0.0.1:4000:4000" not in text
     assert "\n  litellm:" not in text
 
@@ -94,17 +97,19 @@ def test_start_quimera_controls_only_own_litellm_pid() -> None:
 
 def test_start_quimera_reuses_existing_litellm_gateway() -> None:
     text = _script_text()
+    start_text = Path("infra/litellm/start_litellm.sh").read_text(encoding="utf-8")
 
     assert "litellm_readiness_ok" in text
-    assert "already running" in text
+    assert "already healthy" in start_text
     assert "return 0" in text
 
 
 def test_start_quimera_warns_on_placeholder_litellm_master_key() -> None:
     text = _script_text()
+    start_text = Path("infra/litellm/start_litellm.sh").read_text(encoding="utf-8")
 
     assert "QUIMERA_DEV_LITELLM_PLACEHOLDER_KEY" in text
-    assert "placeholder LITELLM_MASTER_KEY" in text
+    assert "placeholder LITELLM_MASTER_KEY" in start_text
 
 
 def test_start_quimera_wires_warmup_and_release_hooks() -> None:


### PR DESCRIPTION
Refs #110

## Summary
- Keeps LiteLLM host-only and adds PR-05B audit, version fingerprint, safe local reports, and opt-in overhead benchmark.
- Normalizes active LiteLLM config to OLLAMA_BASE_URL, preserves legacy aliases, and adds canonical qwen/nomic aliases.
- Hardens start lifecycle: readiness reuse, owned PID, --num_workers 1, no LiteLLM Docker, no pkill/killall.
- Adds PR-05B SDD plus unit/integration contracts for audit, fingerprint, benchmark, host boundary and Agent0 gateway regression.

## Validation
- uv run pytest tests/unit/test_litellm_config_yaml.py tests/unit/test_litellm_timeout_policy.py tests/unit/test_litellm_config_validator.py tests/unit/test_litellm_cache_policy.py tests/unit/test_litellm_audit_contract.py tests/unit/test_litellm_version_fingerprint.py tests/unit/test_litellm_overhead_contract.py tests/unit/test_start_quimera_litellm_host.py tests/unit/test_start_quimera_script.py -q: 58 passed
- uv run pytest tests/unit/test_litellm*.py tests/unit/test_start_quimera_litellm_host.py tests/unit/test_start_quimera_script.py -q: 78 passed / 8 subtests
- uv run pytest tests/unit -q: 1669 passed / 256 subtests
- uv run pytest -q: 1685 passed / 51 skipped / 259 subtests
- uv run mypy --strict infra/litellm/config_validator.py infra/litellm/render_config.py infra/litellm/smoke_test.py infra/litellm/audit.py infra/litellm/version_fingerprint.py infra/litellm/overhead_benchmark.py: success
- uv run pyright infra/litellm/config_validator.py infra/litellm/render_config.py infra/litellm/smoke_test.py infra/litellm/audit.py infra/litellm/version_fingerprint.py infra/litellm/overhead_benchmark.py: 0 errors
- bash -n scripts/start_quimera.sh infra/litellm/start_litellm.sh: clean
- uv run python -m infra.litellm.config_validator infra/litellm/litellm_config.yaml: success with expected qdrant-semantic policy warning
- uv run python -m infra.litellm.render_config: fallback local
- uv run python -m infra.litellm.audit: generated JSON/Markdown, status warn due expected local-service/experimental warnings
- uv run python -m infra.litellm.overhead_benchmark: SKIPPED_VALID without opt-in

## Explicit non-scope
No LiteLLM Docker service, no MCP server, no FastAPI/gRPC, no remote providers, no model downloads, no HybridRAG mutation, no PostgreSQL/Timescale schema change, no Qdrant collection deletion/recreate.