### PR TITLE
RAG-01B PR-06: OpenTelemetry base layer

### DIFF
--- a/.env.observability.example
+++ b/.env.observability.example
@@ -1,0 +1,19 @@
+# Quimera/OpenClaw local observability example.
+# Copy values into your local environment when enabling OpenTelemetry.
+
+OTEL_SERVICE_NAME=quimera
+QUIMERA_ENV=local
+OTEL_SDK_DISABLED=false
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+
+# Leave unset for local console spans. Set one of these for an OTLP HTTP collector.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces
+
+QUIMERA_OTEL_MAX_QUEUE_SIZE=2048
+QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE=512
+QUIMERA_OTEL_SCHEDULE_DELAY_MILLIS=5000
+QUIMERA_OTEL_EXPORT_TIMEOUT_MILLIS=30000
+
+# LiteLLM must never capture prompts/responses into OTel in this local-first stack.
+OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=NO_CONTENT

--- a/backend/observability/__init__.py
+++ b/backend/observability/__init__.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from opentelemetry.metrics import Meter
+    from opentelemetry.trace import Tracer
+
+__all__ = [
+    "force_flush_tracing",
+    "get_meter",
+    "get_tracer",
+    "instrument_asyncpg_once",
+    "is_otel_disabled",
+    "setup_observability",
+    "setup_tracing",
+    "shutdown_tracing",
+]
+
+
+def setup_tracing() -> None:
+    import_module("backend.observability.tracer").setup_tracing()
+
+
+def setup_observability(*, instrument_asyncpg: bool = True) -> None:
+    import_module("backend.observability.tracer").setup_observability(
+        instrument_asyncpg=instrument_asyncpg
+    )
+
+
+def get_tracer(name: str) -> "Tracer":
+    return cast("Tracer", import_module("backend.observability.tracer").get_tracer(name))
+
+
+def get_meter(name: str) -> "Meter":
+    return cast("Meter", import_module("backend.observability.tracer").get_meter(name))
+
+
+def shutdown_tracing() -> None:
+    import_module("backend.observability.tracer").shutdown_tracing()
+
+
+def force_flush_tracing(timeout_millis: int = 30000) -> bool:
+    return bool(
+        import_module("backend.observability.tracer").force_flush_tracing(
+            timeout_millis=timeout_millis
+        )
+    )
+
+
+def instrument_asyncpg_once() -> None:
+    import_module("backend.observability.tracer").instrument_asyncpg_once()
+
+
+def is_otel_disabled() -> bool:
+    return bool(import_module("backend.observability.tracer").is_otel_disabled())

--- a/backend/observability/attributes.py
+++ b/backend/observability/attributes.py
@@ -12,6 +12,11 @@ GEN_AI_EVALUATION_NAME = "gen_ai.evaluation.name"
 GEN_AI_EVALUATION_SCORE = "gen_ai.evaluation.score"
 ERROR_TYPE = "error.type"
 
+DB_SYSTEM_NAME = "db.system.name"
+DB_OPERATION_NAME = "db.operation.name"
+DB_COLLECTION_NAME = "db.collection.name"
+DB_NAMESPACE = "db.namespace"
+
 MCP_METHOD_NAME = "mcp.method.name"
 MCP_SESSION_ID = "mcp.session.id"
 MCP_PROTOCOL_VERSION = "mcp.protocol.version"
@@ -58,6 +63,15 @@ GENAI_ATTRS = frozenset(
         GEN_AI_EVALUATION_NAME,
         GEN_AI_EVALUATION_SCORE,
         ERROR_TYPE,
+    }
+)
+
+DB_ATTRS = frozenset(
+    {
+        DB_SYSTEM_NAME,
+        DB_OPERATION_NAME,
+        DB_COLLECTION_NAME,
+        DB_NAMESPACE,
     }
 )
 
@@ -114,6 +128,7 @@ SAFE_ATTRIBUTE_PREFIXES = frozenset(
         "cache.",
         "latency.",
         "error.",
+        "db.",
     }
 )
 
@@ -165,5 +180,4 @@ PII_FORBIDDEN_SUBSTRINGS = frozenset(
     }
 )
 
-SAFE_ATTRS = GENAI_ATTRS | MCP_ATTRS | QUIMERA_ATTRS
-
+SAFE_ATTRS = GENAI_ATTRS | DB_ATTRS | MCP_ATTRS | QUIMERA_ATTRS

--- a/backend/observability/attributes.py
+++ b/backend/observability/attributes.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+GEN_AI_PROVIDER_NAME = "gen_ai.provider.name"
+GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
+GEN_AI_DATA_SOURCE_ID = "gen_ai.data_source.id"
+GEN_AI_AGENT_NAME = "gen_ai.agent.name"
+GEN_AI_AGENT_ID = "gen_ai.agent.id"
+GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+GEN_AI_EVALUATION_NAME = "gen_ai.evaluation.name"
+GEN_AI_EVALUATION_SCORE = "gen_ai.evaluation.score"
+ERROR_TYPE = "error.type"
+
+MCP_METHOD_NAME = "mcp.method.name"
+MCP_SESSION_ID = "mcp.session.id"
+MCP_PROTOCOL_VERSION = "mcp.protocol.version"
+JSONRPC_REQUEST_ID = "jsonrpc.request.id"
+NETWORK_TRANSPORT = "network.transport"
+NETWORK_PROTOCOL_NAME = "network.protocol.name"
+
+QUIMERA_AGENT_ID = "quimera.agent_id"
+QUIMERA_SESSION_ID = "quimera.session_id"
+QUIMERA_TASK_ID = "quimera.task_id"
+QUIMERA_STAGE = "quimera.stage"
+QUIMERA_PROFILE_NAME = "quimera.profile_name"
+QUIMERA_SCHEMA_VERSION = "quimera.schema_version"
+HYBRID_BACKEND = "hybrid.backend"
+HYBRID_FUSION_BACKEND = "hybrid.fusion.backend"
+RETRIEVAL_CACHE_HIT = "retrieval.cache_hit"
+RETRIEVAL_CACHE_BYPASS = "retrieval.cache_bypass"
+RETRIEVAL_TOP_K = "retrieval.top_k"
+RETRIEVAL_RESULT_COUNT = "retrieval.result_count"
+RETRIEVAL_RERANK_ENABLED = "retrieval.rerank.enabled"
+RETRIEVAL_RRF_K = "retrieval.rrf.k"
+CACHE_BACKEND = "cache.backend"
+CACHE_COLLECTION = "cache.collection"
+CACHE_HIT = "cache.hit"
+CACHE_SCHEMA_VERSION = "cache.schema_version"
+LATENCY_EMBED_MS = "latency.embed_ms"
+LATENCY_RETRIEVAL_MS = "latency.retrieval_ms"
+LATENCY_RRF_MS = "latency.rrf_ms"
+LATENCY_RERANK_MS = "latency.rerank_ms"
+LATENCY_PG_MS = "latency.pg_ms"
+LATENCY_LLM_MS = "latency.llm_ms"
+LATENCY_TOTAL_MS = "latency.total_ms"
+
+GENAI_ATTRS = frozenset(
+    {
+        GEN_AI_OPERATION_NAME,
+        GEN_AI_PROVIDER_NAME,
+        GEN_AI_REQUEST_MODEL,
+        GEN_AI_RESPONSE_MODEL,
+        GEN_AI_DATA_SOURCE_ID,
+        GEN_AI_AGENT_NAME,
+        GEN_AI_AGENT_ID,
+        GEN_AI_TOOL_NAME,
+        GEN_AI_EVALUATION_NAME,
+        GEN_AI_EVALUATION_SCORE,
+        ERROR_TYPE,
+    }
+)
+
+MCP_ATTRS = frozenset(
+    {
+        MCP_METHOD_NAME,
+        MCP_SESSION_ID,
+        MCP_PROTOCOL_VERSION,
+        JSONRPC_REQUEST_ID,
+        NETWORK_TRANSPORT,
+        NETWORK_PROTOCOL_NAME,
+    }
+)
+
+QUIMERA_ATTRS = frozenset(
+    {
+        QUIMERA_AGENT_ID,
+        QUIMERA_SESSION_ID,
+        QUIMERA_TASK_ID,
+        QUIMERA_STAGE,
+        QUIMERA_PROFILE_NAME,
+        QUIMERA_SCHEMA_VERSION,
+        HYBRID_BACKEND,
+        HYBRID_FUSION_BACKEND,
+        RETRIEVAL_CACHE_HIT,
+        RETRIEVAL_CACHE_BYPASS,
+        RETRIEVAL_TOP_K,
+        RETRIEVAL_RESULT_COUNT,
+        RETRIEVAL_RERANK_ENABLED,
+        RETRIEVAL_RRF_K,
+        CACHE_BACKEND,
+        CACHE_COLLECTION,
+        CACHE_HIT,
+        CACHE_SCHEMA_VERSION,
+        LATENCY_EMBED_MS,
+        LATENCY_RETRIEVAL_MS,
+        LATENCY_RRF_MS,
+        LATENCY_RERANK_MS,
+        LATENCY_PG_MS,
+        LATENCY_LLM_MS,
+        LATENCY_TOTAL_MS,
+    }
+)
+
+SAFE_ATTRIBUTE_PREFIXES = frozenset(
+    {
+        "gen_ai.",
+        "mcp.",
+        "jsonrpc.",
+        "network.",
+        "quimera.",
+        "hybrid.",
+        "retrieval.",
+        "cache.",
+        "latency.",
+        "error.",
+    }
+)
+
+PII_FORBIDDEN_ATTRS = frozenset(
+    {
+        "query_text",
+        "prompt",
+        "answer",
+        "response",
+        "response_text",
+        "raw_response",
+        "chunk",
+        "chunk_text",
+        "document",
+        "document_text",
+        "vector",
+        "embedding",
+        "payload",
+        "raw_payload",
+        "authorization",
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "dsn",
+        "database_url",
+    }
+)
+
+PII_FORBIDDEN_SUBSTRINGS = frozenset(
+    {
+        "query_text",
+        "prompt",
+        "answer",
+        "raw_response",
+        "response_text",
+        "chunk",
+        "document_text",
+        "vector",
+        "embedding",
+        "payload",
+        "authorization",
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "dsn",
+        "database_url",
+    }
+)
+
+SAFE_ATTRS = GENAI_ATTRS | MCP_ATTRS | QUIMERA_ATTRS
+

--- a/backend/observability/context.py
+++ b/backend/observability/context.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+from backend.observability.attributes import (
+    QUIMERA_AGENT_ID,
+    QUIMERA_PROFILE_NAME,
+    QUIMERA_SESSION_ID,
+    QUIMERA_TASK_ID,
+)
+from backend.observability.safety import validate_attributes
+
+_agent_id: ContextVar[str | None] = ContextVar("quimera_agent_id", default=None)
+_session_id: ContextVar[str | None] = ContextVar("quimera_session_id", default=None)
+_task_id: ContextVar[str | None] = ContextVar("quimera_task_id", default=None)
+_profile_name: ContextVar[str | None] = ContextVar("quimera_profile_name", default=None)
+
+
+def set_quimera_context(
+    *,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+    task_id: str | None = None,
+    profile_name: str | None = None,
+) -> dict[str, str]:
+    if agent_id is not None:
+        _agent_id.set(agent_id)
+    if session_id is not None:
+        _session_id.set(session_id)
+    if task_id is not None:
+        _task_id.set(task_id)
+    if profile_name is not None:
+        _profile_name.set(profile_name)
+    return get_quimera_context_attributes()
+
+
+def clear_quimera_context() -> None:
+    _agent_id.set(None)
+    _session_id.set(None)
+    _task_id.set(None)
+    _profile_name.set(None)
+
+
+def get_quimera_context_attributes() -> dict[str, str]:
+    attrs = {
+        QUIMERA_AGENT_ID: _agent_id.get(),
+        QUIMERA_SESSION_ID: _session_id.get(),
+        QUIMERA_TASK_ID: _task_id.get(),
+        QUIMERA_PROFILE_NAME: _profile_name.get(),
+    }
+    compact = {key: value for key, value in attrs.items() if value is not None}
+    return {key: str(value) for key, value in validate_attributes(compact).items()}
+

--- a/backend/observability/decorators.py
+++ b/backend/observability/decorators.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import re
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from functools import wraps
@@ -10,11 +11,14 @@ from opentelemetry.trace import Status, StatusCode
 
 from backend.observability.attributes import (
     CACHE_HIT,
+    DB_COLLECTION_NAME,
+    DB_OPERATION_NAME,
+    DB_SYSTEM_NAME,
     ERROR_TYPE,
+    GEN_AI_OPERATION_NAME,
     GEN_AI_AGENT_ID,
     GEN_AI_AGENT_NAME,
     GEN_AI_DATA_SOURCE_ID,
-    GEN_AI_OPERATION_NAME,
     GEN_AI_PROVIDER_NAME,
     GEN_AI_REQUEST_MODEL,
     GEN_AI_TOOL_NAME,
@@ -34,6 +38,7 @@ from backend.observability.tracer import get_tracer
 P = ParamSpec("P")
 R = TypeVar("R")
 AsyncCallable = Callable[P, Awaitable[R]]
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
 
 
 def _ensure_async(fn: Callable[P, object]) -> AsyncCallable[P, R]:
@@ -69,6 +74,15 @@ def _cache_hit(result: object) -> bool | None:
             return raw
     raw_attr = getattr(result, "cache_hit", None)
     return raw_attr if isinstance(raw_attr, bool) else None
+
+
+def _validate_safe_name(value: str, field_name: str) -> str:
+    if not _SAFE_NAME_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a safe low-cardinality identifier")
+    lowered = value.lower()
+    if any(token in lowered for token in ("prompt", "query", "answer", "response", "chunk", "vector", "embedding", "payload", "secret", "token", "password", "api_key")):
+        raise ValueError(f"{field_name} must not contain sensitive content markers")
+    return value
 
 
 def _trace_async(
@@ -171,11 +185,20 @@ def traced_rrf(*, backend: str = "python_rrf") -> Callable[[Callable[P, object]]
 
 
 def traced_pg(table: str, operation: str) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    safe_table = _validate_safe_name(table, "table")
+    safe_operation = _validate_safe_name(operation.upper(), "operation")
+
     def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
         return _trace_async(
             fn,
-            span_name=f"pg {operation} {table}",
-            base_attrs={"quimera.pg_table": table, "quimera.pg_operation": operation},
+            span_name=f"pg {safe_operation} {safe_table}",
+            base_attrs={
+                DB_SYSTEM_NAME: "postgresql",
+                DB_OPERATION_NAME: safe_operation,
+                DB_COLLECTION_NAME: safe_table,
+                "quimera.pg_table": safe_table,
+                "quimera.pg_operation": safe_operation,
+            },
             latency_attr=LATENCY_PG_MS,
         )
 
@@ -202,11 +225,18 @@ def traced_mcp_tool(
     *,
     method_name: str = "tools/call",
 ) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    safe_tool_name = _validate_safe_name(tool_name, "tool_name")
+    safe_method_name = _validate_safe_name(method_name.replace("/", ":"), "method_name").replace(":", "/")
+
     def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
         return _trace_async(
             fn,
-            span_name=f"mcp {tool_name}",
-            base_attrs={GEN_AI_TOOL_NAME: tool_name, MCP_METHOD_NAME: method_name},
+            span_name=f"mcp {safe_method_name}",
+            base_attrs={
+                GEN_AI_OPERATION_NAME: "execute_tool",
+                GEN_AI_TOOL_NAME: safe_tool_name,
+                MCP_METHOD_NAME: safe_method_name,
+            },
             latency_attr="latency.total_ms",
         )
 

--- a/backend/observability/decorators.py
+++ b/backend/observability/decorators.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import inspect
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from functools import wraps
+from typing import Any, ParamSpec, TypeVar, cast
+
+from opentelemetry.trace import Status, StatusCode
+
+from backend.observability.attributes import (
+    CACHE_HIT,
+    ERROR_TYPE,
+    GEN_AI_AGENT_ID,
+    GEN_AI_AGENT_NAME,
+    GEN_AI_DATA_SOURCE_ID,
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_MODEL,
+    GEN_AI_TOOL_NAME,
+    HYBRID_FUSION_BACKEND,
+    LATENCY_EMBED_MS,
+    LATENCY_LLM_MS,
+    LATENCY_PG_MS,
+    LATENCY_RETRIEVAL_MS,
+    LATENCY_RRF_MS,
+    MCP_METHOD_NAME,
+    RETRIEVAL_RESULT_COUNT,
+)
+from backend.observability.context import get_quimera_context_attributes
+from backend.observability.safety import sanitize_error_message, validate_attributes
+from backend.observability.tracer import get_tracer
+
+P = ParamSpec("P")
+R = TypeVar("R")
+AsyncCallable = Callable[P, Awaitable[R]]
+
+
+def _ensure_async(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+    if not inspect.iscoroutinefunction(fn):
+        raise TypeError("OpenTelemetry Quimera decorators support async functions only")
+    return cast(AsyncCallable[P, R], fn)
+
+
+def _duration_ms(start_ns: int) -> float:
+    return (time.perf_counter_ns() - start_ns) / 1_000_000.0
+
+
+def _set_attrs(span: Any, attrs: Mapping[str, object]) -> None:
+    for key, value in validate_attributes(attrs).items():
+        span.set_attribute(key, value)
+
+
+def _result_count(result: object) -> int | None:
+    if isinstance(result, Mapping):
+        raw = result.get("result_count")
+        if isinstance(raw, int):
+            return raw
+    if isinstance(result, list | tuple):
+        return len(result)
+    raw_attr = getattr(result, "result_count", None)
+    return raw_attr if isinstance(raw_attr, int) else None
+
+
+def _cache_hit(result: object) -> bool | None:
+    if isinstance(result, Mapping):
+        raw = result.get("cache_hit")
+        if isinstance(raw, bool):
+            return raw
+    raw_attr = getattr(result, "cache_hit", None)
+    return raw_attr if isinstance(raw_attr, bool) else None
+
+
+def _trace_async(
+    fn: Callable[P, object],
+    *,
+    span_name: str,
+    base_attrs: Mapping[str, object],
+    latency_attr: str,
+    enrich_result: Callable[[object], Mapping[str, object]] | None = None,
+) -> AsyncCallable[P, R]:
+    async_fn: AsyncCallable[P, R] = _ensure_async(fn)
+
+    @wraps(async_fn)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        tracer = get_tracer("quimera.observability")
+        attrs = {**get_quimera_context_attributes(), **dict(base_attrs)}
+        with tracer.start_as_current_span(span_name, attributes=validate_attributes(attrs)) as span:
+            start_ns = time.perf_counter_ns()
+            try:
+                result = await async_fn(*args, **kwargs)
+            except Exception as exc:
+                _set_attrs(span, {latency_attr: _duration_ms(start_ns), ERROR_TYPE: type(exc).__name__})
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, sanitize_error_message(str(exc))))
+                raise
+            _set_attrs(span, {latency_attr: _duration_ms(start_ns)})
+            if enrich_result is not None:
+                _set_attrs(span, enrich_result(result))
+            return result
+
+    return wrapper
+
+
+def traced_embed(model: str | None = None) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        attrs: dict[str, object] = {
+            GEN_AI_OPERATION_NAME: "embeddings",
+            GEN_AI_PROVIDER_NAME: "ollama",
+        }
+        if model:
+            attrs[GEN_AI_REQUEST_MODEL] = model
+        return _trace_async(fn, span_name="embeddings", base_attrs=attrs, latency_attr=LATENCY_EMBED_MS)
+
+    return decorator
+
+
+def traced_llm(
+    model: str | None = None,
+    *,
+    operation: str = "chat",
+) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        attrs: dict[str, object] = {
+            GEN_AI_OPERATION_NAME: operation,
+            GEN_AI_PROVIDER_NAME: "ollama",
+        }
+        if model:
+            attrs[GEN_AI_REQUEST_MODEL] = model
+        return _trace_async(fn, span_name=f"{operation} {model or 'local'}", base_attrs=attrs, latency_attr=LATENCY_LLM_MS)
+
+    return decorator
+
+
+def traced_retrieval(source: str | None = None) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def enrich(result: object) -> Mapping[str, object]:
+        attrs: dict[str, object] = {}
+        count = _result_count(result)
+        hit = _cache_hit(result)
+        if count is not None:
+            attrs[RETRIEVAL_RESULT_COUNT] = count
+        if hit is not None:
+            attrs[CACHE_HIT] = hit
+        return attrs
+
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        attrs = {GEN_AI_OPERATION_NAME: "retrieval"}
+        if source:
+            attrs[GEN_AI_DATA_SOURCE_ID] = source
+        return _trace_async(
+            fn,
+            span_name=f"retrieval {source or 'local'}",
+            base_attrs=attrs,
+            latency_attr=LATENCY_RETRIEVAL_MS,
+            enrich_result=enrich,
+        )
+
+    return decorator
+
+
+def traced_rrf(*, backend: str = "python_rrf") -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        return _trace_async(
+            fn,
+            span_name="retrieval rrf",
+            base_attrs={HYBRID_FUSION_BACKEND: backend},
+            latency_attr=LATENCY_RRF_MS,
+        )
+
+    return decorator
+
+
+def traced_pg(table: str, operation: str) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        return _trace_async(
+            fn,
+            span_name=f"pg {operation} {table}",
+            base_attrs={"quimera.pg_table": table, "quimera.pg_operation": operation},
+            latency_attr=LATENCY_PG_MS,
+        )
+
+    return decorator
+
+
+def traced_agent(
+    agent_name: str,
+    agent_id: str | None = None,
+) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        attrs: dict[str, object] = {
+            GEN_AI_AGENT_NAME: agent_name,
+        }
+        if agent_id:
+            attrs[GEN_AI_AGENT_ID] = agent_id
+        return _trace_async(fn, span_name=f"agent {agent_name}", base_attrs=attrs, latency_attr="latency.total_ms")
+
+    return decorator
+
+
+def traced_mcp_tool(
+    tool_name: str,
+    *,
+    method_name: str = "tools/call",
+) -> Callable[[Callable[P, object]], AsyncCallable[P, R]]:
+    def decorator(fn: Callable[P, object]) -> AsyncCallable[P, R]:
+        return _trace_async(
+            fn,
+            span_name=f"mcp {tool_name}",
+            base_attrs={GEN_AI_TOOL_NAME: tool_name, MCP_METHOD_NAME: method_name},
+            latency_attr="latency.total_ms",
+        )
+
+    return decorator

--- a/backend/observability/events.py
+++ b/backend/observability/events.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Protocol
+
+from backend.observability.attributes import (
+    CACHE_BACKEND,
+    CACHE_HIT,
+    GEN_AI_EVALUATION_NAME,
+    GEN_AI_EVALUATION_SCORE,
+)
+from backend.observability.safety import validate_attribute_key, validate_attributes
+
+
+class EventSpan(Protocol):
+    def add_event(self, name: str, attributes: Mapping[str, object] | None = None) -> None: ...
+
+
+def add_safe_event(
+    span: EventSpan,
+    name: str,
+    attributes: Mapping[str, object] | None = None,
+) -> None:
+    validate_attribute_key(f"quimera.{name}" if "." not in name else name)
+    span.add_event(name, validate_attributes(attributes))
+
+
+def add_evaluation_score(
+    span: EventSpan,
+    metric_name: str,
+    score: float,
+    label: str | None = None,
+) -> None:
+    if not math.isfinite(score):
+        raise ValueError("evaluation score must be finite")
+    attrs: dict[str, object] = {
+        GEN_AI_EVALUATION_NAME: metric_name,
+        GEN_AI_EVALUATION_SCORE: score,
+    }
+    if label is not None:
+        attrs["quimera.evaluation_label"] = label
+    add_safe_event(span, "gen_ai.evaluation.result", attrs)
+
+
+def add_cache_decision_event(
+    span: EventSpan,
+    *,
+    hit: bool,
+    backend: str,
+    reason: str | None = None,
+) -> None:
+    attrs: dict[str, object] = {
+        CACHE_HIT: hit,
+        CACHE_BACKEND: backend,
+    }
+    if reason is not None:
+        attrs["quimera.cache_reason"] = reason
+    add_safe_event(span, "quimera.cache.decision", attrs)
+

--- a/backend/observability/lite_llm.py
+++ b/backend/observability/lite_llm.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return raw
+
+
+def validate_litellm_otel_callback_config(path: Path) -> dict[str, bool]:
+    cfg = _load_yaml(path)
+    settings = cfg.get("litellm_settings")
+    if not isinstance(settings, dict):
+        raise ValueError("litellm_settings is required")
+    callbacks = settings.get("callbacks")
+    callbacks_present = isinstance(callbacks, list) and "otel" in callbacks
+    callback_settings = cfg.get("callback_settings")
+    otel_settings = callback_settings.get("otel") if isinstance(callback_settings, dict) else None
+    message_logging_disabled = (
+        isinstance(otel_settings, dict)
+        and otel_settings.get("message_logging") is False
+        and settings.get("turn_off_message_logging") is True
+    )
+    return {
+        "callbacks_present": callbacks_present,
+        "message_logging_disabled": message_logging_disabled,
+    }
+
+
+def ensure_litellm_otel_callback_present(path: Path) -> None:
+    cfg = _load_yaml(path)
+    settings = cfg.setdefault("litellm_settings", {})
+    if not isinstance(settings, dict):
+        raise ValueError("litellm_settings must be a mapping")
+    callbacks = settings.setdefault("callbacks", [])
+    if not isinstance(callbacks, list):
+        raise ValueError("litellm_settings.callbacks must be a list")
+    if "otel" not in callbacks:
+        callbacks.append("otel")
+    settings["turn_off_message_logging"] = True
+    callback_settings = cfg.setdefault("callback_settings", {})
+    if not isinstance(callback_settings, dict):
+        raise ValueError("callback_settings must be a mapping")
+    otel_settings = callback_settings.setdefault("otel", {})
+    if not isinstance(otel_settings, dict):
+        raise ValueError("callback_settings.otel must be a mapping")
+    otel_settings["message_logging"] = False
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validate", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--config", type=Path, default=Path("infra/litellm/litellm_config.yaml"))
+    args = parser.parse_args()
+    result = validate_litellm_otel_callback_config(args.config)
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(result)
+    return 0 if all(result.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())
+

--- a/backend/observability/metrics.py
+++ b/backend/observability/metrics.py
@@ -12,6 +12,8 @@ from backend.observability.tracer import build_resource, is_otel_disabled
 _METRICS_INITIALIZED = False
 _GENAI_OPERATION_DURATION: Histogram | None = None
 _RETRIEVAL_OPERATION_DURATION: Histogram | None = None
+GENAI_OPERATION_DURATION_METRIC_NAME = "gen_ai.client.operation.duration"
+RETRIEVAL_OPERATION_DURATION_METRIC_NAME = "quimera.retrieval.operation.duration"
 
 
 def setup_metrics() -> None:
@@ -22,12 +24,12 @@ def setup_metrics() -> None:
     metrics.set_meter_provider(provider)
     meter = metrics.get_meter("quimera.observability")
     _GENAI_OPERATION_DURATION = meter.create_histogram(
-        "gen_ai.client.operation.duration",
+        GENAI_OPERATION_DURATION_METRIC_NAME,
         unit="s",
         description="Duration of local GenAI client operations.",
     )
     _RETRIEVAL_OPERATION_DURATION = meter.create_histogram(
-        "quimera.retrieval.operation.duration",
+        RETRIEVAL_OPERATION_DURATION_METRIC_NAME,
         unit="ms",
         description="Duration of Quimera retrieval operations.",
     )

--- a/backend/observability/metrics.py
+++ b/backend/observability/metrics.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from opentelemetry import metrics
+from opentelemetry.metrics import Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+
+from backend.observability.safety import validate_attributes
+from backend.observability.tracer import build_resource, is_otel_disabled
+
+_METRICS_INITIALIZED = False
+_GENAI_OPERATION_DURATION: Histogram | None = None
+_RETRIEVAL_OPERATION_DURATION: Histogram | None = None
+
+
+def setup_metrics() -> None:
+    global _GENAI_OPERATION_DURATION, _METRICS_INITIALIZED, _RETRIEVAL_OPERATION_DURATION
+    if _METRICS_INITIALIZED or is_otel_disabled():
+        return
+    provider = MeterProvider(resource=build_resource())
+    metrics.set_meter_provider(provider)
+    meter = metrics.get_meter("quimera.observability")
+    _GENAI_OPERATION_DURATION = meter.create_histogram(
+        "gen_ai.client.operation.duration",
+        unit="s",
+        description="Duration of local GenAI client operations.",
+    )
+    _RETRIEVAL_OPERATION_DURATION = meter.create_histogram(
+        "quimera.retrieval.operation.duration",
+        unit="ms",
+        description="Duration of Quimera retrieval operations.",
+    )
+    _METRICS_INITIALIZED = True
+
+
+def get_meter(name: str = "quimera.observability") -> Meter:
+    setup_metrics()
+    return metrics.get_meter(name)
+
+
+def record_genai_operation_duration(
+    duration_ms: float,
+    attributes: Mapping[str, object] | None = None,
+) -> None:
+    setup_metrics()
+    if _GENAI_OPERATION_DURATION is None:
+        return
+    _GENAI_OPERATION_DURATION.record(duration_ms / 1000.0, validate_attributes(attributes))
+
+
+def record_retrieval_duration(
+    duration_ms: float,
+    attributes: Mapping[str, object] | None = None,
+) -> None:
+    setup_metrics()
+    if _RETRIEVAL_OPERATION_DURATION is None:
+        return
+    _RETRIEVAL_OPERATION_DURATION.record(duration_ms, validate_attributes(attributes))
+
+
+def _reset_for_tests() -> None:
+    global _GENAI_OPERATION_DURATION, _METRICS_INITIALIZED, _RETRIEVAL_OPERATION_DURATION
+    _METRICS_INITIALIZED = False
+    _GENAI_OPERATION_DURATION = None
+    _RETRIEVAL_OPERATION_DURATION = None

--- a/backend/observability/safety.py
+++ b/backend/observability/safety.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import TypeAlias
+
+from backend.observability.attributes import (
+    PII_FORBIDDEN_ATTRS,
+    PII_FORBIDDEN_SUBSTRINGS,
+    SAFE_ATTRS,
+    SAFE_ATTRIBUTE_PREFIXES,
+)
+
+AttributeValue: TypeAlias = str | bool | int | float
+
+_ATTR_KEY_RE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z0-9_]+)*$")
+_SECRET_VALUE_RE = re.compile(
+    r"(?i)(bearer\s+[a-z0-9._-]+|(?<![a-z0-9])sk-[a-z0-9_-]+|password=|api[_-]?key=|token=|secret=|postgres(?:ql)?://[^@\s]+@)"
+)
+
+
+def _is_forbidden_key(key: str) -> bool:
+    normalized = key.strip().lower()
+    if normalized in PII_FORBIDDEN_ATTRS:
+        return True
+    if normalized in SAFE_ATTRS:
+        return False
+    return any(part in normalized for part in PII_FORBIDDEN_SUBSTRINGS)
+
+
+def validate_attribute_key(key: str) -> str:
+    normalized = key.strip()
+    if not normalized:
+        raise ValueError("attribute key cannot be empty")
+    if normalized != normalized.lower():
+        raise ValueError(f"attribute key must be lowercase: {key}")
+    if not _ATTR_KEY_RE.match(normalized):
+        raise ValueError(f"attribute key must be dotted lowercase tokens: {key}")
+    if _is_forbidden_key(normalized):
+        raise ValueError(f"attribute key is not safe for telemetry: {key}")
+    if normalized not in SAFE_ATTRS and not normalized.startswith(tuple(SAFE_ATTRIBUTE_PREFIXES)):
+        raise ValueError(f"attribute key prefix is not allowed: {key}")
+    return normalized
+
+
+def validate_attribute_value(value: object) -> AttributeValue:
+    if isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        if _SECRET_VALUE_RE.search(value):
+            raise ValueError("attribute value appears to contain a secret")
+        return value
+    raise ValueError("attribute value must be a primitive")
+
+
+def validate_attributes(attributes: Mapping[str, object] | None) -> dict[str, AttributeValue]:
+    if attributes is None:
+        return {}
+    validated: dict[str, AttributeValue] = {}
+    for key, value in attributes.items():
+        validated[validate_attribute_key(key)] = validate_attribute_value(value)
+    return validated
+
+
+def sanitize_error_message(message: str) -> str:
+    sanitized = _SECRET_VALUE_RE.sub("[REDACTED]", message)
+    return sanitized[:500]
+
+
+def redact_mapping(mapping: Mapping[str, object]) -> dict[str, object]:
+    redacted: dict[str, object] = {}
+    for key, value in mapping.items():
+        if _is_forbidden_key(key):
+            redacted[key] = "[REDACTED]"
+        elif isinstance(value, Mapping):
+            redacted[key] = redact_mapping(value)
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def assert_no_pii_keys(mapping: Mapping[str, object]) -> None:
+    for key, value in mapping.items():
+        validate_attribute_key(key)
+        if isinstance(value, Mapping):
+            assert_no_pii_keys(value)

--- a/backend/observability/tracer.py
+++ b/backend/observability/tracer.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from opentelemetry import metrics, trace
+from opentelemetry.metrics import Meter
+from opentelemetry.sdk.resources import DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.trace import Tracer
+
+_TRACING_INITIALIZED = False
+_ACTIVE_PROVIDER: TracerProvider | None = None
+_ASYNC_PG_INSTRUMENTED = False
+
+
+@dataclass(frozen=True)
+class BatchSpanProcessorConfig:
+    max_queue_size: int
+    max_export_batch_size: int
+    schedule_delay_millis: int
+    export_timeout_millis: int
+
+
+def is_otel_disabled() -> bool:
+    return os.getenv("OTEL_SDK_DISABLED", "").strip().lower() == "true"
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def batch_span_processor_config() -> BatchSpanProcessorConfig:
+    config = BatchSpanProcessorConfig(
+        max_queue_size=_env_int("QUIMERA_OTEL_MAX_QUEUE_SIZE", 2048),
+        max_export_batch_size=_env_int("QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE", 512),
+        schedule_delay_millis=_env_int("QUIMERA_OTEL_SCHEDULE_DELAY_MILLIS", 5000),
+        export_timeout_millis=_env_int("QUIMERA_OTEL_EXPORT_TIMEOUT_MILLIS", 30000),
+    )
+    if config.max_export_batch_size > config.max_queue_size:
+        raise ValueError("QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE must be <= QUIMERA_OTEL_MAX_QUEUE_SIZE")
+    return config
+
+
+def build_resource() -> Resource:
+    attrs: dict[str, str] = {
+        SERVICE_NAME: os.getenv("OTEL_SERVICE_NAME", "quimera"),
+        DEPLOYMENT_ENVIRONMENT: os.getenv("QUIMERA_ENV", "local"),
+        "quimera.project": "openclaw",
+    }
+    version = os.getenv("QUIMERA_VERSION")
+    if version:
+        attrs["service.version"] = version
+    return Resource.create(attrs)
+
+
+def _otlp_endpoint() -> str | None:
+    traces_endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    if traces_endpoint:
+        return traces_endpoint
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if endpoint:
+        return endpoint.rstrip("/") + "/v1/traces"
+    return None
+
+
+def _build_span_exporter() -> Any:
+    endpoint = _otlp_endpoint()
+    if endpoint is None:
+        return ConsoleSpanExporter()
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    return OTLPSpanExporter(endpoint=endpoint)
+
+
+def setup_tracing() -> None:
+    global _ACTIVE_PROVIDER, _TRACING_INITIALIZED
+    if _TRACING_INITIALIZED or is_otel_disabled():
+        return
+    config = batch_span_processor_config()
+    provider = TracerProvider(resource=build_resource())
+    processor = BatchSpanProcessor(
+        _build_span_exporter(),
+        max_queue_size=config.max_queue_size,
+        max_export_batch_size=config.max_export_batch_size,
+        schedule_delay_millis=config.schedule_delay_millis,
+        export_timeout_millis=config.export_timeout_millis,
+    )
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    _ACTIVE_PROVIDER = provider
+    _TRACING_INITIALIZED = True
+
+
+def setup_observability(*, instrument_asyncpg: bool = True) -> None:
+    setup_tracing()
+    if instrument_asyncpg:
+        instrument_asyncpg_once()
+
+
+def get_tracer(name: str) -> Tracer:
+    setup_tracing()
+    return trace.get_tracer(name)
+
+
+def get_meter(name: str) -> Meter:
+    from backend.observability.metrics import get_meter as _get_meter
+
+    return _get_meter(name)
+
+
+def shutdown_tracing() -> None:
+    global _ACTIVE_PROVIDER, _ASYNC_PG_INSTRUMENTED, _TRACING_INITIALIZED
+    if _ACTIVE_PROVIDER is not None:
+        _ACTIVE_PROVIDER.shutdown()
+    _ACTIVE_PROVIDER = None
+    _TRACING_INITIALIZED = False
+    _ASYNC_PG_INSTRUMENTED = False
+
+
+def force_flush_tracing(timeout_millis: int = 30000) -> bool:
+    if _ACTIVE_PROVIDER is None:
+        return True
+    return bool(_ACTIVE_PROVIDER.force_flush(timeout_millis=timeout_millis))
+
+
+def instrument_asyncpg_once() -> None:
+    global _ASYNC_PG_INSTRUMENTED
+    if _ASYNC_PG_INSTRUMENTED or is_otel_disabled():
+        return
+    try:
+        from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+    except ImportError:
+        logger.warning("otel_asyncpg_instrumentation_unavailable")
+        return
+    instrumentor_cls: Any = AsyncPGInstrumentor
+    instrumentor_cls().instrument()
+    _ASYNC_PG_INSTRUMENTED = True
+
+
+def build_doctor_report(config_path: Path | None = None) -> dict[str, object]:
+    from backend.observability.lite_llm import validate_litellm_otel_callback_config
+
+    config = config_path or Path("infra/litellm/litellm_config.yaml")
+    semconv = os.getenv("OTEL_SEMCONV_STABILITY_OPT_IN", "")
+    backend_files = sorted(Path("backend/observability").glob("*.py"))
+    imports_requests = any(_imports_module(path, "requests") for path in backend_files)
+    try:
+        import opentelemetry  # noqa: F401
+        from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor  # noqa: F401
+
+        packages_ok = True
+        asyncpg_ok = True
+    except ImportError:
+        packages_ok = False
+        asyncpg_ok = False
+    litellm_validation = validate_litellm_otel_callback_config(config)
+    checks = {
+        "otel_sdk_disabled": is_otel_disabled(),
+        "service_name": os.getenv("OTEL_SERVICE_NAME", "quimera"),
+        "trace_exporter": "otlp_http" if _otlp_endpoint() else "console",
+        "traces_endpoint": _otlp_endpoint(),
+        "semconv_gen_ai_latest_experimental": (
+            "gen_ai_latest_experimental" in {item.strip() for item in semconv.split(",") if item.strip()}
+            if semconv
+            else False
+        ),
+        "litellm_otel_callback": litellm_validation["callbacks_present"],
+        "litellm_message_logging_disabled": litellm_validation["message_logging_disabled"],
+        "backend_observability_imports_requests": imports_requests,
+        "opentelemetry_packages_importable": packages_ok,
+        "asyncpg_instrumentor_importable": asyncpg_ok,
+    }
+    status = "ok"
+    if not checks["litellm_otel_callback"] or not checks["litellm_message_logging_disabled"] or imports_requests:
+        status = "fail"
+    elif semconv and not checks["semconv_gen_ai_latest_experimental"]:
+        status = "warn"
+    return {"status": status, "checks": checks}
+
+
+def _imports_module(path: Path, module_name: str) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == module_name or alias.name.startswith(f"{module_name}.") for alias in node.names):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            if node.module == module_name or node.module.startswith(f"{module_name}."):
+                return True
+    return False
+
+
+def _main() -> int:
+    if "--doctor" not in sys.argv:
+        return 0
+    json_output = "--json" in sys.argv
+    config = Path("infra/litellm/litellm_config.yaml")
+    if "--config" in sys.argv:
+        config = Path(sys.argv[sys.argv.index("--config") + 1])
+    report = build_doctor_report(config)
+    if json_output:
+        print(json.dumps(report, sort_keys=True))
+    else:
+        print(f"otel-doctor status: {report['status']}")
+        print(json.dumps(report["checks"], indent=2, sort_keys=True))
+    return 0 if report["status"] in {"ok", "warn"} else 1
+
+
+def _reset_for_tests() -> None:
+    global _ACTIVE_PROVIDER, _ASYNC_PG_INSTRUMENTED, _TRACING_INITIALIZED
+    _ACTIVE_PROVIDER = None
+    _TRACING_INITIALIZED = False
+    _ASYNC_PG_INSTRUMENTED = False
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,60 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-04
-**Updated by:** Codex — RAG-01B PR-05B LiteLLM host audit
+**Updated by:** Codex — RAG-01B PR-06 OpenTelemetry base layer
+
+---
+
+## RAG-01B PR-06 — OpenTelemetry Base Layer
+
+Current branch: `rag-01b/pr-06-otel-base-layer`
+Base branch: `rag-01b/pr-05b-litellm-host-audit` while PR-05B remains open.
+
+Implemented:
+
+- Added `backend/observability/` base package with OTel tracing setup,
+  idempotent asyncpg instrumentation, safe attributes, PII/content guards,
+  contextvars, events, metrics and async-only decorators.
+- Added LiteLLM OTel callback guard and source YAML callback settings:
+  `litellm_settings.callbacks: ["otel"]` plus
+  `callback_settings.otel.message_logging: false`.
+- Added `scripts/start_quimera.sh otel-doctor` and `otel-doctor --json`.
+- Added `.env.observability.example` and PR-06 SDD.
+- Added OTel dependencies:
+  `opentelemetry-api`, `opentelemetry-sdk`,
+  `opentelemetry-exporter-otlp-proto-http`,
+  `opentelemetry-instrumentation-asyncpg`.
+
+Scope explicitly not changed:
+
+- No full RAG runtime instrumentation.
+- No dashboard, collector, Grafana, Tempo, Jaeger or Prometheus service.
+- No MCP server, FastAPI, REST API or gRPC.
+- No PostgreSQL/Timescale schema change.
+- No Qdrant collection change.
+- No LiteLLM Docker service.
+
+Validation:
+
+- PR-06 focused OTel tests: 39 passed.
+- LiteLLM/start-script compatibility block: 58 passed.
+- Full unit suite: 1707 passed.
+- Full regression: 1726 passed / 51 skipped.
+- Focused post-typing block: 52 passed / 2 skipped.
+- `uv run mypy --strict .`: success.
+- `uv run pyright`: 0 errors.
+- `bash -n scripts/start_quimera.sh`: clean.
+- `uv run python -m infra.litellm.config_validator`: success with one expected
+  qdrant-semantic policy warning.
+- `./scripts/start_quimera.sh otel-doctor --json`: status `ok`.
+- `git diff --check`: clean.
+
+Handoff to PR-07:
+
+- Wire decorators into selected RAG/Gateway execution paths.
+- Decide optional collector/profile strategy.
+- Keep content capture disabled unless a future ADR explicitly changes the
+  privacy boundary.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -13,6 +13,7 @@
 
 Current branch: `rag-01b/pr-06-otel-base-layer`
 Base branch: `rag-01b/pr-05b-litellm-host-audit` while PR-05B remains open.
+Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/113>
 
 Implemented:
 
@@ -59,6 +60,35 @@ Handoff to PR-07:
 - Decide optional collector/profile strategy.
 - Keep content capture disabled unless a future ADR explicitly changes the
   privacy boundary.
+
+---
+
+## RAG-01B PR-06 RC-01 — OTel SemConv and Test Marker Cleanup
+
+Current branch: `rag-01b/pr-06-otel-base-layer`
+Draft PR: <https://github.com/franciscosalido/OPENCLAW/pull/113>
+
+Implemented:
+
+- `traced_pg` now emits current OTel DB semconv attributes for PostgreSQL:
+  `db.system.name=postgresql`, `db.operation.name` and `db.collection.name`,
+  while preserving `quimera.pg_table`, `quimera.pg_operation` and
+  `latency.pg_ms`.
+- Added public metric name constants for the GenAI and retrieval histograms.
+- Added `pytest.mark.integration` to all PR-06 OTel integration tests, so
+  `pytest -m integration` includes them.
+- Hardened `traced_mcp_tool`: validates low-cardinality tool/method names,
+  stores tool name as `gen_ai.tool.name`, and keeps span name based on
+  `mcp.method.name` rather than raw tool name.
+
+Validation:
+
+- RC focused block: 17 passed.
+- `pytest -m integration` on OTel integration tests: 3 passed.
+- `uv run mypy --strict .`: success.
+- `uv run pyright`: 0 errors.
+- `uv run pytest`: 1730 passed / 51 skipped.
+- `git diff --check`: clean.
 
 ---
 

--- a/docs/specs/rag-01b/pr-06-otel-base-layer.md
+++ b/docs/specs/rag-01b/pr-06-otel-base-layer.md
@@ -86,3 +86,23 @@ Ollama or any model endpoint.
 PR-07 should wire these decorators into selected RAG and gateway seams, define
 sampling policy for local development, and decide whether a collector/profile is
 worth adding as an optional operator path.
+
+## RC-01 Residual Risk Cleanup
+
+RC-01 addressed reviewer residual risks without widening PR-06 into runtime RAG
+instrumentation:
+
+- `traced_pg` now emits current OpenTelemetry database semantic convention
+  metadata for PostgreSQL:
+  - `db.system.name=postgresql`
+  - `db.operation.name`
+  - `db.collection.name`
+  Existing `quimera.pg_table`, `quimera.pg_operation` and `latency.pg_ms`
+  remain for the Quimera contract.
+- Metric instrument names are public constants:
+  - `GENAI_OPERATION_DURATION_METRIC_NAME`
+  - `RETRIEVAL_OPERATION_DURATION_METRIC_NAME`
+- OTel integration smoke tests are marked with `pytest.mark.integration`.
+- `traced_mcp_tool` validates `tool_name`/`method_name`, stores the tool name
+  only as `gen_ai.tool.name`, and uses the low-cardinality MCP method in the
+  span name.

--- a/docs/specs/rag-01b/pr-06-otel-base-layer.md
+++ b/docs/specs/rag-01b/pr-06-otel-base-layer.md
@@ -1,0 +1,88 @@
+# RAG-01B-PR-06 — OpenTelemetry Base Layer
+
+Status: Draft implementation
+
+## Objective
+
+Create the base OpenTelemetry layer for Quimera/OpenClaw without instrumenting
+the live RAG runtime end-to-end.
+
+This PR adds idempotent tracing setup, safe attribute constants, async-only
+decorators, context propagation helpers, base metrics, safe span events, a
+LiteLLM OTel callback guard and an `otel-doctor` command.
+
+## Decisions
+
+- OpenTelemetry is optional at runtime and disabled quietly when
+  `OTEL_SDK_DISABLED=true`.
+- When no OTLP HTTP endpoint is configured, spans use the local console
+  exporter.
+- OTLP HTTP is the only remote exporter configured in this PR.
+- AsyncPG instrumentation is best-effort and idempotent.
+- LiteLLM remains a host process; this PR does not add a LiteLLM Docker service.
+- LiteLLM OTel callback must be present with message logging disabled.
+
+## Attribute Contract
+
+Quimera uses a hybrid semantic model:
+
+- OpenTelemetry GenAI semantic conventions for model, agent, tool, retrieval and
+  evaluation metadata.
+- MCP-compatible attributes where future tool spans need them.
+- Quimera-specific attributes for local RAG/cache/fusion/latency metadata.
+
+Prompt text, query text, answers, responses, chunks, documents, vectors,
+embeddings, raw payloads, authorization data, API keys, tokens, passwords,
+secrets and full DSNs are forbidden in attributes and span events.
+
+`gen_ai.response.model` is explicitly allowed because it is model metadata, not
+response content.
+
+## Runtime Contract
+
+`backend/observability/tracer.py` exposes:
+
+- `setup_tracing()`
+- `setup_observability(instrument_asyncpg=True)`
+- `get_tracer(name)`
+- `get_meter(name)`
+- `shutdown_tracing()`
+- `force_flush_tracing(timeout_millis=30000)`
+- `instrument_asyncpg_once()`
+- `is_otel_disabled()`
+
+Batch span processor settings are controlled by:
+
+- `QUIMERA_OTEL_MAX_QUEUE_SIZE`
+- `QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE`
+- `QUIMERA_OTEL_SCHEDULE_DELAY_MILLIS`
+- `QUIMERA_OTEL_EXPORT_TIMEOUT_MILLIS`
+
+`QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE` must be less than or equal to
+`QUIMERA_OTEL_MAX_QUEUE_SIZE`.
+
+## LiteLLM
+
+`infra/litellm/litellm_config.yaml` includes:
+
+- `litellm_settings.callbacks: ["otel"]`
+- `litellm_settings.turn_off_message_logging: true`
+- `callback_settings.otel.message_logging: false`
+
+The doctor checks these settings without starting LiteLLM and without calling
+Ollama or any model endpoint.
+
+## Out Of Scope
+
+- Full RAG pipeline instrumentation.
+- Dashboards, collectors, Grafana, Tempo, Jaeger or Prometheus.
+- MCP server, API, gRPC or runtime gateway changes.
+- PostgreSQL/Timescale schema changes.
+- Qdrant collection changes.
+- Capturing raw prompt/response/chunk/vector content.
+
+## Handoff To PR-07
+
+PR-07 should wire these decorators into selected RAG and gateway seams, define
+sampling policy for local development, and decide whether a collector/profile is
+worth adding as an optional operator path.

--- a/infra/litellm/litellm_config.yaml
+++ b/infra/litellm/litellm_config.yaml
@@ -155,6 +155,8 @@ model_list:
       output_dimensions: 768
 
 litellm_settings:
+  callbacks:
+    - otel
   cache: true
   cache_params:
     type: qdrant-semantic
@@ -172,6 +174,10 @@ litellm_settings:
   redact_user_api_key_info: true
   num_retries: 1
   request_timeout: 165
+
+callback_settings:
+  otel:
+    message_logging: false
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "pyyaml>=6.0.2",
     "loguru>=0.7.3",
     "asyncpg>=0.30.0",
+    "opentelemetry-api>=1.42.1",
+    "opentelemetry-sdk>=1.42.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.42.1",
+    "opentelemetry-instrumentation-asyncpg>=0.63b1",
 ]
 
 [dependency-groups]

--- a/scripts/start_quimera.sh
+++ b/scripts/start_quimera.sh
@@ -36,6 +36,7 @@ RELEASE_MODELS=0
 NO_DOCKER=0
 NO_OLLAMA=0
 FOLLOW_LOGS=0
+OTEL_JSON=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -47,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --no-docker) NO_DOCKER=1 ;;
     --no-ollama) NO_OLLAMA=1 ;;
     --logs) FOLLOW_LOGS=1 ;;
+    --json) OTEL_JSON=1 ;;
     --help|-h) COMMAND="help" ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -146,6 +148,15 @@ litellm_fingerprint() {
 litellm_benchmark() {
   load_env
   uv run python -m infra.litellm.overhead_benchmark
+}
+
+otel_doctor() {
+  load_env
+  if [[ "${OTEL_JSON}" -eq 1 ]]; then
+    uv run python -m backend.observability.tracer --doctor --json --config "${QUIMERA_LITELLM_CONFIG}"
+  else
+    uv run python -m backend.observability.tracer --doctor --config "${QUIMERA_LITELLM_CONFIG}"
+  fi
 }
 
 litellm_start() {
@@ -321,8 +332,8 @@ Usage: scripts/start_quimera.sh <command> [flags]
 Commands: start, stop, restart, status, logs, doctor, test, warmup, release,
           litellm-validate, litellm-render, litellm-start, litellm-stop,
           litellm-restart, litellm-smoke, litellm-audit, litellm-fingerprint,
-          litellm-benchmark
-Flags: --build --warmup --doctor --integration --release-models --no-docker --no-ollama --logs --help
+          litellm-benchmark, otel-doctor
+Flags: --build --warmup --doctor --integration --release-models --no-docker --no-ollama --logs --json --help
 HELP
 }
 
@@ -345,6 +356,7 @@ case "${COMMAND}" in
   litellm-audit) litellm_audit ;;
   litellm-fingerprint) litellm_fingerprint ;;
   litellm-benchmark) litellm_benchmark ;;
+  otel-doctor) otel_doctor ;;
   help|--help|-h) show_help ;;
   *) echo "Unknown command: ${COMMAND}" >&2; show_help; exit 2 ;;
 esac

--- a/tests/integration/test_litellm_host_qdrant_cache_smoke.py
+++ b/tests/integration/test_litellm_host_qdrant_cache_smoke.py
@@ -28,7 +28,7 @@ def test_litellm_qdrant_cache_backend_is_reachable() -> None:
     assert collections.status_code < 400
 
 
-def test_litellm_qdrant_semantic_cache_runtime_policy(tmp_path) -> None:
+def test_litellm_qdrant_semantic_cache_runtime_policy(tmp_path: Path) -> None:
     if os.environ.get("RUN_LITELLM_QDRANT_CACHE_SMOKE") != "1":
         pytest.skip("RUN_LITELLM_QDRANT_CACHE_SMOKE=1 is required")
 

--- a/tests/integration/test_otel_console_exporter_smoke.py
+++ b/tests/integration/test_otel_console_exporter_smoke.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from backend.observability.tracer import force_flush_tracing, setup_tracing, shutdown_tracing
+
+pytestmark = pytest.mark.integration
 
 
 def test_otel_console_exporter_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -12,4 +16,3 @@ def test_otel_console_exporter_smoke(monkeypatch) -> None:  # type: ignore[no-un
 
     assert force_flush_tracing(timeout_millis=1000) is True
     shutdown_tracing()
-

--- a/tests/integration/test_otel_console_exporter_smoke.py
+++ b/tests/integration/test_otel_console_exporter_smoke.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from backend.observability.tracer import force_flush_tracing, setup_tracing, shutdown_tracing
+
+
+def test_otel_console_exporter_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+
+    setup_tracing()
+
+    assert force_flush_tracing(timeout_millis=1000) is True
+    shutdown_tracing()
+

--- a/tests/integration/test_otel_context_asyncio_gather.py
+++ b/tests/integration/test_otel_context_asyncio_gather.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from backend.observability.context import (
     clear_quimera_context,
     get_quimera_context_attributes,
     set_quimera_context,
 )
+
+pytestmark = pytest.mark.integration
 
 
 async def test_otel_context_asyncio_gather_isolated() -> None:

--- a/tests/integration/test_otel_context_asyncio_gather.py
+++ b/tests/integration/test_otel_context_asyncio_gather.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+
+from backend.observability.context import (
+    clear_quimera_context,
+    get_quimera_context_attributes,
+    set_quimera_context,
+)
+
+
+async def test_otel_context_asyncio_gather_isolated() -> None:
+    clear_quimera_context()
+
+    async def worker(task_id: str) -> str:
+        set_quimera_context(task_id=task_id)
+        await asyncio.sleep(0)
+        return get_quimera_context_attributes()["quimera.task_id"]
+
+    assert list(await asyncio.gather(worker("task-a"), worker("task-b"))) == ["task-a", "task-b"]

--- a/tests/integration/test_otel_disabled_import_smoke.py
+++ b/tests/integration/test_otel_disabled_import_smoke.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from backend.observability.tracer import setup_observability
+
+pytestmark = pytest.mark.integration
 
 
 def test_otel_disabled_import_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
 
     setup_observability()
-

--- a/tests/integration/test_otel_disabled_import_smoke.py
+++ b/tests/integration/test_otel_disabled_import_smoke.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from backend.observability.tracer import setup_observability
+
+
+def test_otel_disabled_import_smoke(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+    setup_observability()
+

--- a/tests/unit/test_litellm_config_yaml.py
+++ b/tests/unit/test_litellm_config_yaml.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -8,13 +9,13 @@ import yaml
 CONFIG = Path("infra/litellm/litellm_config.yaml")
 
 
-def _load_config() -> dict:
+def _load_config() -> dict[str, Any]:
     raw = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
     assert isinstance(raw, dict)
     return raw
 
 
-def _aliases() -> dict[str, dict]:
+def _aliases() -> dict[str, dict[str, Any]]:
     return {item["model_name"]: item for item in _load_config()["model_list"]}
 
 

--- a/tests/unit/test_litellm_timeout_policy.py
+++ b/tests/unit/test_litellm_timeout_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -11,7 +12,7 @@ CONFIG = Path("infra/litellm/litellm_config.yaml")
 CHAT_ALIASES = {"local_chat", "local_think", "local_rag", "local_json"}
 
 
-def _aliases() -> dict[str, dict]:
+def _aliases() -> dict[str, dict[str, Any]]:
     raw = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
     assert isinstance(raw, dict)
     return {item["model_name"]: item for item in raw["model_list"]}

--- a/tests/unit/test_otel_attributes.py
+++ b/tests/unit/test_otel_attributes.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from backend.observability import attributes as attrs
+
+
+def test_attribute_sets_have_no_duplicates() -> None:
+    all_values = [*attrs.GENAI_ATTRS, *attrs.MCP_ATTRS, *attrs.QUIMERA_ATTRS]
+
+    assert len(all_values) == len(set(all_values))
+
+
+def test_required_semantic_attributes_are_declared() -> None:
+    assert "gen_ai.operation.name" in attrs.GENAI_ATTRS
+    assert "gen_ai.provider.name" in attrs.GENAI_ATTRS
+    assert "gen_ai.response.model" in attrs.GENAI_ATTRS
+    assert "mcp.method.name" in attrs.MCP_ATTRS
+    assert "retrieval.cache_hit" in attrs.QUIMERA_ATTRS
+    assert "latency.llm_ms" in attrs.QUIMERA_ATTRS
+
+
+def test_allowed_attribute_constants_do_not_contain_sensitive_keys() -> None:
+    forbidden = attrs.PII_FORBIDDEN_ATTRS
+
+    assert attrs.SAFE_ATTRS.isdisjoint(forbidden)
+
+
+def test_attribute_names_are_lowercase_dotted_tokens() -> None:
+    for key in attrs.SAFE_ATTRS:
+        assert key == key.lower()
+        assert " " not in key
+        assert "." in key
+

--- a/tests/unit/test_otel_attributes.py
+++ b/tests/unit/test_otel_attributes.py
@@ -13,6 +13,8 @@ def test_required_semantic_attributes_are_declared() -> None:
     assert "gen_ai.operation.name" in attrs.GENAI_ATTRS
     assert "gen_ai.provider.name" in attrs.GENAI_ATTRS
     assert "gen_ai.response.model" in attrs.GENAI_ATTRS
+    assert "db.system.name" in attrs.DB_ATTRS
+    assert "db.operation.name" in attrs.DB_ATTRS
     assert "mcp.method.name" in attrs.MCP_ATTRS
     assert "retrieval.cache_hit" in attrs.QUIMERA_ATTRS
     assert "latency.llm_ms" in attrs.QUIMERA_ATTRS
@@ -29,4 +31,3 @@ def test_attribute_names_are_lowercase_dotted_tokens() -> None:
         assert key == key.lower()
         assert " " not in key
         assert "." in key
-

--- a/tests/unit/test_otel_context.py
+++ b/tests/unit/test_otel_context.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+
+from backend.observability.context import (
+    clear_quimera_context,
+    get_quimera_context_attributes,
+    set_quimera_context,
+)
+
+
+def test_quimera_context_roundtrip_and_clear() -> None:
+    clear_quimera_context()
+
+    set_quimera_context(agent_id="agent-a", session_id="session-a", task_id="task-a")
+
+    assert get_quimera_context_attributes() == {
+        "quimera.agent_id": "agent-a",
+        "quimera.session_id": "session-a",
+        "quimera.task_id": "task-a",
+    }
+    clear_quimera_context()
+    assert get_quimera_context_attributes() == {}
+
+
+async def test_contextvars_do_not_leak_between_gather_tasks() -> None:
+    clear_quimera_context()
+
+    async def worker(session_id: str) -> str:
+        set_quimera_context(session_id=session_id)
+        await asyncio.sleep(0)
+        return get_quimera_context_attributes()["quimera.session_id"]
+
+    assert list(await asyncio.gather(worker("a"), worker("b"))) == ["a", "b"]

--- a/tests/unit/test_otel_decorators.py
+++ b/tests/unit/test_otel_decorators.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import TracebackType
+from typing import Any
+
+import pytest
+
+from backend.observability import decorators
+from backend.observability.context import clear_quimera_context, set_quimera_context
+
+
+class FakeSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+        self.exceptions: list[Exception] = []
+        self.status: object | None = None
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def record_exception(self, exc: Exception) -> None:
+        self.exceptions.append(exc)
+
+    def set_status(self, status: object) -> None:
+        self.status = status
+
+
+class FakeSpanContext:
+    def __init__(self, span: FakeSpan, attributes: Mapping[str, object] | None) -> None:
+        self.span = span
+        if attributes:
+            self.span.attributes.update(attributes)
+
+    def __enter__(self) -> FakeSpan:
+        return self.span
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+
+class FakeTracer:
+    def __init__(self) -> None:
+        self.span = FakeSpan()
+        self.span_names: list[str] = []
+
+    def start_as_current_span(
+        self,
+        name: str,
+        attributes: Mapping[str, object] | None = None,
+    ) -> FakeSpanContext:
+        self.span_names.append(name)
+        return FakeSpanContext(self.span, attributes)
+
+
+async def test_traced_llm_sets_model_context_and_latency(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = FakeTracer()
+    monkeypatch.setattr(decorators, "get_tracer", lambda name: tracer)
+    clear_quimera_context()
+    set_quimera_context(session_id="s-1")
+
+    @decorators.traced_llm(model="qwen3:14b")
+    async def call() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    assert await call() == {"ok": "yes"}
+    assert getattr(call, "__wrapped__") is not None
+    assert tracer.span.attributes["gen_ai.operation.name"] == "chat"
+    assert tracer.span.attributes["gen_ai.request.model"] == "qwen3:14b"
+    assert tracer.span.attributes["quimera.session_id"] == "s-1"
+    assert "latency.llm_ms" in tracer.span.attributes
+
+
+async def test_traced_retrieval_records_result_count_and_cache_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = FakeTracer()
+    monkeypatch.setattr(decorators, "get_tracer", lambda name: tracer)
+
+    @decorators.traced_retrieval(source="qdrant")
+    async def retrieve() -> dict[str, Any]:
+        return {"result_count": 3, "cache_hit": True}
+
+    await retrieve()
+
+    assert tracer.span.attributes["retrieval.result_count"] == 3
+    assert tracer.span.attributes["cache.hit"] is True
+
+
+async def test_decorator_records_exception_and_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = FakeTracer()
+    monkeypatch.setattr(decorators, "get_tracer", lambda name: tracer)
+
+    @decorators.traced_pg(table="sessions", operation="select")
+    async def broken() -> None:
+        raise RuntimeError("bad postgresql://user:secret@localhost/db")
+
+    with pytest.raises(RuntimeError):
+        await broken()
+
+    assert tracer.span.attributes["error.type"] == "RuntimeError"
+    assert tracer.span.exceptions
+    assert tracer.span.status is not None
+
+
+def test_decorator_rejects_sync_functions() -> None:
+    with pytest.raises(TypeError, match="async functions only"):
+
+        @decorators.traced_embed(model="nomic-embed-text")
+        def sync_fn() -> None:
+            return None

--- a/tests/unit/test_otel_decorators.py
+++ b/tests/unit/test_otel_decorators.py
@@ -106,6 +106,45 @@ async def test_decorator_records_exception_and_reraises(monkeypatch: pytest.Monk
     assert tracer.span.status is not None
 
 
+async def test_traced_pg_sets_postgresql_semconv_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = FakeTracer()
+    monkeypatch.setattr(decorators, "get_tracer", lambda name: tracer)
+
+    @decorators.traced_pg(table="sessions", operation="select")
+    async def query() -> None:
+        return None
+
+    await query()
+
+    assert tracer.span.attributes["db.system.name"] == "postgresql"
+    assert tracer.span.attributes["db.operation.name"] == "SELECT"
+    assert tracer.span.attributes["db.collection.name"] == "sessions"
+    assert tracer.span.attributes["quimera.pg_table"] == "sessions"
+    assert tracer.span.attributes["quimera.pg_operation"] == "SELECT"
+
+
+async def test_traced_mcp_tool_uses_method_span_name_and_safe_tool_attribute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracer = FakeTracer()
+    monkeypatch.setattr(decorators, "get_tracer", lambda name: tracer)
+
+    @decorators.traced_mcp_tool(tool_name="safe_tool")
+    async def call_tool() -> None:
+        return None
+
+    await call_tool()
+
+    assert tracer.span_names == ["mcp tools/call"]
+    assert tracer.span.attributes["gen_ai.operation.name"] == "execute_tool"
+    assert tracer.span.attributes["gen_ai.tool.name"] == "safe_tool"
+
+
+def test_traced_mcp_tool_rejects_sensitive_or_free_text_tool_name() -> None:
+    with pytest.raises(ValueError):
+        decorators.traced_mcp_tool(tool_name="dump_prompt please")
+
+
 def test_decorator_rejects_sync_functions() -> None:
     with pytest.raises(TypeError, match="async functions only"):
 

--- a/tests/unit/test_otel_events.py
+++ b/tests/unit/test_otel_events.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.observability.events import (
+    add_cache_decision_event,
+    add_evaluation_score,
+    add_safe_event,
+)
+
+
+class FakeSpan:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, object]] = []
+
+    def add_event(self, name: str, attributes: object | None = None) -> None:
+        self.events.append((name, attributes))
+
+
+def test_add_safe_event_records_valid_metadata_only() -> None:
+    span = FakeSpan()
+
+    add_safe_event(span, "quimera.retrieval.stage", {"quimera.stage": "pack"})
+
+    assert span.events == [("quimera.retrieval.stage", {"quimera.stage": "pack"})]
+
+
+def test_add_safe_event_rejects_prompt_payload() -> None:
+    with pytest.raises(ValueError):
+        add_safe_event(FakeSpan(), "quimera.retrieval.stage", {"quimera.prompt": "raw"})
+
+
+def test_add_evaluation_score_records_genai_event() -> None:
+    span = FakeSpan()
+
+    add_evaluation_score(span, "faithfulness", 0.91, label="synthetic")
+
+    assert span.events[0][0] == "gen_ai.evaluation.result"
+
+
+def test_add_cache_decision_event_records_safe_reason() -> None:
+    span = FakeSpan()
+
+    add_cache_decision_event(span, hit=False, backend="qdrant", reason="schema_version_miss")
+
+    assert span.events[0][1] == {
+        "cache.hit": False,
+        "cache.backend": "qdrant",
+        "quimera.cache_reason": "schema_version_miss",
+    }
+

--- a/tests/unit/test_otel_litellm_config.py
+++ b/tests/unit/test_otel_litellm_config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from backend.observability.lite_llm import (
+    ensure_litellm_otel_callback_present,
+    validate_litellm_otel_callback_config,
+)
+
+
+CONFIG = Path("infra/litellm/litellm_config.yaml")
+
+
+def test_litellm_config_has_otel_callback_with_message_logging_disabled() -> None:
+    validation = validate_litellm_otel_callback_config(CONFIG)
+
+    assert validation == {
+        "callbacks_present": True,
+        "message_logging_disabled": True,
+    }
+
+
+def test_ensure_litellm_otel_callback_present_is_explicit_edit(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        yaml.safe_dump({"litellm_settings": {"turn_off_message_logging": True}}),
+        encoding="utf-8",
+    )
+
+    ensure_litellm_otel_callback_present(path)
+
+    cfg = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert cfg["litellm_settings"]["callbacks"] == ["otel"]
+    assert cfg["callback_settings"]["otel"]["message_logging"] is False
+

--- a/tests/unit/test_otel_metrics.py
+++ b/tests/unit/test_otel_metrics.py
@@ -21,6 +21,11 @@ def test_record_genai_duration_converts_ms_to_seconds(monkeypatch) -> None:  # t
     assert fake.records == [(1.25, {"gen_ai.operation.name": "chat"})]
 
 
+def test_metric_names_are_public_constants() -> None:
+    assert metrics.GENAI_OPERATION_DURATION_METRIC_NAME == "gen_ai.client.operation.duration"
+    assert metrics.RETRIEVAL_OPERATION_DURATION_METRIC_NAME == "quimera.retrieval.operation.duration"
+
+
 def test_record_retrieval_duration_keeps_ms(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     fake = FakeHistogram()
     monkeypatch.setattr(metrics, "_RETRIEVAL_OPERATION_DURATION", fake)
@@ -29,4 +34,3 @@ def test_record_retrieval_duration_keeps_ms(monkeypatch) -> None:  # type: ignor
     metrics.record_retrieval_duration(37.5, {"retrieval.result_count": 4})
 
     assert fake.records == [(37.5, {"retrieval.result_count": 4})]
-

--- a/tests/unit/test_otel_metrics.py
+++ b/tests/unit/test_otel_metrics.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from backend.observability import metrics
+
+
+class FakeHistogram:
+    def __init__(self) -> None:
+        self.records: list[tuple[float, object]] = []
+
+    def record(self, value: float, attributes: object | None = None) -> None:
+        self.records.append((value, attributes))
+
+
+def test_record_genai_duration_converts_ms_to_seconds(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = FakeHistogram()
+    monkeypatch.setattr(metrics, "_GENAI_OPERATION_DURATION", fake)
+    monkeypatch.setattr(metrics, "setup_metrics", lambda: None)
+
+    metrics.record_genai_operation_duration(1250.0, {"gen_ai.operation.name": "chat"})
+
+    assert fake.records == [(1.25, {"gen_ai.operation.name": "chat"})]
+
+
+def test_record_retrieval_duration_keeps_ms(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    fake = FakeHistogram()
+    monkeypatch.setattr(metrics, "_RETRIEVAL_OPERATION_DURATION", fake)
+    monkeypatch.setattr(metrics, "setup_metrics", lambda: None)
+
+    metrics.record_retrieval_duration(37.5, {"retrieval.result_count": 4})
+
+    assert fake.records == [(37.5, {"retrieval.result_count": 4})]
+

--- a/tests/unit/test_otel_safety.py
+++ b/tests/unit/test_otel_safety.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.observability.safety import (
+    assert_no_pii_keys,
+    redact_mapping,
+    sanitize_error_message,
+    validate_attribute_key,
+    validate_attribute_value,
+    validate_attributes,
+)
+
+
+def test_validate_allows_official_response_model_attribute() -> None:
+    assert validate_attribute_key("gen_ai.response.model") == "gen_ai.response.model"
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["prompt", "quimera.prompt", "chunk_text", "cache.raw_payload", "quimera.api_key"],
+)
+def test_validate_blocks_sensitive_attribute_keys(key: str) -> None:
+    with pytest.raises(ValueError):
+        validate_attribute_key(key)
+
+
+def test_validate_blocks_secret_like_values() -> None:
+    with pytest.raises(ValueError):
+        validate_attribute_value("postgresql://user:secret@127.0.0.1:5432/db")
+
+
+def test_validate_attributes_returns_sanitized_copy() -> None:
+    assert validate_attributes({"retrieval.cache_hit": True}) == {"retrieval.cache_hit": True}
+
+
+def test_sanitize_error_message_redacts_dsn() -> None:
+    msg = sanitize_error_message("failed postgresql://user:secret@127.0.0.1/db")
+
+    assert "secret" not in msg
+    assert "[REDACTED]" in msg
+
+
+def test_redact_mapping_recurses_sensitive_keys() -> None:
+    redacted = redact_mapping({"safe": {"api_key": "secret"}, "prompt": "hello"})
+
+    assert redacted["prompt"] == "[REDACTED]"
+    assert redacted["safe"] == {"api_key": "[REDACTED]"}
+
+
+def test_assert_no_pii_keys_rejects_nested_payload() -> None:
+    with pytest.raises(ValueError):
+        assert_no_pii_keys({"quimera.stage": "ok", "quimera.payload": "bad"})
+

--- a/tests/unit/test_otel_tracer.py
+++ b/tests/unit/test_otel_tracer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.observability import tracer
+
+
+def test_is_otel_disabled_respects_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+    assert tracer.is_otel_disabled() is True
+
+
+def test_batch_config_validates_export_batch_not_larger_than_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUIMERA_OTEL_MAX_QUEUE_SIZE", "4")
+    monkeypatch.setenv("QUIMERA_OTEL_MAX_EXPORT_BATCH_SIZE", "5")
+
+    with pytest.raises(ValueError):
+        tracer.batch_span_processor_config()
+
+
+def test_build_resource_uses_quimera_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTEL_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("QUIMERA_ENV", raising=False)
+
+    attrs = tracer.build_resource().attributes
+
+    assert attrs["service.name"] == "quimera"
+    assert attrs["deployment.environment"] == "local"
+    assert attrs["quimera.project"] == "openclaw"
+
+
+def test_setup_tracing_noops_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer._reset_for_tests()
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+    tracer.setup_tracing()
+
+    assert tracer._ACTIVE_PROVIDER is None
+
+
+def test_doctor_report_checks_litellm_callback_and_no_requests_import() -> None:
+    report = tracer.build_doctor_report(Path("infra/litellm/litellm_config.yaml"))
+
+    assert isinstance(report["checks"], dict)
+    checks = report["checks"]
+    assert checks["backend_observability_imports_requests"] is False
+    assert checks["opentelemetry_packages_importable"] is True
+

--- a/tests/unit/test_start_quimera_otel_doctor.py
+++ b/tests/unit/test_start_quimera_otel_doctor.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+START = Path("scripts/start_quimera.sh")
+
+
+def test_start_quimera_declares_otel_doctor_command() -> None:
+    text = START.read_text(encoding="utf-8")
+
+    assert "otel-doctor" in text
+    assert "otel_doctor()" in text
+    assert "backend.observability.tracer --doctor" in text
+
+
+def test_start_quimera_supports_otel_doctor_json_flag() -> None:
+    text = START.read_text(encoding="utf-8")
+
+    assert "--json) OTEL_JSON=1" in text
+    assert "--doctor --json" in text
+

--- a/uv.lock
+++ b/uv.lock
@@ -80,12 +80,97 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -423,6 +508,10 @@ dependencies = [
     { name = "asyncpg" },
     { name = "httpx" },
     { name = "loguru" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-asyncpg" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
@@ -443,6 +532,10 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "opentelemetry-api", specifier = ">=1.42.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.42.1" },
+    { name = "opentelemetry-instrumentation-asyncpg", specifier = ">=0.63b1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.42.1" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -456,6 +549,116 @@ dev = [
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/6d/4de72d97ff54db1ed270c7a59c9b904b917c0ac7af429c086c388b824ddb/opentelemetry_instrumentation-0.63b1.tar.gz", hash = "sha256:32368d6ae52c8de20aa790a6ad86b10a76f09956092337ae37d675773990e541", size = 41081, upload-time = "2026-05-21T16:36:14.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/a1/9314e621c143e4d82a5bf7a43c2ff7a745d31023506336857607c8c543cc/opentelemetry_instrumentation-0.63b1-py3-none-any.whl", hash = "sha256:f1986716d52cc316ea5f60189098726a9071d8ecc0eee96c9ed110be08bade9c", size = 35577, upload-time = "2026-05-21T16:34:56.818Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asyncpg"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/52/86a5d3e287fb67a6ff4d6dde7653f52b5c18ecd5429809508b507a0988a0/opentelemetry_instrumentation_asyncpg-0.63b1.tar.gz", hash = "sha256:8459cd11e3c114a0b823feb99dc8bac4c55a5374c4287211d0c2cc98787c38e0", size = 8745, upload-time = "2026-05-21T16:36:20.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/09/62151650fe7bf76669130042fd2fc809e15b2c89489bfd4bb58d292a83f8/opentelemetry_instrumentation_asyncpg-0.63b1-py3-none-any.whl", hash = "sha256:ab3762e3d507e7a9bfab97a12fefa4c5b4048fcfbcbb3ae4887cf18bab364857", size = 9250, upload-time = "2026-05-21T16:35:08.22Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
@@ -757,6 +960,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260408"
 source = { registry = "https://pypi.org/simple" }
@@ -802,4 +1020,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]


### PR DESCRIPTION
## Summary

Implements RAG-01B-PR-06 OpenTelemetry base layer for Quimera/OpenClaw.

- Adds `backend/observability/` with idempotent tracing setup, asyncpg instrumentation guard, safe attributes, PII/content safety, contextvars, events, metrics and async-only decorators.
- Adds LiteLLM OTel callback guard and config contract with `callbacks: ["otel"]` and message logging disabled.
- Adds `scripts/start_quimera.sh otel-doctor` plus `otel-doctor --json`.
- Adds `.env.observability.example` and PR-06 SDD.
- Adds minimal OTel dependencies: API, SDK, OTLP HTTP exporter and asyncpg instrumentation.

## Scope intentionally excluded

- No full RAG runtime instrumentation.
- No collector/dashboard/Grafana/Tempo/Jaeger/Prometheus service.
- No MCP server, FastAPI, REST API or gRPC.
- No PostgreSQL/Timescale schema change.
- No Qdrant collection change.
- No LiteLLM Docker service.
- No raw prompt/query/answer/response/chunk/vector capture.

## Validation

- `uv run pytest tests/unit/test_otel_attributes.py tests/unit/test_otel_safety.py tests/unit/test_otel_context.py tests/unit/test_otel_events.py tests/unit/test_otel_decorators.py tests/unit/test_otel_metrics.py tests/unit/test_otel_tracer.py tests/unit/test_otel_litellm_config.py tests/unit/test_start_quimera_otel_doctor.py tests/integration/test_otel_disabled_import_smoke.py tests/integration/test_otel_console_exporter_smoke.py tests/integration/test_otel_context_asyncio_gather.py` — 39 passed
- LiteLLM/start-script compatibility block — 58 passed
- `uv run pytest tests/unit` — 1707 passed
- `uv run pytest` — 1726 passed, 51 skipped
- `uv run mypy --strict .` — success
- `uv run pyright` — 0 errors
- `bash -n scripts/start_quimera.sh` — clean
- `uv run python -m infra.litellm.config_validator` — success, one expected qdrant-semantic warning
- `./scripts/start_quimera.sh otel-doctor --json` — status `ok`
- `git diff --check` — clean

Closes #112.
