### PR TITLE
RAG-01B PR-10 Working Memory Qdrant pgvector

### DIFF
--- a/backend/mcp/working_memory_server.py
+++ b/backend/mcp/working_memory_server.py
@@ -1,0 +1,74 @@
+"""FastMCP server for QUIMERA working memory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from backend.mcp.working_memory_tools import (
+    build_working_memory_health,
+    working_memory_cleanup_expired,
+    working_memory_query,
+    working_memory_restore,
+    working_memory_snapshot,
+    working_memory_upsert,
+)
+from backend.working_memory.config import WorkingMemorySettings, get_working_memory_settings
+
+
+def create_working_memory_server(settings: WorkingMemorySettings | None = None) -> FastMCP[Any]:
+    resolved = settings or get_working_memory_settings()
+    server: FastMCP[Any] = FastMCP("quimera-working-memory")
+
+    @server.tool
+    async def working_memory_health() -> dict[str, object]:
+        return build_working_memory_health(resolved)
+
+    @server.tool
+    async def working_memory_point_upsert(
+        agent_id: str,
+        session_id: str,
+        memory_kind: str,
+        vector: list[float],
+        metadata: dict[str, object] | None = None,
+        safe_summary: str | None = None,
+    ) -> dict[str, object]:
+        return await working_memory_upsert(
+            agent_id=agent_id,
+            session_id=session_id,
+            memory_kind=memory_kind,
+            vector=vector,
+            metadata=metadata,
+            safe_summary=safe_summary,
+            settings=resolved,
+            store=None,
+        )
+
+    @server.tool
+    async def working_memory_points_query(agent_id: str, session_id: str, query_vector: list[float], limit: int = 10) -> dict[str, object]:
+        return await working_memory_query(agent_id, session_id, query_vector, limit=limit, settings=resolved, store=None)
+
+    @server.tool
+    async def working_memory_session_snapshot(agent_id: str, session_id: str) -> dict[str, object]:
+        return await working_memory_snapshot(agent_id, session_id, snapshot_service=None)
+
+    @server.tool
+    async def working_memory_session_restore(agent_id: str, session_id: str) -> dict[str, object]:
+        return await working_memory_restore(agent_id, session_id, settings=resolved, restore_service=None)
+
+    @server.tool
+    async def working_memory_expired_cleanup(agent_id: str | None = None, session_id: str | None = None) -> dict[str, object]:
+        return await working_memory_cleanup_expired(settings=resolved, cleanup_service=None, agent_id=agent_id, session_id=session_id)
+
+    return server
+
+
+def main() -> int:
+    server = create_working_memory_server()
+    server.run(transport="streamable-http", host="127.0.0.1", port=8813, path="/mcp")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/mcp/working_memory_tools.py
+++ b/backend/mcp/working_memory_tools.py
@@ -1,0 +1,147 @@
+"""Safe MCP-callable helpers for working memory."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+from uuid import UUID, uuid4
+
+from backend.mcp.mcp_models import HealthResponse, ToolResponse
+from backend.mcp.mcp_safety import validate_limit, validate_non_empty_text, validate_uuid
+from backend.working_memory.cleanup import CleanupService
+from backend.working_memory.config import WorkingMemorySettings
+from backend.working_memory.models import MemoryKind, WorkingMemoryPoint
+from backend.working_memory.restore_service import RestoreService
+from backend.working_memory.safety import sanitize_metadata, validate_safe_summary
+from backend.working_memory.snapshot_service import SnapshotService
+
+
+class WorkingMemoryStoreLike(Protocol):
+    async def upsert_memory_point(self, point: WorkingMemoryPoint) -> str: ...
+    async def query_working_memory(self, *, agent_id: str, session_id: str, query_vector: list[float], limit: int = 10) -> list[dict[str, Any]]: ...
+
+
+def build_working_memory_health(settings: WorkingMemorySettings) -> dict[str, object]:
+    return HealthResponse(
+        status="ok" if settings.enabled else "skipped",
+        backend="working_memory",
+        details={
+            "collection": settings.collection_name,
+            "vector_name": settings.vector_name,
+            "vector_size": settings.vector_size,
+            "restore_enabled": settings.restore_enabled,
+            "cleanup_enabled": settings.cleanup_enabled,
+        },
+    ).model_dump()
+
+
+async def working_memory_upsert(
+    *,
+    agent_id: str,
+    session_id: str,
+    memory_kind: str,
+    vector: list[float],
+    metadata: dict[str, object] | None = None,
+    safe_summary: str | None = None,
+    settings: WorkingMemorySettings,
+    store: WorkingMemoryStoreLike | None,
+    task_id: str | None = None,
+    topic: str | None = None,
+    importance: float = 0.5,
+) -> dict[str, object]:
+    validate_non_empty_text(agent_id, "agent_id")
+    clean_session = validate_uuid(session_id, "session_id")
+    if memory_kind not in ("turn_summary", "agent_state", "scratchpad", "handoff", "tool_observation"):
+        raise ValueError("memory_kind is unsupported")
+    if len(vector) != settings.vector_size:
+        raise ValueError("working memory vector dimension mismatch")
+    now = datetime.now(UTC)
+    point = WorkingMemoryPoint(
+        point_id=f"wm-{uuid4().hex}",
+        agent_id=agent_id,
+        session_id=UUID(clean_session),
+        memory_kind=memory_kind,  # type: ignore[arg-type]
+        vector=tuple(vector),
+        vector_dim=settings.vector_size,
+        recency_ts=now,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(seconds=settings.default_ttl_seconds),
+        ttl_seconds=settings.default_ttl_seconds,
+        embedding_model="nomic-embed-text",
+        task_id=task_id,
+        topic=topic,
+        importance=importance,
+        safe_summary=validate_safe_summary(safe_summary),
+        metadata=sanitize_metadata(metadata),
+    )
+    point_id = await store.upsert_memory_point(point) if store is not None else point.point_id
+    return ToolResponse(ok=True, data={"point_ids": [point_id], "count": 1, "checksum": point.payload_checksum}).model_dump()
+
+
+async def working_memory_query(
+    agent_id: str,
+    session_id: str,
+    query_vector: list[float],
+    *,
+    limit: int,
+    settings: WorkingMemorySettings,
+    store: WorkingMemoryStoreLike | None,
+) -> dict[str, object]:
+    validate_non_empty_text(agent_id, "agent_id")
+    clean_session = validate_uuid(session_id, "session_id")
+    validate_limit(limit, maximum=50)
+    if len(query_vector) != settings.vector_size:
+        raise ValueError("working memory vector dimension mismatch")
+    results = await store.query_working_memory(agent_id=agent_id, session_id=clean_session, query_vector=query_vector, limit=limit) if store is not None else []
+    return ToolResponse(ok=True, data={"results": results, "count": len(results), "vectors_exposed": False}).model_dump()
+
+
+async def working_memory_snapshot(
+    agent_id: str,
+    session_id: str,
+    *,
+    snapshot_service: SnapshotService | None,
+) -> dict[str, object]:
+    validate_non_empty_text(agent_id, "agent_id")
+    clean_session = validate_uuid(session_id, "session_id")
+    if snapshot_service is None:
+        return ToolResponse(ok=False, error="working memory snapshot unavailable").model_dump()
+    result = await snapshot_service.create_session_snapshot(agent_id=agent_id, session_id=clean_session)
+    return ToolResponse(ok=True, data=result).model_dump()
+
+
+async def working_memory_restore(
+    agent_id: str,
+    session_id: str,
+    *,
+    settings: WorkingMemorySettings,
+    restore_service: RestoreService | None,
+) -> dict[str, object]:
+    validate_non_empty_text(agent_id, "agent_id")
+    clean_session = validate_uuid(session_id, "session_id")
+    if not settings.restore_enabled:
+        return ToolResponse(ok=False, error="working memory restore disabled").model_dump()
+    if restore_service is None:
+        return ToolResponse(ok=False, error="working memory restore unavailable").model_dump()
+    report = await restore_service.restore_latest_snapshot(agent_id=agent_id, session_id=clean_session)
+    return ToolResponse(ok=report.status in {"ok", "warn"}, data=report.to_dict()).model_dump()
+
+
+async def working_memory_cleanup_expired(
+    *,
+    settings: WorkingMemorySettings,
+    cleanup_service: CleanupService | None,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, object]:
+    if not settings.cleanup_enabled:
+        return ToolResponse(ok=False, error="working memory cleanup disabled").model_dump()
+    if cleanup_service is None:
+        return ToolResponse(ok=False, error="working memory cleanup unavailable").model_dump()
+    if agent_id is not None:
+        validate_non_empty_text(agent_id, "agent_id")
+    if session_id is not None:
+        validate_uuid(session_id, "session_id")
+    result = await cleanup_service.cleanup_expired(agent_id=agent_id, session_id=session_id)
+    return ToolResponse(ok=result.status == "ok", data={"deleted_count": result.deleted_count, "status": result.status}).model_dump()

--- a/backend/working_memory/__init__.py
+++ b/backend/working_memory/__init__.py
@@ -1,0 +1,6 @@
+"""Hot working memory backed by Qdrant with pgvector checkpoints."""
+
+from backend.working_memory.config import WorkingMemorySettings
+from backend.working_memory.models import WorkingMemoryPoint
+
+__all__ = ["WorkingMemoryPoint", "WorkingMemorySettings"]

--- a/backend/working_memory/checkpoint_repository.py
+++ b/backend/working_memory/checkpoint_repository.py
@@ -1,0 +1,213 @@
+"""Asyncpg repository for pgvector working-memory checkpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any, Protocol
+from uuid import UUID
+
+import asyncpg  # type: ignore[import-untyped]
+
+from backend.observability.decorators import traced_pg
+from backend.working_memory.models import WorkingMemoryPoint
+from backend.working_memory.safety import compute_payload_checksum, sanitize_metadata
+
+
+class PoolLike(Protocol):
+    async def fetchrow(self, query: str, *args: object) -> Any: ...
+    async def fetch(self, query: str, *args: object) -> list[Any]: ...
+    async def execute(self, query: str, *args: object) -> str: ...
+
+
+class WorkingMemoryCheckpointRepository:
+    """Persist and load working-memory checkpoints through asyncpg."""
+
+    def __init__(self, pool: asyncpg.Pool | PoolLike) -> None:
+        self._pool = pool
+
+    @traced_pg("working_memory_snapshots", "INSERT")
+    async def create_snapshot_header(
+        self,
+        *,
+        agent_id: str,
+        session_id: str,
+        snapshot_epoch: int,
+        collection_name: str,
+        vector_name: str,
+        embedding_model: str,
+        vector_dim: int,
+        snapshot_kind: str,
+        point_count: int,
+        checksum: str,
+        expires_at: datetime | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> str:
+        row = await self._pool.fetchrow(
+            """
+            INSERT INTO working_memory_snapshots (
+                agent_id, session_id, snapshot_epoch, collection_name, vector_name,
+                embedding_model, vector_dim, snapshot_kind, point_count, checksum,
+                expires_at, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            RETURNING snapshot_id
+            """,
+            agent_id,
+            UUID(session_id),
+            snapshot_epoch,
+            collection_name,
+            vector_name,
+            embedding_model,
+            vector_dim,
+            snapshot_kind,
+            point_count,
+            checksum,
+            expires_at,
+            sanitize_metadata(metadata),
+        )
+        return str(row["snapshot_id"])
+
+    @traced_pg("working_memory_snapshot_points", "INSERT")
+    async def insert_snapshot_points(self, *, snapshot_id: str, points: Sequence[WorkingMemoryPoint]) -> None:
+        for point in points:
+            await self._pool.execute(
+                """
+                INSERT INTO working_memory_snapshot_points (
+                    snapshot_id, point_id, agent_id, session_id, memory_kind,
+                    source_ref, topic, safe_summary, embedding_model, vector_dim,
+                    memory_vector, importance, recency_ts, expires_at,
+                    payload_checksum, metadata, created_at
+                )
+                VALUES (
+                    $1, $2, $3, $4, $5,
+                    $6, $7, $8, $9, $10,
+                    $11::vector, $12, $13, $14,
+                    $15, $16, $17
+                )
+                ON CONFLICT (snapshot_id, point_id) DO UPDATE SET
+                    payload_checksum = EXCLUDED.payload_checksum,
+                    metadata = EXCLUDED.metadata
+                """,
+                UUID(snapshot_id),
+                point.point_id,
+                point.agent_id,
+                point.session_id,
+                point.memory_kind,
+                point.source_ref,
+                point.topic,
+                point.safe_summary,
+                point.embedding_model,
+                point.vector_dim,
+                _vector_literal(point.vector),
+                point.importance,
+                point.recency_ts,
+                point.expires_at,
+                point.payload_checksum,
+                point.metadata,
+                point.created_at,
+            )
+
+    async def get_latest_snapshot(self, *, agent_id: str, session_id: str) -> dict[str, Any] | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT *
+            FROM working_memory_snapshots
+            WHERE agent_id = $1 AND session_id = $2
+              AND (expires_at IS NULL OR expires_at > NOW())
+            ORDER BY snapshot_epoch DESC, created_at DESC
+            LIMIT 1
+            """,
+            agent_id,
+            UUID(session_id),
+        )
+        return dict(row) if row is not None else None
+
+    async def load_snapshot_points(self, snapshot_id: str) -> list[WorkingMemoryPoint]:
+        rows = await self._pool.fetch(
+            """
+            SELECT *
+            FROM working_memory_snapshot_points
+            WHERE snapshot_id = $1
+            ORDER BY created_at ASC, point_id ASC
+            """,
+            UUID(snapshot_id),
+        )
+        return [_point_from_row(dict(row)) for row in rows]
+
+    async def mark_snapshot_restored(self, snapshot_id: str) -> None:
+        await self._pool.execute(
+            """
+            UPDATE working_memory_snapshots
+            SET metadata = metadata || '{"restored": true}'::jsonb
+            WHERE snapshot_id = $1
+            """,
+            UUID(snapshot_id),
+        )
+
+    async def expire_old_snapshots(self, before_ts: datetime) -> int:
+        result = await self._pool.execute(
+            """
+            DELETE FROM working_memory_snapshots
+            WHERE expires_at IS NOT NULL AND expires_at < $1
+            """,
+            before_ts,
+        )
+        return _rows_from_status(result)
+
+    async def validate_snapshot_checksum(self, snapshot_id: str) -> bool:
+        header = await self._pool.fetchrow(
+            "SELECT checksum FROM working_memory_snapshots WHERE snapshot_id = $1",
+            UUID(snapshot_id),
+        )
+        if header is None:
+            return False
+        rows = await self._pool.fetch(
+            """
+            SELECT point_id, payload_checksum
+            FROM working_memory_snapshot_points
+            WHERE snapshot_id = $1
+            ORDER BY point_id ASC
+            """,
+            UUID(snapshot_id),
+        )
+        computed = compute_payload_checksum({"points": [dict(row) for row in rows]})
+        return bool(computed == header["checksum"])
+
+
+def _vector_literal(vector: Sequence[float]) -> str:
+    return "[" + ",".join(str(float(item)) for item in vector) + "]"
+
+
+def _point_from_row(row: dict[str, Any]) -> WorkingMemoryPoint:
+    vector_value = row.get("memory_vector", [])
+    if isinstance(vector_value, str):
+        vector = tuple(float(item) for item in vector_value.strip("[]").split(",") if item)
+    else:
+        vector = tuple(float(item) for item in vector_value)
+    return WorkingMemoryPoint(
+        point_id=str(row["point_id"]),
+        agent_id=str(row["agent_id"]),
+        session_id=row["session_id"] if isinstance(row["session_id"], UUID) else UUID(str(row["session_id"])),
+        memory_kind=str(row["memory_kind"]),  # type: ignore[arg-type]
+        vector=vector,
+        vector_dim=int(row["vector_dim"]),
+        recency_ts=row["recency_ts"],
+        created_at=row["created_at"],
+        updated_at=row["created_at"],
+        expires_at=row["expires_at"],
+        ttl_seconds=max(1, int((row["expires_at"] - row["created_at"]).total_seconds())) if row["expires_at"] else 1,
+        embedding_model=str(row["embedding_model"]),
+        source_ref=row.get("source_ref"),
+        topic=row.get("topic"),
+        importance=float(row["importance"]) if row.get("importance") is not None else 0.5,
+        safe_summary=row.get("safe_summary"),
+        metadata=dict(row.get("metadata") or {}),
+    )
+
+
+def _rows_from_status(status: str) -> int:
+    try:
+        return int(status.rsplit(" ", 1)[-1])
+    except ValueError:
+        return 0

--- a/backend/working_memory/checkpoint_repository.py
+++ b/backend/working_memory/checkpoint_repository.py
@@ -32,7 +32,7 @@ class WorkingMemoryCheckpointRepository:
         *,
         agent_id: str,
         session_id: str,
-        snapshot_epoch: int,
+        snapshot_epoch: int | None,
         collection_name: str,
         vector_name: str,
         embedding_model: str,
@@ -45,12 +45,20 @@ class WorkingMemoryCheckpointRepository:
     ) -> str:
         row = await self._pool.fetchrow(
             """
+            WITH locked AS (
+                SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2::text))
+            ),
+            next_epoch AS (
+                SELECT COALESCE($3::bigint, COALESCE(MAX(snapshot_epoch), 0) + 1) AS snapshot_epoch
+                FROM working_memory_snapshots, locked
+                WHERE agent_id = $1 AND session_id = $2
+            )
             INSERT INTO working_memory_snapshots (
                 agent_id, session_id, snapshot_epoch, collection_name, vector_name,
                 embedding_model, vector_dim, snapshot_kind, point_count, checksum,
                 expires_at, metadata
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+            VALUES ($1, $2, (SELECT snapshot_epoch FROM next_epoch), $4, $5, $6, $7, $8, $9, $10, $11, $12)
             RETURNING snapshot_id
             """,
             agent_id,

--- a/backend/working_memory/cleanup.py
+++ b/backend/working_memory/cleanup.py
@@ -1,0 +1,40 @@
+"""Cleanup helpers for expired working-memory points."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from backend.observability.decorators import traced_cache
+from backend.working_memory.config import WorkingMemorySettings
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupResult:
+    status: str
+    deleted_count: int
+
+
+class CleanupStore(Protocol):
+    async def delete_expired_points(self, *, agent_id: str | None = None, session_id: str | None = None) -> int:
+        ...
+
+
+class CleanupService:
+    def __init__(self, *, store: CleanupStore, settings: WorkingMemorySettings) -> None:
+        self._store = store
+        self._settings = settings
+
+    @traced_cache(operation="working_memory.cleanup", collection="quimera_working_memory")
+    async def cleanup_expired(self, *, agent_id: str | None = None, session_id: str | None = None) -> CleanupResult:
+        if not self._settings.cleanup_enabled:
+            return CleanupResult(status="disabled", deleted_count=0)
+        _assert_cleanup_collection(self._settings.collection_name)
+        deleted = await self._store.delete_expired_points(agent_id=agent_id, session_id=session_id)
+        return CleanupResult(status="ok", deleted_count=deleted)
+
+
+def _assert_cleanup_collection(collection_name: str) -> None:
+    if collection_name == "quimera_working_memory" or collection_name.startswith("quimera_working_memory_test_"):
+        return
+    raise ValueError("cleanup is only allowed for working memory collections")

--- a/backend/working_memory/config.py
+++ b/backend/working_memory/config.py
@@ -1,0 +1,81 @@
+"""Settings for QUIMERA hot working memory."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal, Self
+from urllib.parse import urlparse
+
+from pydantic import AliasChoices, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+WorkingMemoryDistance = Literal["Cosine", "Dot", "Euclid", "Manhattan"]
+
+
+class WorkingMemorySettings(BaseSettings):
+    """Environment-backed settings for Qdrant working memory."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="QUIMERA_WM_",
+        env_ignore_empty=True,
+        extra="ignore",
+    )
+
+    enabled: bool = True
+    qdrant_url: str = "http://127.0.0.1:6333"
+    collection_name: str = Field(
+        default="quimera_working_memory",
+        validation_alias=AliasChoices("QUIMERA_WM_COLLECTION", "collection_name"),
+    )
+    vector_name: str = "work-dense"
+    vector_size: int = Field(default=768, gt=0)
+    distance: WorkingMemoryDistance = "Cosine"
+    default_ttl_seconds: int = Field(default=3600, gt=0)
+    max_points_per_session: int = Field(default=512, gt=0)
+    snapshot_every_writes: int = Field(default=20, gt=0)
+    snapshot_interval_seconds: int = Field(default=300, gt=0)
+    restore_enabled: bool = False
+    cleanup_enabled: bool = False
+
+    @field_validator("qdrant_url", mode="after")
+    @classmethod
+    def validate_local_qdrant_url(cls, value: str) -> str:
+        clean = value.strip()
+        parsed = urlparse(clean)
+        if parsed.scheme != "http":
+            raise ValueError("working memory qdrant_url must use local http")
+        if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+            raise ValueError("working memory qdrant_url must be loopback-local")
+        return clean
+
+    @field_validator("collection_name", mode="after")
+    @classmethod
+    def validate_collection_name(cls, value: str) -> str:
+        clean = value.strip()
+        if not clean.startswith("quimera_working_memory"):
+            raise ValueError("working memory collection must use quimera_working_memory prefix")
+        if clean in {"quimera_knowledge", "quimera_query_cache", "quimera_llm_cache"}:
+            raise ValueError("working memory collection must not reuse knowledge/cache collections")
+        return clean
+
+    @field_validator("vector_name", mode="after")
+    @classmethod
+    def validate_text(cls, value: str) -> str:
+        clean = value.strip()
+        if not clean:
+            raise ValueError("working memory text setting cannot be empty")
+        return clean
+
+    @model_validator(mode="after")
+    def validate_runtime_bounds(self) -> Self:
+        if self.collection_name in {"quimera_knowledge", "quimera_query_cache", "quimera_llm_cache"}:
+            raise ValueError("working memory collection must be isolated")
+        return self
+
+
+@lru_cache(maxsize=1)
+def get_working_memory_settings() -> WorkingMemorySettings:
+    """Return cached working-memory settings."""
+
+    return WorkingMemorySettings()

--- a/backend/working_memory/metrics.py
+++ b/backend/working_memory/metrics.py
@@ -1,0 +1,24 @@
+"""Safe metric names for working memory instrumentation."""
+
+from __future__ import annotations
+
+
+WM_STAGE = "working_memory"
+WM_UPSERT_SPAN = "working_memory.upsert"
+WM_QUERY_SPAN = "working_memory.query"
+WM_SNAPSHOT_SPAN = "working_memory.snapshot"
+WM_RESTORE_SPAN = "working_memory.restore"
+WM_CLEANUP_SPAN = "working_memory.cleanup"
+
+SAFE_WORKING_MEMORY_ATTRIBUTES = frozenset(
+    {
+        "quimera.agent_id",
+        "quimera.session_id",
+        "quimera.stage",
+        "cache.collection",
+        "working_memory.point_count",
+        "working_memory.snapshot_id",
+        "working_memory.restore_count",
+        "latency.total_ms",
+    }
+)

--- a/backend/working_memory/models.py
+++ b/backend/working_memory/models.py
@@ -1,0 +1,175 @@
+"""Immutable value models for hot working memory."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from backend.working_memory.safety import (
+    compute_payload_checksum,
+    sanitize_metadata,
+    validate_safe_payload,
+    validate_safe_summary,
+)
+
+
+SCHEMA_VERSION_POINT_V1 = "working-memory-point-v1"
+MemoryKind = Literal["turn_summary", "agent_state", "scratchpad", "handoff", "tool_observation"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WorkingMemoryPoint:
+    """A single hot working-memory point.
+
+    The vector is intentionally excluded from repr and from Qdrant payload.
+    """
+
+    point_id: str
+    agent_id: str
+    session_id: UUID
+    memory_kind: MemoryKind
+    vector: tuple[float, ...] = field(repr=False)
+    vector_dim: int
+    recency_ts: datetime
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime
+    ttl_seconds: int
+    embedding_model: str
+    source_ref: str | None = None
+    topic: str | None = None
+    task_id: str | None = None
+    importance: float = 0.5
+    checkpoint_id: str | None = None
+    safe_summary: str | None = field(default=None, repr=False)
+    metadata: dict[str, Any] = field(default_factory=dict, repr=False)
+    schema_version: str = SCHEMA_VERSION_POINT_V1
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.point_id, "point_id")
+        _require_non_empty(self.agent_id, "agent_id")
+        _require_non_empty(self.embedding_model, "embedding_model")
+        if not isinstance(self.session_id, UUID):
+            raise TypeError("session_id must be a UUID")
+        if self.memory_kind not in ("turn_summary", "agent_state", "scratchpad", "handoff", "tool_observation"):
+            raise ValueError("memory_kind is unsupported")
+        _validate_vector(self.vector)
+        if self.vector_dim != len(self.vector):
+            raise ValueError("vector_dim must match vector length")
+        if not 0.0 <= self.importance <= 1.0:
+            raise ValueError("importance must be between 0.0 and 1.0")
+        for field_name in ("recency_ts", "created_at", "updated_at", "expires_at"):
+            _require_tzaware(getattr(self, field_name), field_name)
+        if self.expires_at <= self.created_at:
+            raise ValueError("expires_at must be greater than created_at")
+        if self.ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be > 0")
+        if self.schema_version != SCHEMA_VERSION_POINT_V1:
+            raise ValueError("schema_version must be working-memory-point-v1")
+        object.__setattr__(self, "safe_summary", validate_safe_summary(self.safe_summary))
+        object.__setattr__(self, "metadata", sanitize_metadata(validate_safe_payload(self.metadata)))
+
+    @property
+    def payload_checksum(self) -> str:
+        """Return checksum over the safe payload, excluding the checksum itself."""
+
+        return compute_payload_checksum(self._payload_without_checksum())
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        resolved = now or datetime.now(UTC)
+        _require_tzaware(resolved, "now")
+        return self.expires_at <= resolved
+
+    def to_qdrant_payload(self) -> dict[str, Any]:
+        """Return safe Qdrant payload with no vector or raw content."""
+
+        payload = self._payload_without_checksum()
+        payload["payload_checksum"] = self.payload_checksum
+        return payload
+
+    def _payload_without_checksum(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "agent_id": self.agent_id,
+            "session_id": str(self.session_id),
+            "task_id": self.task_id,
+            "topic": self.topic,
+            "memory_kind": self.memory_kind,
+            "source_ref": self.source_ref,
+            "importance": self.importance,
+            "recency_ts": self.recency_ts.isoformat(),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "ttl_seconds": self.ttl_seconds,
+            "embedding_model": self.embedding_model,
+            "vector_dim": self.vector_dim,
+            "checkpoint_id": self.checkpoint_id,
+            "safe_summary": self.safe_summary,
+            "metadata": self.metadata,
+        }
+
+
+def point_from_payload(*, point_id: str, vector: tuple[float, ...], payload: dict[str, Any]) -> WorkingMemoryPoint:
+    """Build a point from a Qdrant/Postgres payload."""
+
+    return WorkingMemoryPoint(
+        point_id=point_id,
+        agent_id=str(payload["agent_id"]),
+        session_id=UUID(str(payload["session_id"])),
+        memory_kind=str(payload["memory_kind"]),  # type: ignore[arg-type]
+        vector=vector,
+        vector_dim=int(payload["vector_dim"]),
+        recency_ts=_parse_datetime(payload["recency_ts"]),
+        created_at=_parse_datetime(payload["created_at"]),
+        updated_at=_parse_datetime(payload.get("updated_at", payload["created_at"])),
+        expires_at=_parse_datetime(payload["expires_at"]),
+        ttl_seconds=int(payload["ttl_seconds"]),
+        embedding_model=str(payload["embedding_model"]),
+        source_ref=_optional_str(payload.get("source_ref")),
+        topic=_optional_str(payload.get("topic")),
+        task_id=_optional_str(payload.get("task_id")),
+        importance=float(payload.get("importance", 0.5)),
+        checkpoint_id=_optional_str(payload.get("checkpoint_id")),
+        safe_summary=_optional_str(payload.get("safe_summary")),
+        metadata=dict(payload.get("metadata", {})) if isinstance(payload.get("metadata"), dict) else {},
+    )
+
+
+def _parse_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    _require_tzaware(parsed, "datetime")
+    return parsed
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+
+
+def _require_tzaware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+def _validate_vector(vector: tuple[float, ...]) -> None:
+    if not vector:
+        raise ValueError("vector cannot be empty")
+    for item in vector:
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise TypeError("vector must contain numeric values")
+        if not math.isfinite(float(item)):
+            raise ValueError("vector must contain finite values")

--- a/backend/working_memory/qdrant_store.py
+++ b/backend/working_memory/qdrant_store.py
@@ -1,0 +1,308 @@
+"""Qdrant hot-path store for QUIMERA working memory."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http import models
+
+from backend.observability.decorators import traced_cache
+from backend.working_memory.config import WorkingMemoryDistance, WorkingMemorySettings
+from backend.working_memory.models import WorkingMemoryPoint, point_from_payload
+
+
+WORKING_MEMORY_PAYLOAD_INDEXES: Mapping[str, models.PayloadSchemaType] = {
+    "agent_id": models.PayloadSchemaType.KEYWORD,
+    "session_id": models.PayloadSchemaType.KEYWORD,
+    "task_id": models.PayloadSchemaType.KEYWORD,
+    "memory_kind": models.PayloadSchemaType.KEYWORD,
+    "topic": models.PayloadSchemaType.KEYWORD,
+    "expires_at": models.PayloadSchemaType.DATETIME,
+    "checkpoint_id": models.PayloadSchemaType.KEYWORD,
+    "schema_version": models.PayloadSchemaType.KEYWORD,
+    "importance": models.PayloadSchemaType.FLOAT,
+}
+
+
+class WorkingMemoryQdrantClient(Protocol):
+    async def collection_exists(self, **kwargs: Any) -> bool: ...
+    async def create_collection(self, **kwargs: Any) -> Any: ...
+    async def get_collection(self, **kwargs: Any) -> Any: ...
+    async def create_payload_index(self, **kwargs: Any) -> Any: ...
+    async def upsert(self, **kwargs: Any) -> Any: ...
+    async def query_points(self, **kwargs: Any) -> Any: ...
+    async def scroll(self, **kwargs: Any) -> tuple[list[Any], Any]: ...
+    async def set_payload(self, **kwargs: Any) -> Any: ...
+    async def delete(self, **kwargs: Any) -> Any: ...
+
+
+class WorkingMemoryQdrantStore:
+    """Dedicated Qdrant collection for small, restorable working memory."""
+
+    def __init__(
+        self,
+        client: AsyncQdrantClient | WorkingMemoryQdrantClient,
+        settings: WorkingMemorySettings,
+    ) -> None:
+        self._client = client
+        self._settings = settings
+
+    async def ensure_collection(self) -> None:
+        if await self._client.collection_exists(collection_name=self._settings.collection_name):
+            await self.assert_collection_compatible()
+        else:
+            await self._client.create_collection(
+                collection_name=self._settings.collection_name,
+                vectors_config={
+                    self._settings.vector_name: models.VectorParams(
+                        size=self._settings.vector_size,
+                        distance=qdrant_distance(self._settings.distance),
+                        on_disk=False,
+                    )
+                },
+                optimizers_config=models.OptimizersConfigDiff(default_segment_number=2),
+            )
+        for field_name, field_schema in WORKING_MEMORY_PAYLOAD_INDEXES.items():
+            await self._client.create_payload_index(
+                collection_name=self._settings.collection_name,
+                field_name=field_name,
+                field_schema=field_schema,
+            )
+
+    async def assert_collection_compatible(self) -> None:
+        info = await self._client.get_collection(collection_name=self._settings.collection_name)
+        vectors = _extract_vectors_config(info)
+        if self._settings.vector_name not in vectors:
+            raise ValueError("working memory vector name mismatch")
+        vector_config = vectors[self._settings.vector_name]
+        raw_size = vector_config.get("size")
+        if not isinstance(raw_size, int):
+            raise ValueError("working memory vector size is invalid")
+        if raw_size != self._settings.vector_size:
+            raise ValueError("working memory vector size mismatch")
+        if _normalize_distance(str(vector_config["distance"])) != self._settings.distance:
+            raise ValueError("working memory distance mismatch")
+        if vector_config.get("on_disk") is True:
+            raise ValueError("working memory vector storage must be in-memory")
+
+    @traced_cache(operation="working_memory.upsert", collection="quimera_working_memory")
+    async def upsert_memory_point(self, point: WorkingMemoryPoint) -> str:
+        self._validate_vector_dim(point.vector)
+        await self._client.upsert(
+            collection_name=self._settings.collection_name,
+            points=[
+                models.PointStruct(
+                    id=point.point_id,
+                    vector={self._settings.vector_name: list(point.vector)},
+                    payload=point.to_qdrant_payload(),
+                )
+            ],
+            wait=True,
+        )
+        return point.point_id
+
+    @traced_cache(operation="working_memory.query", collection="quimera_working_memory")
+    async def query_working_memory(
+        self,
+        *,
+        agent_id: str,
+        session_id: str,
+        query_vector: Sequence[float],
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        clean_limit = _validate_limit(limit)
+        vector = self._validate_vector_dim(tuple(float(item) for item in query_vector))
+        result = await self._client.query_points(
+            collection_name=self._settings.collection_name,
+            query=list(vector),
+            using=self._settings.vector_name,
+            query_filter=_agent_session_filter(agent_id=agent_id, session_id=session_id),
+            limit=clean_limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        points = list(getattr(result, "points", []))
+        return [_safe_result_from_point(point) for point in points]
+
+    async def list_session_memory(self, *, agent_id: str, session_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        points, _ = await self._client.scroll(
+            collection_name=self._settings.collection_name,
+            scroll_filter=_agent_session_filter(agent_id=agent_id, session_id=session_id),
+            limit=_validate_limit(limit),
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [_safe_result_from_point(point) for point in points]
+
+    async def mark_checkpointed(self, *, point_ids: Iterable[str], checkpoint_id: str) -> None:
+        ids = [point_id for point_id in point_ids if point_id.strip()]
+        if not ids:
+            return
+        await self._client.set_payload(
+            collection_name=self._settings.collection_name,
+            payload={"checkpoint_id": checkpoint_id},
+            points=models.PointIdsList(points=cast(Any, ids)),
+            wait=True,
+        )
+
+    async def delete_expired_points(self, *, agent_id: str | None = None, session_id: str | None = None) -> int:
+        conditions: list[models.Condition] = [
+            models.FieldCondition(
+                key="expires_at",
+                range=models.DatetimeRange(lte=datetime.now(UTC)),
+            )
+        ]
+        if agent_id is not None:
+            conditions.append(models.FieldCondition(key="agent_id", match=models.MatchValue(value=agent_id)))
+        if session_id is not None:
+            conditions.append(models.FieldCondition(key="session_id", match=models.MatchValue(value=session_id)))
+        await self._client.delete(
+            collection_name=self._settings.collection_name,
+            points_selector=models.FilterSelector(filter=models.Filter(must=conditions)),
+            wait=True,
+        )
+        return 0
+
+    async def delete_session_points(self, *, agent_id: str, session_id: str) -> int:
+        await self._client.delete(
+            collection_name=self._settings.collection_name,
+            points_selector=models.FilterSelector(filter=_agent_session_filter(agent_id=agent_id, session_id=session_id)),
+            wait=True,
+        )
+        return 0
+
+    async def export_session_points_for_snapshot(self, *, agent_id: str, session_id: str, limit: int | None = None) -> list[WorkingMemoryPoint]:
+        points, _ = await self._client.scroll(
+            collection_name=self._settings.collection_name,
+            scroll_filter=_agent_session_filter(agent_id=agent_id, session_id=session_id),
+            limit=limit or self._settings.max_points_per_session,
+            with_payload=True,
+            with_vectors=True,
+        )
+        return [_point_from_qdrant_point(point, vector_name=self._settings.vector_name) for point in points]
+
+    async def restore_points_from_snapshot(self, points: list[WorkingMemoryPoint]) -> int:
+        if not points:
+            return 0
+        for point in points:
+            self._validate_vector_dim(point.vector)
+        await self._client.upsert(
+            collection_name=self._settings.collection_name,
+            points=[
+                models.PointStruct(
+                    id=point.point_id,
+                    vector={self._settings.vector_name: list(point.vector)},
+                    payload=point.to_qdrant_payload(),
+                )
+                for point in points
+            ],
+            wait=True,
+        )
+        return len(points)
+
+    def _validate_vector_dim(self, vector: Sequence[float]) -> tuple[float, ...]:
+        clean = tuple(float(item) for item in vector)
+        if len(clean) != self._settings.vector_size:
+            raise ValueError("working memory vector dimension mismatch")
+        return clean
+
+
+def qdrant_distance(distance: WorkingMemoryDistance) -> models.Distance:
+    if distance == "Cosine":
+        return models.Distance.COSINE
+    if distance == "Dot":
+        return models.Distance.DOT
+    if distance == "Euclid":
+        return models.Distance.EUCLID
+    if distance == "Manhattan":
+        return models.Distance.MANHATTAN
+    raise ValueError("unsupported working memory distance")
+
+
+def _agent_session_filter(*, agent_id: str, session_id: str) -> models.Filter:
+    UUID(session_id)
+    return models.Filter(
+        must=[
+            models.FieldCondition(key="agent_id", match=models.MatchValue(value=agent_id)),
+            models.FieldCondition(key="session_id", match=models.MatchValue(value=session_id)),
+        ]
+    )
+
+
+def _validate_limit(limit: int) -> int:
+    if not 1 <= limit <= 50:
+        raise ValueError("limit must be between 1 and 50")
+    return limit
+
+
+def _safe_result_from_point(point: Any) -> dict[str, Any]:
+    payload = dict(getattr(point, "payload", {}) or {})
+    return {
+        "point_id": str(getattr(point, "id", "")),
+        "score": float(getattr(point, "score", 0.0)),
+        "agent_id": payload.get("agent_id"),
+        "session_id": payload.get("session_id"),
+        "memory_kind": payload.get("memory_kind"),
+        "topic": payload.get("topic"),
+        "safe_summary": payload.get("safe_summary"),
+        "importance": payload.get("importance"),
+        "expires_at": payload.get("expires_at"),
+        "payload_checksum": payload.get("payload_checksum"),
+    }
+
+
+def _point_from_qdrant_point(point: Any, *, vector_name: str) -> WorkingMemoryPoint:
+    payload = dict(getattr(point, "payload", {}) or {})
+    vector_obj = getattr(point, "vector", {})
+    vector: object
+    if isinstance(vector_obj, Mapping):
+        vector = vector_obj.get(vector_name, ())
+    else:
+        vector = vector_obj
+    return point_from_payload(
+        point_id=str(getattr(point, "id")),
+        vector=tuple(float(item) for item in cast(Sequence[float], vector)),
+        payload=payload,
+    )
+
+
+def _extract_vectors_config(info: object) -> dict[str, dict[str, object]]:
+    raw = _to_mapping(info)
+    config = _safe_mapping(raw.get("config"))
+    params = _safe_mapping(config.get("params"))
+    vectors = params.get("vectors")
+    if isinstance(vectors, Mapping):
+        return {str(name): _safe_mapping(value) for name, value in vectors.items()}
+    params_obj = getattr(getattr(info, "config", None), "params", None)
+    vectors_obj = getattr(params_obj, "vectors", None)
+    if isinstance(vectors_obj, Mapping):
+        return {str(name): _to_mapping(value) for name, value in vectors_obj.items()}
+    return {}
+
+
+def _normalize_distance(distance: str) -> WorkingMemoryDistance:
+    normalized = distance.split(".")[-1].lower()
+    if normalized == "cosine":
+        return "Cosine"
+    if normalized == "dot":
+        return "Dot"
+    if normalized == "euclid":
+        return "Euclid"
+    if normalized == "manhattan":
+        return "Manhattan"
+    raise ValueError("unsupported working memory distance")
+
+
+def _to_mapping(value: object) -> dict[str, object]:
+    if hasattr(value, "model_dump"):
+        dumped = cast(Any, value).model_dump(mode="json", exclude_none=True)
+        return dict(dumped) if isinstance(dumped, Mapping) else {}
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _safe_mapping(value: object) -> dict[str, object]:
+    return _to_mapping(value)

--- a/backend/working_memory/restore_service.py
+++ b/backend/working_memory/restore_service.py
@@ -45,10 +45,18 @@ class RestoreReport:
 class RestoreService:
     """Merge or gated-replace restore service."""
 
-    def __init__(self, *, store: RestoreStore, repository: RestoreRepository, replace_enabled: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        store: RestoreStore,
+        repository: RestoreRepository,
+        replace_enabled: bool = False,
+        abort_on_checksum_fail: bool = False,
+    ) -> None:
         self._store = store
         self._repository = repository
         self._replace_enabled = replace_enabled
+        self._abort_on_checksum_fail = abort_on_checksum_fail
 
     async def restore_latest_snapshot(self, *, agent_id: str, session_id: str) -> RestoreReport:
         snapshot = await self._repository.get_latest_snapshot(agent_id=agent_id, session_id=session_id)
@@ -61,6 +69,15 @@ class RestoreService:
         if replace and not self._replace_enabled:
             raise ValueError("working memory replace restore is disabled")
         checksum_ok = await self._repository.validate_snapshot_checksum(snapshot_id)
+        if not checksum_ok and self._abort_on_checksum_fail:
+            return RestoreReport(
+                status="fail",
+                snapshot_id=snapshot_id,
+                restored_count=0,
+                skipped_expired_count=0,
+                checksum_ok=False,
+                warnings=["snapshot checksum mismatch; restore aborted"],
+            )
         points = await self._repository.load_snapshot_points(snapshot_id)
         now = datetime.now(UTC)
         active = [point for point in points if not point.is_expired(now)]

--- a/backend/working_memory/restore_service.py
+++ b/backend/working_memory/restore_service.py
@@ -1,0 +1,90 @@
+"""Restore working-memory Qdrant points from pgvector checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from backend.observability.decorators import traced_cache
+from backend.working_memory.models import WorkingMemoryPoint
+
+
+class RestoreStore(Protocol):
+    async def restore_points_from_snapshot(self, points: list[WorkingMemoryPoint]) -> int: ...
+    async def delete_session_points(self, *, agent_id: str, session_id: str) -> int: ...
+
+
+class RestoreRepository(Protocol):
+    async def get_latest_snapshot(self, *, agent_id: str, session_id: str) -> dict[str, Any] | None: ...
+    async def load_snapshot_points(self, snapshot_id: str) -> list[WorkingMemoryPoint]: ...
+    async def validate_snapshot_checksum(self, snapshot_id: str) -> bool: ...
+    async def mark_snapshot_restored(self, snapshot_id: str) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreReport:
+    status: str
+    snapshot_id: str | None
+    restored_count: int
+    skipped_expired_count: int
+    checksum_ok: bool
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "snapshot_id": self.snapshot_id,
+            "restored_count": self.restored_count,
+            "skipped_expired_count": self.skipped_expired_count,
+            "checksum_ok": self.checksum_ok,
+            "warnings": list(self.warnings),
+        }
+
+
+class RestoreService:
+    """Merge or gated-replace restore service."""
+
+    def __init__(self, *, store: RestoreStore, repository: RestoreRepository, replace_enabled: bool = False) -> None:
+        self._store = store
+        self._repository = repository
+        self._replace_enabled = replace_enabled
+
+    async def restore_latest_snapshot(self, *, agent_id: str, session_id: str) -> RestoreReport:
+        snapshot = await self._repository.get_latest_snapshot(agent_id=agent_id, session_id=session_id)
+        if snapshot is None:
+            return RestoreReport(status="skipped", snapshot_id=None, restored_count=0, skipped_expired_count=0, checksum_ok=False, warnings=["snapshot not found"])
+        return await self.restore_snapshot(str(snapshot["snapshot_id"]), agent_id=agent_id, session_id=session_id)
+
+    @traced_cache(operation="working_memory.restore", collection="quimera_working_memory")
+    async def restore_snapshot(self, snapshot_id: str, *, agent_id: str, session_id: str, replace: bool = False) -> RestoreReport:
+        if replace and not self._replace_enabled:
+            raise ValueError("working memory replace restore is disabled")
+        checksum_ok = await self._repository.validate_snapshot_checksum(snapshot_id)
+        points = await self._repository.load_snapshot_points(snapshot_id)
+        now = datetime.now(UTC)
+        active = [point for point in points if not point.is_expired(now)]
+        skipped = len(points) - len(active)
+        if replace:
+            await self._store.delete_session_points(agent_id=agent_id, session_id=session_id)
+        restored_count = await self._store.restore_points_from_snapshot(active)
+        await self._repository.mark_snapshot_restored(snapshot_id)
+        return RestoreReport(
+            status="ok" if checksum_ok else "warn",
+            snapshot_id=snapshot_id,
+            restored_count=restored_count,
+            skipped_expired_count=skipped,
+            checksum_ok=checksum_ok,
+            warnings=[] if checksum_ok else ["snapshot checksum mismatch"],
+        )
+
+    async def dry_run_restore(self, snapshot_id: str) -> RestoreReport:
+        points = await self._repository.load_snapshot_points(snapshot_id)
+        checksum_ok = await self._repository.validate_snapshot_checksum(snapshot_id)
+        return RestoreReport(status="dry_run", snapshot_id=snapshot_id, restored_count=len(points), skipped_expired_count=0, checksum_ok=checksum_ok)
+
+    async def verify_restored_count(self, snapshot_id: str) -> int:
+        return len(await self._repository.load_snapshot_points(snapshot_id))
+
+    async def verify_restored_checksum(self, snapshot_id: str) -> bool:
+        return await self._repository.validate_snapshot_checksum(snapshot_id)

--- a/backend/working_memory/safety.py
+++ b/backend/working_memory/safety.py
@@ -1,0 +1,146 @@
+"""Safety gates for hot working memory payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+
+FORBIDDEN_WORKING_MEMORY_KEYS = frozenset(
+    {
+        "prompt",
+        "raw_prompt",
+        "answer",
+        "response",
+        "completion",
+        "chunk",
+        "chunk_text",
+        "document_text",
+        "payload",
+        "authorization",
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "dsn",
+        "connection_string",
+        "vector",
+        "embedding",
+    }
+)
+SAFE_OPERATIONAL_KEYS = frozenset(
+    {
+        "embedding_model",
+        "vector_dim",
+        "source_ref",
+        "safe_summary",
+        "payload_checksum",
+        "point_id",
+        "agent_id",
+        "session_id",
+        "task_id",
+        "topic",
+        "memory_kind",
+        "importance",
+        "recency_ts",
+        "created_at",
+        "updated_at",
+        "expires_at",
+        "ttl_seconds",
+        "checkpoint_id",
+        "schema_version",
+        "metadata",
+        "checksum",
+        "points",
+        "count",
+    }
+)
+_SECRET_PATTERN = re.compile(
+    r"(authorization\s*:|bearer\s+[a-z0-9._-]+|sk-[a-z0-9_-]+|api[_-]?key|password|secret|postgresql://)",
+    re.IGNORECASE,
+)
+
+
+class WorkingMemorySafetyError(ValueError):
+    """Raised when working-memory data is unsafe to persist or report."""
+
+
+def validate_safe_payload(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    """Return mapping as a dict after rejecting unsafe keys recursively."""
+
+    _reject_sensitive_keys(mapping)
+    return dict(mapping)
+
+
+def sanitize_metadata(mapping: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return metadata with sensitive nested keys redacted, not persisted raw."""
+
+    if mapping is None:
+        return {}
+    return {str(key): _sanitize_value(str(key), value) for key, value in mapping.items()}
+
+
+def validate_safe_summary(text: str | None) -> str | None:
+    """Validate an optional short summary safe enough for MCP/tool output."""
+
+    if text is None:
+        return None
+    clean = text.strip()
+    if len(clean) > 512:
+        raise WorkingMemorySafetyError("safe_summary must be <= 512 characters")
+    if _SECRET_PATTERN.search(clean):
+        raise WorkingMemorySafetyError("safe_summary must not contain secret-like text")
+    return clean
+
+
+def compute_payload_checksum(mapping: Mapping[str, Any]) -> str:
+    """Return deterministic SHA-256 checksum for safe payload metadata."""
+
+    safe = validate_safe_payload(sanitize_metadata(mapping))
+    encoded = json.dumps(safe, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def assert_agent_session_scope(agent_id: str, session_id: str) -> None:
+    """Validate mandatory agent/session scope."""
+
+    if not agent_id.strip():
+        raise WorkingMemorySafetyError("agent_id cannot be empty")
+    try:
+        UUID(session_id)
+    except ValueError as exc:
+        raise WorkingMemorySafetyError("session_id must be a valid UUID") from exc
+
+
+def _reject_sensitive_keys(mapping: Mapping[str, Any]) -> None:
+    for key, value in mapping.items():
+        lowered = str(key).casefold()
+        if _is_sensitive_key(lowered):
+            raise WorkingMemorySafetyError(f"sensitive working-memory key is forbidden: {key}")
+        if isinstance(value, Mapping):
+            _reject_sensitive_keys(value)
+
+
+def _sanitize_value(key: str, value: Any) -> Any:
+    lowered = key.casefold()
+    if _is_sensitive_key(lowered):
+        return "[REDACTED]"
+    if isinstance(value, Mapping):
+        return {str(child_key): _sanitize_value(str(child_key), child_value) for child_key, child_value in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_value(key, item) for item in value]
+    if isinstance(value, str) and _SECRET_PATTERN.search(value):
+        return "[REDACTED]"
+    return value
+
+
+def _is_sensitive_key(lowered_key: str) -> bool:
+    if lowered_key in SAFE_OPERATIONAL_KEYS:
+        return False
+    if lowered_key in FORBIDDEN_WORKING_MEMORY_KEYS:
+        return True
+    return any(token in lowered_key for token in FORBIDDEN_WORKING_MEMORY_KEYS - {"vector", "embedding", "payload"})

--- a/backend/working_memory/snapshot_service.py
+++ b/backend/working_memory/snapshot_service.py
@@ -1,0 +1,89 @@
+"""Snapshot orchestration for working memory."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from itertools import count
+from typing import Any, Protocol
+
+from backend.observability.decorators import traced_cache
+from backend.working_memory.config import WorkingMemorySettings
+from backend.working_memory.models import WorkingMemoryPoint
+from backend.working_memory.safety import compute_payload_checksum
+
+
+class SnapshotStore(Protocol):
+    async def export_session_points_for_snapshot(self, *, agent_id: str, session_id: str, limit: int | None = None) -> list[WorkingMemoryPoint]: ...
+    async def mark_checkpointed(self, *, point_ids: Iterable[str], checkpoint_id: str) -> None: ...
+
+
+class SnapshotRepository(Protocol):
+    async def create_snapshot_header(self, **kwargs: Any) -> str: ...
+    async def insert_snapshot_points(self, *, snapshot_id: str, points: list[WorkingMemoryPoint]) -> None: ...
+
+
+_EPOCH_COUNTER = count(1)
+
+
+class SnapshotService:
+    """Create full or delta snapshots on demand; no daemon."""
+
+    def __init__(
+        self,
+        *,
+        store: SnapshotStore | None,
+        repository: SnapshotRepository | None,
+        settings: WorkingMemorySettings | None = None,
+    ) -> None:
+        self._store = store
+        self._repository = repository
+        self._settings = settings or WorkingMemorySettings()
+
+    @traced_cache(operation="working_memory.snapshot", collection="quimera_working_memory")
+    async def create_session_snapshot(self, *, agent_id: str, session_id: str, kind: str = "full") -> dict[str, Any]:
+        if self._store is None or self._repository is None:
+            raise RuntimeError("snapshot dependencies are not configured")
+        points = self.active_points(
+            await self._store.export_session_points_for_snapshot(agent_id=agent_id, session_id=session_id),
+            now=datetime.now(UTC),
+        )
+        checksum = compute_snapshot_checksum(points)
+        snapshot_id = await self._repository.create_snapshot_header(
+            agent_id=agent_id,
+            session_id=session_id,
+            snapshot_epoch=self.next_snapshot_epoch(agent_id, session_id),
+            collection_name=self._settings.collection_name,
+            vector_name=self._settings.vector_name,
+            embedding_model=points[0].embedding_model if points else "unknown",
+            vector_dim=points[0].vector_dim if points else self._settings.vector_size,
+            snapshot_kind=kind,
+            point_count=len(points),
+            checksum=checksum,
+            metadata={"kind": kind},
+        )
+        await self._repository.insert_snapshot_points(snapshot_id=snapshot_id, points=points)
+        await self._store.mark_checkpointed(point_ids=[point.point_id for point in points], checkpoint_id=snapshot_id)
+        return {"snapshot_id": snapshot_id, "point_count": len(points), "checksum": checksum}
+
+    async def create_delta_snapshot(self, *, agent_id: str, session_id: str, since_checkpoint_id: str) -> dict[str, Any]:
+        return await self.create_session_snapshot(agent_id=agent_id, session_id=session_id, kind="delta")
+
+    def active_points(self, points: Iterable[WorkingMemoryPoint], *, now: datetime) -> list[WorkingMemoryPoint]:
+        return [point for point in points if not point.is_expired(now)]
+
+    def next_snapshot_epoch(self, agent_id: str, session_id: str) -> int:
+        if not agent_id.strip() or not session_id.strip():
+            raise ValueError("agent_id and session_id are required")
+        return next(_EPOCH_COUNTER)
+
+    def should_snapshot(self, *, write_count: int, elapsed_seconds: int) -> bool:
+        return write_count >= self._settings.snapshot_every_writes or elapsed_seconds >= self._settings.snapshot_interval_seconds
+
+
+def compute_snapshot_checksum(points: Iterable[WorkingMemoryPoint]) -> str:
+    rows = [
+        {"point_id": point.point_id, "payload_checksum": point.payload_checksum}
+        for point in sorted(points, key=lambda item: item.point_id)
+    ]
+    return compute_payload_checksum({"points": rows})

--- a/backend/working_memory/snapshot_service.py
+++ b/backend/working_memory/snapshot_service.py
@@ -52,7 +52,7 @@ class SnapshotService:
         snapshot_id = await self._repository.create_snapshot_header(
             agent_id=agent_id,
             session_id=session_id,
-            snapshot_epoch=self.next_snapshot_epoch(agent_id, session_id),
+            snapshot_epoch=None,
             collection_name=self._settings.collection_name,
             vector_name=self._settings.vector_name,
             embedding_model=points[0].embedding_model if points else "unknown",

--- a/backend/working_memory/snapshot_service.py
+++ b/backend/working_memory/snapshot_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import UTC, datetime
-from itertools import count
+import time
 from typing import Any, Protocol
 
 from backend.observability.decorators import traced_cache
@@ -23,7 +23,7 @@ class SnapshotRepository(Protocol):
     async def insert_snapshot_points(self, *, snapshot_id: str, points: list[WorkingMemoryPoint]) -> None: ...
 
 
-_EPOCH_COUNTER = count(1)
+_LAST_EPOCH_MS = 0
 
 
 class SnapshotService:
@@ -75,7 +75,7 @@ class SnapshotService:
     def next_snapshot_epoch(self, agent_id: str, session_id: str) -> int:
         if not agent_id.strip() or not session_id.strip():
             raise ValueError("agent_id and session_id are required")
-        return next(_EPOCH_COUNTER)
+        return next_snapshot_epoch_ms()
 
     def should_snapshot(self, *, write_count: int, elapsed_seconds: int) -> bool:
         return write_count >= self._settings.snapshot_every_writes or elapsed_seconds >= self._settings.snapshot_interval_seconds
@@ -87,3 +87,14 @@ def compute_snapshot_checksum(points: Iterable[WorkingMemoryPoint]) -> str:
         for point in sorted(points, key=lambda item: item.point_id)
     ]
     return compute_payload_checksum({"points": rows})
+
+
+def next_snapshot_epoch_ms() -> int:
+    """Return a wall-clock millisecond epoch with a per-process monotonic guard."""
+
+    global _LAST_EPOCH_MS
+    current = time.time_ns() // 1_000_000
+    if current <= _LAST_EPOCH_MS:
+        current = _LAST_EPOCH_MS + 1
+    _LAST_EPOCH_MS = current
+    return current

--- a/docs/04_MEM/WORKING_MEMORY_QDRANT.md
+++ b/docs/04_MEM/WORKING_MEMORY_QDRANT.md
@@ -1,0 +1,27 @@
+# QUIMERA Working Memory Qdrant
+
+PR-10 implements the first hot vector working memory for active agent/session
+state.
+
+Canonical contract:
+
+- Qdrant collection `quimera_working_memory` is the hot path.
+- Named vector `work-dense` uses size `768`, distance `Cosine`, `on_disk=false`.
+- Postgres/pgvector checkpoints are the durable restore source.
+- Working memory is not HybridRAG, not semantic cache, and not canonical
+  long-term memory.
+- Agents must access working memory through repository/MCP/LiteLLM surfaces,
+  not direct SDK calls.
+
+Safety:
+
+- No raw prompt, response, answer, chunk, document text, vector, DSN, token,
+  password or secret in payloads, logs or reports.
+- `safe_summary` is capped at 512 characters.
+- All query and cleanup paths are scoped by `agent_id` and `session_id`.
+
+Restore:
+
+- Default restore merges points by ID.
+- Replace restore is disabled unless explicitly enabled.
+- Replace can only remove points for the same agent/session scope.

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -72,8 +72,10 @@ Implemented:
 - Added `abort_on_checksum_fail` to `RestoreService`. Default remains
   availability-first warn-and-restore; strict operators can now abort restore
   before any point is written when checksum validation fails.
-- Replaced module-level `count(1)` snapshot epochs with wall-clock millisecond
-  epochs plus a local monotonic guard, avoiding restart-to-1 behavior.
+- Replaced module-level `count(1)` snapshot epochs in the real snapshot flow
+  with PostgreSQL `MAX(snapshot_epoch) + 1` allocation under an advisory lock
+  scoped to `(agent_id, session_id)`, avoiding restart-to-1 behavior and
+  cross-process epoch races.
 - Documented that `integration/hybrid_fixture.py` uses `delete_collection` only
   for synthetic HybridRAG fixture teardown and not in working-memory runtime.
 
@@ -81,13 +83,15 @@ Validation:
 
 - `.venv/bin/python --version`: Python 3.12.13.
 - Required host Python 3.12 unit block:
-  66 passed.
+  68 passed.
 - PR-10 focused unit/integration block:
   70 passed / 4 skipped.
 - Full host Python 3.12 regression with `.venv/bin/python -m pytest`:
-  1889 passed / 65 skipped.
+  1891 passed / 65 skipped.
 - `uv run mypy --strict` on PR-10 working-memory/MCP/tests:
   success.
+- `uv run pyright` on PR-10 working-memory/MCP/tests:
+  0 errors / 0 warnings.
 
 ---
 

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -65,6 +65,30 @@ Operational note:
   human operator exports the explicit `QUIMERA_TEST_WM_*` variables and a
   test DSN.
 
+### RAG-01B PR-10 RC-01 — Restore Integrity and Host Python 3.12 Gate
+
+Implemented:
+
+- Added `abort_on_checksum_fail` to `RestoreService`. Default remains
+  availability-first warn-and-restore; strict operators can now abort restore
+  before any point is written when checksum validation fails.
+- Replaced module-level `count(1)` snapshot epochs with wall-clock millisecond
+  epochs plus a local monotonic guard, avoiding restart-to-1 behavior.
+- Documented that `integration/hybrid_fixture.py` uses `delete_collection` only
+  for synthetic HybridRAG fixture teardown and not in working-memory runtime.
+
+Validation:
+
+- `.venv/bin/python --version`: Python 3.12.13.
+- Required host Python 3.12 unit block:
+  66 passed.
+- PR-10 focused unit/integration block:
+  70 passed / 4 skipped.
+- Full host Python 3.12 regression with `.venv/bin/python -m pytest`:
+  1889 passed / 65 skipped.
+- `uv run mypy --strict` on PR-10 working-memory/MCP/tests:
+  success.
+
 ---
 
 ## RAG-01B PR-09 — Operational Hardening + Smoke CLI

--- a/docs/04_MEM/current_state.md
+++ b/docs/04_MEM/current_state.md
@@ -5,7 +5,65 @@
 > meaningful sessions.
 
 **Last updated:** 2026-06-06
-**Updated by:** Codex — RAG-01B PR-09 RC-01 operational smoke hardening
+**Updated by:** Codex — RAG-01B PR-10 working memory Qdrant + pgvector
+
+---
+
+## RAG-01B PR-10 — Working Memory Qdrant + pgvector Checkpoints
+
+Current branch: `rag-01b/pr-10-working-memory-qdrant-pgvector`
+Base branch: `rag-01b/pr-08-integration-smoke` after PR-09 merge commit
+`a0870b14d441de9731c84cb3e027ae76fdbb787c`.
+
+Implemented:
+
+- Added accepted ADR-005 in both ADR trees:
+  `docs/adr/ADR-005-qdrant-working-memory-pgvector-checkpoints.md` and
+  `docs/ADR/ADR-005-qdrant-working-memory-pgvector-checkpoints.md`.
+- Added PR-10 SDD and memory handoff:
+  `docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md` and
+  `docs/04_MEM/WORKING_MEMORY_QDRANT.md`.
+- Added `backend/working_memory/` with settings, immutable models, safety
+  gates, Qdrant hot store, pgvector checkpoint repository, snapshot service,
+  restore service, cleanup and safe metric names.
+- Added pgvector checkpoint SQL:
+  `infra/postgres/sql/020_working_memory_checkpoints.sql`.
+- Added working-memory MCP tools/server on loopback Streamable HTTP
+  `127.0.0.1:8813/mcp`.
+- Registered `quimera-working-memory` in host LiteLLM config and allowed only
+  safe Agentic0 health/query tools by default. Upsert/snapshot are optional
+  write tools; restore/cleanup remain disabled by default.
+- Added degraded-safe working-memory smoke report:
+  `integration/working_memory_smoke.py` and
+  `evaluation/results/rag_01b_pr10_working_memory_smoke.json`.
+
+Scope explicitly not changed:
+
+- No Redis, Dragonfly or Python/RAM backend decision.
+- No HybridRAG collection mutation.
+- No `quimera_query_cache` or `quimera_llm_cache` mutation.
+- No pgvector ANN index as hot path.
+- No daemon/scheduler/dashboard/provider remoto/real data.
+- No `delete_collection` flow for working memory.
+
+Validation:
+
+- PR-10 unit/integration block: 67 passed / 4 skipped.
+- PR-10 + LiteLLM/MCP registration block: 75 passed / 4 skipped.
+- `uv run mypy --strict` on PR-10 working-memory, MCP, LiteLLM config and
+  tests: success.
+- `uv run pyright` on the same scope: 0 errors.
+- `uv run python -m infra.litellm.config_validator`: success with one expected
+  qdrant-semantic fallback warning.
+- `uv run python -m integration.working_memory_smoke`: generated skipped safe
+  smoke artifact because live stack was not requested.
+- `git diff --check`: clean.
+
+Operational note:
+
+- Live Qdrant/Postgres restore tests are opt-in and skip cleanly unless the
+  human operator exports the explicit `QUIMERA_TEST_WM_*` variables and a
+  test DSN.
 
 ---
 

--- a/docs/04_MEM/decisions.md
+++ b/docs/04_MEM/decisions.md
@@ -326,3 +326,22 @@ series, K-lines, quantitative features, model runs and Kronos forecasts.
 canonical datastore. Kronos has no separate persistent memory and must read
 derived K-line frames from PostgreSQL/TimescaleDB projections and write
 forecasts/model run metadata back into PostgreSQL/TimescaleDB.
+
+---
+
+## ADR-005 - Qdrant Working Memory with pgvector Checkpoints
+
+**Date:** 2026-06-06 | **Status:** Accepted | **File:** `docs/adr/ADR-005-qdrant-working-memory-pgvector-checkpoints.md`
+
+**Decision:** Qdrant is the initial hot backend for QUIMERA Working Memory.
+The default collection is `quimera_working_memory`, named vector is
+`work-dense`, vector size is `768`, distance is `Cosine`, and Qdrant vector
+storage is `on_disk=false`.
+
+**Checkpoint rule:** Postgres/pgvector stores durable checkpoints in
+`working_memory_snapshots` and `working_memory_snapshot_points`. pgvector is a
+restore/checkpoint layer, not the hot path.
+
+**Boundary:** This does not decide Redis, Dragonfly or Python/RAM backends
+forever. HybridRAG, semantic cache and Postgres/Timescale canonical memory keep
+their existing responsibilities.

--- a/docs/ADR/ADR-005-qdrant-working-memory-pgvector-checkpoints.md
+++ b/docs/ADR/ADR-005-qdrant-working-memory-pgvector-checkpoints.md
@@ -1,0 +1,36 @@
+# ADR-005 - Qdrant Working Memory with pgvector Checkpoints
+
+Status: Accepted
+
+## Decision
+
+Qdrant is the initial backend for QUIMERA Working Memory.
+
+- Default collection: `quimera_working_memory`
+- Vector name: `work-dense`
+- Vector size: `768`
+- Distance: `Cosine`
+- Qdrant vector storage: `on_disk=false`
+- Postgres/pgvector checkpoint tables:
+  - `working_memory_snapshots`
+  - `working_memory_snapshot_points`
+
+pgvector is a checkpoint and restore layer, not the hot path. The fast backend
+remains pluggable.
+
+## Consequences
+
+- Qdrant working memory can be erased and rebuilt from checkpoint.
+- Restore after Qdrant loss is a required behavior.
+- Every checkpoint needs a checksum.
+- TTL is mandatory for working-memory points.
+- Payloads must be sanitized.
+- Logs and reports must not include raw prompt, response, chunk, vector, DSN or
+  secrets.
+
+## Non-Goals
+
+- Choosing Redis definitively.
+- Replacing HybridRAG.
+- Replacing Qdrant knowledge collections.
+- Replacing Postgres/Timescale canonical memory.

--- a/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
+++ b/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
@@ -51,6 +51,17 @@ Restore upserts points back into Qdrant. Replace mode is disabled unless
 explicitly enabled and may only delete points for the same `agent_id` and
 `session_id`.
 
+Checksum mismatch defaults to availability-first behavior: restore continues
+with `status=warn`, `checksum_ok=false` and an explicit warning. Operators that
+prefer integrity over availability can construct `RestoreService` with
+`abort_on_checksum_fail=true`; in that mode no point is restored after checksum
+mismatch.
+
+`snapshot_epoch` is a wall-clock millisecond epoch with a local monotonic guard.
+It does not reset to `1` after process restart and remains sortable across
+process lifetimes. PostgreSQL still enforces uniqueness by
+`(agent_id, session_id, snapshot_epoch)`.
+
 ## TTL And Cleanup
 
 Every point has `expires_at` and `ttl_seconds`. Cleanup only removes expired
@@ -86,6 +97,10 @@ No Redis, Dragonfly, final Python/RAM backend decision, new knowledge
 collection, HybridRAG mutation, cache collection mutation, pgvector ANN hot
 path, scheduler daemon, dashboard, remote provider, real data or real
 collection deletion.
+
+`integration/hybrid_fixture.py` uses `delete_collection` only as teardown for
+synthetic HybridRAG test collections. PR-10 does not add `delete_collection` to
+`backend/working_memory` or the working-memory MCP path.
 
 ## Future Handoff
 

--- a/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
+++ b/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
@@ -1,0 +1,94 @@
+# RAG-01B PR-10 - Working Memory Qdrant + pgvector Checkpoints
+
+## Objective
+
+O PR-10 introduz uma working memory vetorial quente em Qdrant e usa
+Postgres/pgvector como checkpoint durável. A coleção working memory é pequena,
+ativa e restaurável; ela não substitui Qdrant HybridRAG nem Postgres/Timescale
+como memória canônica.
+
+## Decision
+
+Qdrant is the first hot working-memory backend. The backend remains pluggable
+for future Redis, Python/RAM or Dragonfly benchmarks. Postgres/pgvector stores
+durable checkpoints only.
+
+## Memory Boundaries
+
+Working memory: short-lived active agent/session state for current reasoning.
+HybridRAG: dense/sparse retrieval over knowledge collections.
+Long-term memory: Postgres/Timescale canonical relational-temporal memory.
+Semantic cache: Qdrant/LiteLLM response/retrieval cache collections.
+
+## Qdrant Collection Design
+
+- Collection: `quimera_working_memory`
+- Vector name: `work-dense`
+- Vector size: `768`
+- Distance: `Cosine`
+- Storage: `on_disk=false`
+- Required filters: `agent_id` and `session_id`
+- Default limit: `10`; maximum limit: `50`
+- No vector returned by default
+
+Payload contains only safe operational fields: IDs, memory kind, source refs,
+topic, importance, recency, TTL, checksum, safe summary and sanitized metadata.
+
+## pgvector Checkpoint Design
+
+Checkpoint tables:
+
+- `working_memory_snapshots`
+- `working_memory_snapshot_points`
+
+The point table stores `memory_vector vector(768)` for restore. No HNSW/IVFFlat
+index is created in this PR because pgvector is not the hot path.
+
+## Snapshot/Restore Lifecycle
+
+Snapshots are explicit by CLI/MCP or by caller-controlled autosnapshot policy.
+Restore upserts points back into Qdrant. Replace mode is disabled unless
+explicitly enabled and may only delete points for the same `agent_id` and
+`session_id`.
+
+## TTL And Cleanup
+
+Every point has `expires_at` and `ttl_seconds`. Cleanup only removes expired
+points from `quimera_working_memory` or test-prefixed collections.
+
+## Safety/PII
+
+Forbidden fields include prompt, response, answer, chunk text, document text,
+raw payloads, vectors, secrets, tokens, passwords, DSNs and connection strings.
+Reports and logs expose counts, IDs, checksums and safe summaries only.
+
+## MCP Tools
+
+The working-memory MCP server uses Streamable HTTP on `127.0.0.1:8813/mcp`.
+Tools: health, upsert, query, snapshot, restore and cleanup. Restore and cleanup
+are gated by settings.
+
+## OTel/Metrics
+
+Safe spans cover working-memory upsert, query, snapshot, restore and cleanup.
+Attributes are limited to agent/session IDs, collection name, counts, snapshot
+ID and latency.
+
+## Test Plan
+
+Unit tests cover settings, models, safety, Qdrant collection contract, SQL
+schema, snapshot/restore, cleanup and MCP tools. Integration tests are marked
+`integration` and skip cleanly when Qdrant/Postgres are unavailable.
+
+## Negative Scope
+
+No Redis, Dragonfly, final Python/RAM backend decision, new knowledge
+collection, HybridRAG mutation, cache collection mutation, pgvector ANN hot
+path, scheduler daemon, dashboard, remote provider, real data or real
+collection deletion.
+
+## Future Handoff
+
+- Redis/Python/RAM alternatives benchmark.
+- Compacting/reflection policy for active memory.
+- Multi-agent memory arbitration.

--- a/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
+++ b/docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md
@@ -57,9 +57,11 @@ prefer integrity over availability can construct `RestoreService` with
 `abort_on_checksum_fail=true`; in that mode no point is restored after checksum
 mismatch.
 
-`snapshot_epoch` is a wall-clock millisecond epoch with a local monotonic guard.
-It does not reset to `1` after process restart and remains sortable across
-process lifetimes. PostgreSQL still enforces uniqueness by
+`snapshot_epoch` is allocated by PostgreSQL with `MAX(snapshot_epoch) + 1`
+for the same `(agent_id, session_id)` inside snapshot header insertion. The
+repository takes a transaction-scoped advisory lock for that agent/session pair
+before reading the max epoch, so process restarts and concurrent processes do
+not reset or race the durable ordering. PostgreSQL still enforces uniqueness by
 `(agent_id, session_id, snapshot_epoch)`.
 
 ## TTL And Cleanup

--- a/evaluation/results/rag_01b_pr10_working_memory_smoke.json
+++ b/evaluation/results/rag_01b_pr10_working_memory_smoke.json
@@ -1,0 +1,17 @@
+{
+  "agent_id": "agent-pr10-smoke",
+  "checksum_ok": false,
+  "collection": "quimera_working_memory",
+  "generated_at": "2026-06-06T23:59:19.341959+00:00",
+  "query_after_restore_count": 0,
+  "query_before_restore_count": 0,
+  "restored_count": 0,
+  "schema_version": "rag-01b-pr10-working-memory-smoke-v1",
+  "session_id": "c515e95b-0c35-428d-975a-892b3e88cbaf",
+  "snapshot_id": null,
+  "status": "skipped",
+  "upserted_count": 0,
+  "warnings": [
+    "live stack not requested"
+  ]
+}

--- a/infra/litellm/config_validator.py
+++ b/infra/litellm/config_validator.py
@@ -40,7 +40,7 @@ CANONICAL_OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 CANONICAL_QDRANT_BASE_URL = "http://127.0.0.1:6333"
 CANONICAL_LLM_CACHE_COLLECTION = "quimera_llm_cache"
 CANONICAL_RAG_CACHE_COLLECTION = "quimera_query_cache"
-MCP_ALLOWED_PORTS = {8811, 8812}
+MCP_ALLOWED_PORTS = {8811, 8812, 8813}
 MCP_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 AGENTIC0_ALLOWED_TOOLS = {
     "postgres_memory_health",
@@ -49,8 +49,14 @@ AGENTIC0_ALLOWED_TOOLS = {
     "qdrant_memory_health",
     "qdrant_collection_list",
     "qdrant_scroll_safe",
+    "working_memory_health",
+    "working_memory_points_query",
 }
-AGENTIC0_OPTIONAL_WRITE_TOOLS = {"postgres_agent_state_upsert"}
+AGENTIC0_OPTIONAL_WRITE_TOOLS = {
+    "postgres_agent_state_upsert",
+    "working_memory_point_upsert",
+    "working_memory_session_snapshot",
+}
 DESTRUCTIVE_TOOL_PARTS = ("delete", "recreate", "drop", "truncate", "admin", "store")
 CHAT_TIMEOUT_SECONDS = 120
 CHAT_STREAM_TIMEOUT_SECONDS = 45
@@ -297,7 +303,7 @@ class McpServerEntry(BaseModel):
         if parsed.hostname not in {"127.0.0.1", "localhost"}:
             raise ValueError("MCP server URL must be loopback")
         if parsed.port not in MCP_ALLOWED_PORTS:
-            raise ValueError("MCP server URL must use approved PR-07 ports")
+            raise ValueError("MCP server URL must use approved local MCP ports")
         if parsed.path != "/mcp":
             raise ValueError("MCP server path must be /mcp")
         return value

--- a/infra/litellm/litellm_config.yaml
+++ b/infra/litellm/litellm_config.yaml
@@ -188,6 +188,10 @@ mcp_servers:
     url: http://127.0.0.1:8812/mcp
     transport: streamable_http
     available_on_public_internet: false
+  quimera-working-memory:
+    url: http://127.0.0.1:8813/mcp
+    transport: streamable_http
+    available_on_public_internet: false
 
 agentic0_tool_policy:
   virtual_key_name: agentic0-smoke
@@ -198,8 +202,12 @@ agentic0_tool_policy:
     - qdrant_memory_health
     - qdrant_collection_list
     - qdrant_scroll_safe
+    - working_memory_health
+    - working_memory_points_query
   optional_write_tools:
     - postgres_agent_state_upsert
+    - working_memory_point_upsert
+    - working_memory_session_snapshot
   destructive_tools_allowed: false
 
 general_settings:

--- a/infra/postgres/sql/020_working_memory_checkpoints.sql
+++ b/infra/postgres/sql/020_working_memory_checkpoints.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS working_memory_snapshots (
+    snapshot_id UUID PRIMARY KEY DEFAULT uuidv7(),
+    agent_id TEXT NOT NULL,
+    session_id UUID NOT NULL,
+    snapshot_epoch BIGINT NOT NULL,
+    collection_name TEXT NOT NULL,
+    vector_name TEXT NOT NULL,
+    embedding_model TEXT NOT NULL,
+    vector_dim INTEGER NOT NULL CHECK (vector_dim > 0),
+    snapshot_kind TEXT NOT NULL CHECK (snapshot_kind IN ('full','delta')),
+    point_count INTEGER NOT NULL CHECK (point_count >= 0),
+    checksum TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    schema_version TEXT NOT NULL DEFAULT 'working-memory-snapshot-v1',
+    UNIQUE(agent_id, session_id, snapshot_epoch)
+);
+
+CREATE TABLE IF NOT EXISTS working_memory_snapshot_points (
+    snapshot_id UUID NOT NULL REFERENCES working_memory_snapshots(snapshot_id) ON DELETE CASCADE,
+    point_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    session_id UUID NOT NULL,
+    memory_kind TEXT NOT NULL,
+    source_ref TEXT,
+    topic TEXT,
+    safe_summary TEXT CHECK (safe_summary IS NULL OR length(safe_summary) <= 512),
+    embedding_model TEXT NOT NULL,
+    vector_dim INTEGER NOT NULL CHECK (vector_dim > 0),
+    memory_vector vector(768),
+    importance DOUBLE PRECISION CHECK (importance IS NULL OR (importance >= 0 AND importance <= 1)),
+    recency_ts TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ,
+    payload_checksum TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    schema_version TEXT NOT NULL DEFAULT 'working-memory-snapshot-point-v1',
+    PRIMARY KEY (snapshot_id, point_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshots_agent_session_created_at
+    ON working_memory_snapshots(agent_id, session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshots_session_epoch
+    ON working_memory_snapshots(session_id, snapshot_epoch DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshot_points_agent_session
+    ON working_memory_snapshot_points(agent_id, session_id);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshot_points_memory_kind
+    ON working_memory_snapshot_points(memory_kind);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshot_points_expires_at
+    ON working_memory_snapshot_points(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_wm_snapshot_points_payload_checksum
+    ON working_memory_snapshot_points(payload_checksum);

--- a/integration/check_integration_health.py
+++ b/integration/check_integration_health.py
@@ -21,6 +21,7 @@ ServiceStatus = Literal["ok", "fail", "skipped", "unknown"]
 EXPECTED_MCP_SERVERS = {
     "quimera-postgres-memory": ("postgres_memory_health", "postgres_recent_turns_get", "postgres_agent_state_get"),
     "quimera-qdrant-memory": ("qdrant_memory_health", "qdrant_collection_list", "qdrant_scroll_safe"),
+    "quimera-working-memory": ("working_memory_health", "working_memory_points_query"),
 }
 
 

--- a/integration/working_memory_smoke.py
+++ b/integration/working_memory_smoke.py
@@ -1,0 +1,49 @@
+"""Degraded-safe PR-10 working-memory smoke report."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+OUTPUT = Path("evaluation/results/rag_01b_pr10_working_memory_smoke.json")
+SCHEMA_VERSION = "rag-01b-pr10-working-memory-smoke-v1"
+
+
+def build_skipped_smoke(*, reason: str = "live stack not requested") -> dict[str, Any]:
+    session_id = str(uuid4())
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "skipped",
+        "collection": "quimera_working_memory",
+        "agent_id": "agent-pr10-smoke",
+        "session_id": session_id,
+        "upserted_count": 0,
+        "snapshot_id": None,
+        "restored_count": 0,
+        "checksum_ok": False,
+        "query_before_restore_count": 0,
+        "query_after_restore_count": 0,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "warnings": [reason],
+    }
+
+
+def write_smoke_report(report: dict[str, Any], path: Path = OUTPUT) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    report = build_skipped_smoke()
+    write_smoke_report(report)
+    sys.stdout.write(json.dumps(report, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_pr07_litellm_mcp_registration_smoke.py
+++ b/tests/integration/test_pr07_litellm_mcp_registration_smoke.py
@@ -10,4 +10,4 @@ pytestmark = pytest.mark.integration
 def test_litellm_mcp_registration_validates_offline() -> None:
     cfg = validate_config(__import__("pathlib").Path("infra/litellm/litellm_config.yaml"), strict=False)
 
-    assert set(cfg.mcp_servers) == {"quimera-postgres-memory", "quimera-qdrant-memory"}
+    assert set(cfg.mcp_servers) == {"quimera-postgres-memory", "quimera-qdrant-memory", "quimera-working-memory"}

--- a/tests/integration/test_pr07_stack_local_first.py
+++ b/tests/integration/test_pr07_stack_local_first.py
@@ -18,5 +18,7 @@ def test_pr07_stack_is_local_first_static_contract() -> None:
     assert "quimera-litellm" not in compose
     assert "http://127.0.0.1:8811/mcp" in litellm
     assert "http://127.0.0.1:8812/mcp" in litellm
+    assert "http://127.0.0.1:8813/mcp" in litellm
     assert "0.0.0.0:8811" not in litellm
     assert "0.0.0.0:8812" not in litellm
+    assert "0.0.0.0:8813" not in litellm

--- a/tests/integration/test_pr08_litellm_mcp_tools_live.py
+++ b/tests/integration/test_pr08_litellm_mcp_tools_live.py
@@ -14,5 +14,6 @@ def test_pr08_litellm_mcp_servers_registered_static_contract() -> None:
 
     assert "quimera-postgres-memory" in cfg.mcp_servers
     assert "quimera-qdrant-memory" in cfg.mcp_servers
+    assert "quimera-working-memory" in cfg.mcp_servers
     assert cfg.agentic0_tool_policy is not None
     assert "postgres_agent_state_upsert" not in cfg.agentic0_tool_policy.allowed_tools

--- a/tests/integration/test_wm_checkpoint_pgvector_live.py
+++ b/tests/integration/test_wm_checkpoint_pgvector_live.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import asyncpg  # type: ignore[import-untyped]
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_wm_checkpoint_pgvector_live_schema_applies() -> None:
+    dsn = os.environ.get("TEST_POSTGRES_DSN") or os.environ.get("QUIMERA_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip("set TEST_POSTGRES_DSN to run live pgvector checkpoint test")
+    sql = Path("infra/postgres/sql/020_working_memory_checkpoints.sql").read_text(encoding="utf-8")
+    conn = await asyncpg.connect(dsn=dsn)
+    try:
+        await conn.execute(sql)
+        rows = await conn.fetch(
+            """
+            SELECT tablename
+            FROM pg_tables
+            WHERE schemaname = 'public'
+              AND tablename IN ('working_memory_snapshots', 'working_memory_snapshot_points')
+            """
+        )
+    finally:
+        await conn.close()
+
+    assert {row["tablename"] for row in rows} == {"working_memory_snapshots", "working_memory_snapshot_points"}

--- a/tests/integration/test_wm_mcp_live.py
+++ b/tests/integration/test_wm_mcp_live.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+from typing import Any, cast
+
+from backend.mcp.working_memory_tools import build_working_memory_health
+from backend.working_memory.config import WorkingMemorySettings
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_wm_mcp_health_live_contract_without_server() -> None:
+    health = build_working_memory_health(WorkingMemorySettings())
+
+    details = cast(dict[str, Any], health["details"])
+    assert health["backend"] == "working_memory"
+    assert details["collection"] == "quimera_working_memory"

--- a/tests/integration/test_wm_qdrant_live.py
+++ b/tests/integration/test_wm_qdrant_live.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from qdrant_client import AsyncQdrantClient
+
+from backend.working_memory.config import WorkingMemorySettings
+from backend.working_memory.models import WorkingMemoryPoint
+from backend.working_memory.qdrant_store import WorkingMemoryQdrantStore
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_wm_qdrant_live_upsert_query_list() -> None:
+    if os.environ.get("QUIMERA_TEST_WM_QDRANT_LIVE") != "1":
+        pytest.skip("set QUIMERA_TEST_WM_QDRANT_LIVE=1 to run live Qdrant working-memory test")
+    settings = WorkingMemorySettings(collection_name=f"quimera_working_memory_test_{uuid4().hex}", vector_size=4)
+    client = AsyncQdrantClient(url=settings.qdrant_url)
+    store = WorkingMemoryQdrantStore(client, settings)
+    await store.ensure_collection()
+    session_id = uuid4()
+    now = datetime.now(UTC)
+    point = WorkingMemoryPoint(
+        point_id=f"wm-{uuid4().hex}",
+        agent_id="agent-live",
+        session_id=session_id,
+        memory_kind="turn_summary",
+        vector=(0.1, 0.2, 0.3, 0.4),
+        vector_dim=4,
+        recency_ts=now,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(seconds=60),
+        ttl_seconds=60,
+        embedding_model="nomic-embed-text",
+        safe_summary="live safe summary",
+    )
+    await store.upsert_memory_point(point)
+
+    results = await store.query_working_memory(agent_id=point.agent_id, session_id=str(session_id), query_vector=point.vector)
+    listed = await store.list_session_memory(agent_id=point.agent_id, session_id=str(session_id))
+
+    assert results
+    assert listed
+    assert "vector" not in results[0]
+    await store.delete_session_points(agent_id=point.agent_id, session_id=str(session_id))

--- a/tests/integration/test_wm_qdrant_restart_restore_live.py
+++ b/tests/integration/test_wm_qdrant_restart_restore_live.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_wm_qdrant_restart_restore_live_is_opt_in() -> None:
+    if os.environ.get("QUIMERA_TEST_CAN_CONTROL_RUNTIME") != "1":
+        pytest.skip("set QUIMERA_TEST_CAN_CONTROL_RUNTIME=1 to run restart/restore validation")
+    pytest.fail("runtime-control restart restore is intentionally human-operated")

--- a/tests/integration/test_wm_snapshot_restore_live.py
+++ b/tests/integration/test_wm_snapshot_restore_live.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_wm_snapshot_restore_live_requires_explicit_stack() -> None:
+    if os.environ.get("QUIMERA_TEST_WM_RESTORE_LIVE") != "1":
+        pytest.skip("set QUIMERA_TEST_WM_RESTORE_LIVE=1 with Qdrant/Postgres to run restore smoke")
+    pytest.fail("live restore smoke is reserved for explicit operator-run stack validation")

--- a/tests/unit/test_litellm_mcp_config_validator.py
+++ b/tests/unit/test_litellm_mcp_config_validator.py
@@ -17,12 +17,13 @@ def test_litellm_accepts_loopback_mcp_servers() -> None:
     assert "quimera-postgres-memory" in cfg.mcp_servers
     assert cfg.mcp_servers["quimera-postgres-memory"].url == "http://127.0.0.1:8811/mcp"
     assert cfg.mcp_servers["quimera-qdrant-memory"].available_on_public_internet is False
+    assert cfg.mcp_servers["quimera-working-memory"].url == "http://127.0.0.1:8813/mcp"
 
 
 def test_litellm_rejects_public_mcp_server_url() -> None:
     raw = deepcopy(load_raw_config(CONFIG))
     raw["mcp_servers"]["bad-public"] = {
-        "url": "http://0.0.0.0:8811/mcp",
+        "url": "http://0.0.0.0:8813/mcp",
         "transport": "streamable_http",
         "available_on_public_internet": False,
     }
@@ -34,7 +35,7 @@ def test_litellm_rejects_public_mcp_server_url() -> None:
 def test_litellm_rejects_sse_and_public_internet() -> None:
     raw = deepcopy(load_raw_config(CONFIG))
     raw["mcp_servers"]["bad-sse"] = {
-        "url": "http://127.0.0.1:8811/mcp",
+        "url": "http://127.0.0.1:8813/mcp",
         "transport": "sse",
         "available_on_public_internet": True,
     }

--- a/tests/unit/test_pr08_litellm_mcp_allowed_tools.py
+++ b/tests/unit/test_pr08_litellm_mcp_allowed_tools.py
@@ -14,6 +14,12 @@ def test_agentic0_allowed_tools_are_explicit_and_non_destructive() -> None:
     assert not any("delete" in tool or "recreate" in tool or "store" in tool for tool in tools)
     assert "postgres_agent_state_upsert" not in tools
     assert "postgres_agent_state_upsert" in cfg.agentic0_tool_policy.optional_write_tools
+    assert "working_memory_health" in tools
+    assert "working_memory_points_query" in tools
+    assert "working_memory_point_upsert" not in tools
+    assert "working_memory_point_upsert" in cfg.agentic0_tool_policy.optional_write_tools
+    assert "working_memory_session_restore" not in tools
+    assert "working_memory_expired_cleanup" not in tools
     assert cfg.agentic0_tool_policy.virtual_key_name == "agentic0-smoke"
     assert cfg.agentic0_tool_policy.destructive_tools_allowed is False
 
@@ -21,7 +27,11 @@ def test_agentic0_allowed_tools_are_explicit_and_non_destructive() -> None:
 def test_mcp_servers_remain_loopback_and_not_public() -> None:
     cfg = validate_litellm_config(Path("infra/litellm/litellm_config.yaml"))
 
-    assert set(cfg.mcp_servers) == {"quimera-postgres-memory", "quimera-qdrant-memory"}
+    assert set(cfg.mcp_servers) == {
+        "quimera-postgres-memory",
+        "quimera-qdrant-memory",
+        "quimera-working-memory",
+    }
     for server in cfg.mcp_servers.values():
         assert server.url.startswith("http://127.0.0.1:")
         assert server.available_on_public_internet is False

--- a/tests/unit/test_wm_checkpoint_schema.py
+++ b/tests/unit/test_wm_checkpoint_schema.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SQL = Path("infra/postgres/sql/020_working_memory_checkpoints.sql")
+
+
+def test_working_memory_checkpoint_schema_contract() -> None:
+    sql = SQL.read_text(encoding="utf-8")
+    lowered = sql.lower()
+
+    assert "create table if not exists working_memory_snapshots" in lowered
+    assert "create table if not exists working_memory_snapshot_points" in lowered
+    assert "uuidv7()" in lowered
+    assert "memory_vector vector(768)" in lowered
+    assert "snapshot_kind text not null check" in lowered
+    assert "vector_dim integer not null check (vector_dim > 0)" in lowered
+    assert "importance double precision check" in lowered
+    assert "safe_summary text check" in lowered
+    assert "idx_wm_snapshots_agent_session_created_at" in lowered
+    assert "idx_wm_snapshot_points_payload_checksum" in lowered
+    assert "hnsw" not in lowered
+    assert "ivfflat" not in lowered
+    for forbidden in ("prompt", "raw_prompt", "answer", "chunk_text", "document_text"):
+        assert forbidden not in lowered

--- a/tests/unit/test_wm_cleanup.py
+++ b/tests/unit/test_wm_cleanup.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from backend.working_memory.cleanup import CleanupService
+from backend.working_memory.config import WorkingMemorySettings
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.called = False
+
+    async def delete_expired_points(self, *, agent_id: str | None = None, session_id: str | None = None) -> int:
+        self.called = True
+        return 3
+
+
+async def test_cleanup_disabled_by_default() -> None:
+    store = FakeStore()
+    service = CleanupService(store=store, settings=WorkingMemorySettings(cleanup_enabled=False))
+
+    result = await service.cleanup_expired()
+
+    assert result.status == "disabled"
+    assert result.deleted_count == 0
+    assert store.called is False
+
+
+async def test_cleanup_only_allows_working_memory_collections() -> None:
+    store = FakeStore()
+    service = CleanupService(
+        store=store,
+        settings=WorkingMemorySettings(collection_name="quimera_working_memory_test_cleanup", cleanup_enabled=True),
+    )
+
+    result = await service.cleanup_expired(agent_id="agent")
+
+    assert result.status == "ok"
+    assert result.deleted_count == 3
+    assert store.called is True

--- a/tests/unit/test_wm_config.py
+++ b/tests/unit/test_wm_config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from backend.working_memory.config import WorkingMemorySettings
+
+
+def test_wm_settings_defaults() -> None:
+    settings = WorkingMemorySettings()
+
+    assert settings.enabled is True
+    assert settings.qdrant_url == "http://127.0.0.1:6333"
+    assert settings.collection_name == "quimera_working_memory"
+    assert settings.vector_name == "work-dense"
+    assert settings.vector_size == 768
+    assert settings.distance == "Cosine"
+    assert settings.default_ttl_seconds == 3600
+    assert settings.max_points_per_session == 512
+    assert settings.snapshot_every_writes == 20
+    assert settings.snapshot_interval_seconds == 300
+    assert settings.restore_enabled is False
+    assert settings.cleanup_enabled is False
+
+
+def test_wm_settings_reads_quimera_wm_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUIMERA_WM_ENABLED", "0")
+    monkeypatch.setenv("QUIMERA_WM_COLLECTION", "quimera_working_memory_test_a")
+    monkeypatch.setenv("QUIMERA_WM_VECTOR_SIZE", "16")
+    monkeypatch.setenv("QUIMERA_WM_DEFAULT_TTL_SECONDS", "30")
+
+    settings = WorkingMemorySettings()
+
+    assert settings.enabled is False
+    assert settings.collection_name == "quimera_working_memory_test_a"
+    assert settings.vector_size == 16
+    assert settings.default_ttl_seconds == 30
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("qdrant_url", "https://example.com"),
+        ("qdrant_url", "http://10.0.0.2:6333"),
+        ("collection_name", "quimera_query_cache"),
+        ("collection_name", "working_memory"),
+        ("vector_name", " "),
+        ("vector_size", 0),
+        ("default_ttl_seconds", 0),
+        ("max_points_per_session", 0),
+        ("snapshot_every_writes", 0),
+        ("snapshot_interval_seconds", 0),
+    ],
+)
+def test_wm_settings_validation(field: str, value: object) -> None:
+    with pytest.raises(ValueError):
+        WorkingMemorySettings(**cast(Any, {field: value}))
+
+
+def test_wm_settings_forbids_cache_and_hybrid_collections() -> None:
+    for collection in ("quimera_knowledge", "quimera_query_cache", "quimera_llm_cache"):
+        with pytest.raises(ValueError):
+            WorkingMemorySettings(collection_name=collection)

--- a/tests/unit/test_wm_docs.py
+++ b/tests/unit/test_wm_docs.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pr10_sdd_and_adr_contracts_exist() -> None:
+    sdd = Path("docs/specs/rag-01b/pr-10-working-memory-qdrant-pgvector.md").read_text(encoding="utf-8")
+    adr = Path("docs/adr/ADR-005-qdrant-working-memory-pgvector-checkpoints.md").read_text(encoding="utf-8")
+    mem = Path("docs/04_MEM/WORKING_MEMORY_QDRANT.md").read_text(encoding="utf-8")
+
+    assert "working memory vetorial quente em Qdrant" in sdd
+    assert "Status: Accepted" in adr
+    assert "quimera_working_memory" in adr
+    assert "work-dense" in adr
+    assert "pgvector is a checkpoint" in adr
+    assert "not HybridRAG" in mem

--- a/tests/unit/test_wm_mcp_tools.py
+++ b/tests/unit/test_wm_mcp_tools.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from uuid import uuid4
+from typing import Any, cast
+
+import pytest
+
+from backend.mcp.working_memory_tools import (
+    build_working_memory_health,
+    working_memory_cleanup_expired,
+    working_memory_query,
+    working_memory_restore,
+    working_memory_upsert,
+)
+from backend.working_memory.config import WorkingMemorySettings
+
+
+async def test_working_memory_tools_validate_inputs_and_hide_vectors() -> None:
+    session_id = str(uuid4())
+    settings = WorkingMemorySettings(vector_size=3, collection_name="quimera_working_memory_test_mcp")
+
+    response = await working_memory_upsert(
+        agent_id="agent",
+        session_id=session_id,
+        memory_kind="turn_summary",
+        vector=[0.1, 0.2, 0.3],
+        metadata={"safe": True},
+        safe_summary="ok",
+        settings=settings,
+        store=None,
+    )
+
+    assert response["ok"] is True
+    assert "vector" not in str(response).lower()
+    assert "payload" not in str(response).lower()
+
+
+async def test_working_memory_query_limit_and_restore_cleanup_gates() -> None:
+    session_id = str(uuid4())
+    settings = WorkingMemorySettings(vector_size=3, collection_name="quimera_working_memory_test_mcp")
+
+    with pytest.raises(ValueError, match="limit"):
+        await working_memory_query("agent", session_id, [0.1, 0.2, 0.3], limit=100, settings=settings, store=None)
+
+    restore = await working_memory_restore("agent", session_id, settings=settings, restore_service=None)
+    cleanup = await working_memory_cleanup_expired(settings=settings, cleanup_service=None)
+
+    assert restore["ok"] is False
+    assert "disabled" in str(restore["error"])
+    assert cleanup["ok"] is False
+    assert "disabled" in str(cleanup["error"])
+
+
+def test_working_memory_health_contract() -> None:
+    response = build_working_memory_health(WorkingMemorySettings())
+
+    details = cast(dict[str, Any], response["details"])
+    assert response["schema_version"] == "quimera-mcp-health-v1"
+    assert response["backend"] == "working_memory"
+    assert details["collection"] == "quimera_working_memory"

--- a/tests/unit/test_wm_models.py
+++ b/tests/unit/test_wm_models.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from backend.working_memory.models import (
+    SCHEMA_VERSION_POINT_V1,
+    MemoryKind,
+    WorkingMemoryPoint,
+)
+
+
+NOW = datetime(2026, 6, 6, 12, 0, tzinfo=UTC)
+
+
+def _point(**overrides: object) -> WorkingMemoryPoint:
+    values: dict[str, object] = {
+        "point_id": "wm-1",
+        "agent_id": "agent-1",
+        "session_id": uuid4(),
+        "memory_kind": "turn_summary",
+        "vector": (0.1, 0.2, 0.3, 0.4),
+        "vector_dim": 4,
+        "safe_summary": "short safe summary",
+        "importance": 0.5,
+        "recency_ts": NOW,
+        "created_at": NOW,
+        "updated_at": NOW,
+        "expires_at": NOW + timedelta(seconds=60),
+        "ttl_seconds": 60,
+        "embedding_model": "nomic-embed-text",
+        "metadata": {"safe": True},
+    }
+    values.update(overrides)
+    return WorkingMemoryPoint(**values)  # type: ignore[arg-type]
+
+
+def test_working_memory_point_defaults_and_payload_are_safe() -> None:
+    point = _point()
+    payload = point.to_qdrant_payload()
+
+    assert point.schema_version == SCHEMA_VERSION_POINT_V1
+    assert point.memory_kind == "turn_summary"
+    assert payload["schema_version"] == SCHEMA_VERSION_POINT_V1
+    assert payload["safe_summary"] == "short safe summary"
+    assert "vector" not in payload
+    assert "payload_checksum" in payload
+
+
+@pytest.mark.parametrize("kind", list(MemoryKind.__args__))  # type: ignore[attr-defined]
+def test_memory_kind_contract(kind: str) -> None:
+    assert _point(memory_kind=kind).memory_kind == kind
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("agent_id", " ", "agent_id"),
+        ("point_id", " ", "point_id"),
+        ("importance", -0.1, "importance"),
+        ("importance", 1.1, "importance"),
+        ("expires_at", NOW, "expires_at"),
+        ("ttl_seconds", 0, "ttl_seconds"),
+        ("vector_dim", 3, "vector_dim"),
+        ("safe_summary", "x" * 513, "safe_summary"),
+        ("metadata", {"prompt": "bad"}, "sensitive"),
+    ],
+)
+def test_working_memory_point_validation(field: str, value: object, match: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=match):
+        _point(**{field: value})
+
+
+def test_working_memory_point_repr_does_not_leak_summary_or_vector() -> None:
+    point = _point(safe_summary="classified but safe short text", vector=(0.1, 0.2, 0.3, 0.4))
+
+    rendered = repr(point)
+
+    assert "classified" not in rendered
+    assert "0.1" not in rendered
+    assert "vector_dim=4" in rendered

--- a/tests/unit/test_wm_qdrant_collection_contract.py
+++ b/tests/unit/test_wm_qdrant_collection_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from backend.working_memory.config import WorkingMemorySettings
+from backend.working_memory.qdrant_store import (
+    WORKING_MEMORY_PAYLOAD_INDEXES,
+    WorkingMemoryQdrantStore,
+    qdrant_distance,
+)
+
+
+class FakeCollectionClient:
+    def __init__(self) -> None:
+        self.created: list[dict[str, object]] = []
+        self.indexes: list[tuple[str, object]] = []
+
+    async def collection_exists(self, **kwargs: object) -> bool:
+        return False
+
+    async def create_collection(self, **kwargs: object) -> None:
+        self.created.append(kwargs)
+
+    async def create_payload_index(self, **kwargs: object) -> None:
+        self.indexes.append((str(kwargs["field_name"]), kwargs["field_schema"]))
+
+    async def get_collection(self, **kwargs: object) -> object:
+        return {}
+
+    async def upsert(self, **kwargs: object) -> None:
+        return None
+
+    async def query_points(self, **kwargs: object) -> object:
+        return object()
+
+    async def scroll(self, **kwargs: object) -> tuple[list[object], None]:
+        return [], None
+
+    async def set_payload(self, **kwargs: object) -> None:
+        return None
+
+    async def delete(self, **kwargs: object) -> None:
+        return None
+
+
+async def test_collection_config_uses_named_in_memory_cosine_vector() -> None:
+    settings = WorkingMemorySettings(vector_size=4, collection_name="quimera_working_memory_test_contract")
+    client = FakeCollectionClient()
+    store = WorkingMemoryQdrantStore(client, settings)
+
+    await store.ensure_collection()
+
+    created = client.created[0]
+    vectors = created["vectors_config"]
+    assert settings.vector_name in vectors  # type: ignore[operator]
+    vector_params = vectors[settings.vector_name]  # type: ignore[index]
+    assert vector_params.size == 4
+    assert vector_params.distance == qdrant_distance("Cosine")
+    assert vector_params.on_disk is False
+    assert {name for name, _ in client.indexes} == set(WORKING_MEMORY_PAYLOAD_INDEXES)
+
+
+def test_collection_contract_does_not_reference_other_quimera_collections() -> None:
+    assert "quimera_knowledge" not in WorkingMemoryQdrantStore.__module__
+    forbidden = {"quimera_knowledge", "quimera_query_cache", "quimera_llm_cache"}
+    assert forbidden.isdisjoint(WORKING_MEMORY_PAYLOAD_INDEXES)
+
+
+def test_working_memory_store_has_no_delete_collection_method() -> None:
+    assert not hasattr(WorkingMemoryQdrantStore, "delete_collection")

--- a/tests/unit/test_wm_restore_service.py
+++ b/tests/unit/test_wm_restore_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from backend.working_memory.models import WorkingMemoryPoint
+from backend.working_memory.restore_service import RestoreService
+
+
+NOW = datetime(2026, 6, 6, 12, 0, tzinfo=UTC)
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.restored: list[WorkingMemoryPoint] = []
+        self.deleted_scope: tuple[str, str] | None = None
+
+    async def restore_points_from_snapshot(self, points: list[WorkingMemoryPoint]) -> int:
+        self.restored.extend(points)
+        return len(points)
+
+    async def delete_session_points(self, *, agent_id: str, session_id: str) -> int:
+        self.deleted_scope = (agent_id, session_id)
+        return 1
+
+
+class FakeRepository:
+    def __init__(self, points: list[WorkingMemoryPoint]) -> None:
+        self.points = points
+        self.validated: str | None = None
+
+    async def get_latest_snapshot(self, *, agent_id: str, session_id: str) -> dict[str, object] | None:
+        return {"snapshot_id": "snap-1", "checksum": "ok", "agent_id": agent_id, "session_id": session_id}
+
+    async def load_snapshot_points(self, snapshot_id: str) -> list[WorkingMemoryPoint]:
+        return self.points
+
+    async def validate_snapshot_checksum(self, snapshot_id: str) -> bool:
+        self.validated = snapshot_id
+        return True
+
+    async def mark_snapshot_restored(self, snapshot_id: str) -> None:
+        self.validated = snapshot_id
+
+
+def _point() -> WorkingMemoryPoint:
+    now = datetime.now(UTC)
+    return WorkingMemoryPoint(
+        point_id="p1",
+        agent_id="agent",
+        session_id=uuid4(),
+        memory_kind="turn_summary",
+        vector=(0.1, 0.2),
+        vector_dim=2,
+        importance=0.5,
+        recency_ts=now,
+        created_at=now,
+        updated_at=now,
+        expires_at=now + timedelta(seconds=60),
+        ttl_seconds=60,
+        embedding_model="nomic",
+    )
+
+
+async def test_restore_merge_default_and_checksum() -> None:
+    point = _point()
+    store = FakeStore()
+    repo = FakeRepository([point])
+    service = RestoreService(store=store, repository=repo, replace_enabled=False)
+
+    result = await service.restore_latest_snapshot(agent_id=point.agent_id, session_id=str(point.session_id))
+
+    assert result.restored_count == 1
+    assert result.checksum_ok is True
+    assert store.deleted_scope is None
+    assert store.restored == [point]
+
+
+async def test_restore_replace_is_gated() -> None:
+    point = _point()
+    service = RestoreService(store=FakeStore(), repository=FakeRepository([point]), replace_enabled=False)
+
+    with pytest.raises(ValueError, match="disabled"):
+        await service.restore_snapshot("snap-1", agent_id=point.agent_id, session_id=str(point.session_id), replace=True)
+
+
+async def test_restore_replace_deletes_only_agent_session_scope() -> None:
+    point = _point()
+    store = FakeStore()
+    service = RestoreService(store=store, repository=FakeRepository([point]), replace_enabled=True)
+
+    await service.restore_snapshot("snap-1", agent_id=point.agent_id, session_id=str(point.session_id), replace=True)
+
+    assert store.deleted_scope == (point.agent_id, str(point.session_id))

--- a/tests/unit/test_wm_restore_service.py
+++ b/tests/unit/test_wm_restore_service.py
@@ -27,8 +27,9 @@ class FakeStore:
 
 
 class FakeRepository:
-    def __init__(self, points: list[WorkingMemoryPoint]) -> None:
+    def __init__(self, points: list[WorkingMemoryPoint], *, checksum_ok: bool = True) -> None:
         self.points = points
+        self.checksum_ok = checksum_ok
         self.validated: str | None = None
 
     async def get_latest_snapshot(self, *, agent_id: str, session_id: str) -> dict[str, object] | None:
@@ -39,7 +40,7 @@ class FakeRepository:
 
     async def validate_snapshot_checksum(self, snapshot_id: str) -> bool:
         self.validated = snapshot_id
-        return True
+        return self.checksum_ok
 
     async def mark_snapshot_restored(self, snapshot_id: str) -> None:
         self.validated = snapshot_id
@@ -94,3 +95,34 @@ async def test_restore_replace_deletes_only_agent_session_scope() -> None:
     await service.restore_snapshot("snap-1", agent_id=point.agent_id, session_id=str(point.session_id), replace=True)
 
     assert store.deleted_scope == (point.agent_id, str(point.session_id))
+
+
+async def test_restore_can_abort_on_checksum_mismatch() -> None:
+    point = _point()
+    store = FakeStore()
+    service = RestoreService(
+        store=store,
+        repository=FakeRepository([point], checksum_ok=False),
+        abort_on_checksum_fail=True,
+    )
+
+    result = await service.restore_snapshot("snap-1", agent_id=point.agent_id, session_id=str(point.session_id))
+
+    assert result.status == "fail"
+    assert result.checksum_ok is False
+    assert result.restored_count == 0
+    assert store.restored == []
+    assert result.warnings == ["snapshot checksum mismatch; restore aborted"]
+
+
+async def test_restore_warns_but_continues_on_checksum_mismatch_by_default() -> None:
+    point = _point()
+    store = FakeStore()
+    service = RestoreService(store=store, repository=FakeRepository([point], checksum_ok=False))
+
+    result = await service.restore_snapshot("snap-1", agent_id=point.agent_id, session_id=str(point.session_id))
+
+    assert result.status == "warn"
+    assert result.checksum_ok is False
+    assert result.restored_count == 1
+    assert store.restored == [point]

--- a/tests/unit/test_wm_safety.py
+++ b/tests/unit/test_wm_safety.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.working_memory.safety import (
+    WorkingMemorySafetyError,
+    assert_agent_session_scope,
+    compute_payload_checksum,
+    sanitize_metadata,
+    validate_safe_payload,
+    validate_safe_summary,
+)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "prompt",
+        "raw_prompt",
+        "answer",
+        "response",
+        "chunk",
+        "chunk_text",
+        "document_text",
+        "payload",
+        "authorization",
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "dsn",
+        "connection_string",
+        "vector",
+    ],
+)
+def test_validate_safe_payload_rejects_sensitive_keys(key: str) -> None:
+    with pytest.raises(WorkingMemorySafetyError, match="sensitive"):
+        validate_safe_payload({key: "bad"})
+
+
+def test_sanitize_metadata_redacts_nested_sensitive_values() -> None:
+    sanitized = sanitize_metadata({"safe": "yes", "nested": {"token": "bad", "ok": 1}})
+
+    assert sanitized == {"safe": "yes", "nested": {"token": "[REDACTED]", "ok": 1}}
+
+
+def test_safe_summary_limit_and_secret_patterns() -> None:
+    assert validate_safe_summary("a safe summary") == "a safe summary"
+    with pytest.raises(WorkingMemorySafetyError, match="512"):
+        validate_safe_summary("x" * 513)
+    with pytest.raises(WorkingMemorySafetyError, match="secret"):
+        validate_safe_summary("Authorization: Bearer abc")
+
+
+def test_checksum_is_deterministic_and_order_insensitive() -> None:
+    left = compute_payload_checksum({"b": 2, "a": 1})
+    right = compute_payload_checksum({"a": 1, "b": 2})
+
+    assert left == right
+    assert len(left) == 64
+
+
+def test_agent_session_scope_validation() -> None:
+    assert_agent_session_scope("agent", "00000000-0000-0000-0000-000000000001")
+    with pytest.raises(WorkingMemorySafetyError):
+        assert_agent_session_scope(" ", "00000000-0000-0000-0000-000000000001")
+    with pytest.raises(WorkingMemorySafetyError):
+        assert_agent_session_scope("agent", "not-a-uuid")

--- a/tests/unit/test_wm_smoke_report.py
+++ b/tests/unit/test_wm_smoke_report.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from integration.working_memory_smoke import SCHEMA_VERSION, build_skipped_smoke
+
+
+def test_working_memory_smoke_report_is_safe() -> None:
+    report = build_skipped_smoke(reason="unit")
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["status"] == "skipped"
+    assert "vector" not in str(report).lower()
+    assert "prompt" not in str(report).lower()
+    assert "secret" not in str(report).lower()

--- a/tests/unit/test_wm_snapshot_service.py
+++ b/tests/unit/test_wm_snapshot_service.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
+import pytest
+
+from backend.working_memory import snapshot_service
 from backend.working_memory.models import WorkingMemoryPoint
 from backend.working_memory.snapshot_service import SnapshotService, compute_snapshot_checksum
 
@@ -48,6 +51,18 @@ async def test_snapshot_service_filters_expired_points_and_epoch_is_monotonic() 
 
     assert [point.point_id for point in active] == ["a"]
     assert epoch2 > epoch1
+    assert epoch1 > 1_700_000_000_000
+
+
+def test_snapshot_epoch_uses_wall_clock_milliseconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("backend.working_memory.snapshot_service.time.time_ns", lambda: 1_800_000_000_000_000_000)
+    monkeypatch.setattr(snapshot_service, "_LAST_EPOCH_MS", 0)
+
+    first = snapshot_service.next_snapshot_epoch_ms()
+    second = snapshot_service.next_snapshot_epoch_ms()
+
+    assert first == 1_800_000_000_000
+    assert second == 1_800_000_000_001
 
 
 def test_should_snapshot_policy() -> None:

--- a/tests/unit/test_wm_snapshot_service.py
+++ b/tests/unit/test_wm_snapshot_service.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
 
 from backend.working_memory import snapshot_service
+from backend.working_memory.checkpoint_repository import WorkingMemoryCheckpointRepository
 from backend.working_memory.models import WorkingMemoryPoint
 from backend.working_memory.snapshot_service import SnapshotService, compute_snapshot_checksum
 
@@ -31,6 +33,48 @@ def _point(point_id: str, *, expired: bool = False) -> WorkingMemoryPoint:
         ttl_seconds=60,
         embedding_model="nomic",
     )
+
+
+class FakeStore:
+    def __init__(self, points: list[WorkingMemoryPoint]) -> None:
+        self.points = points
+        self.checkpointed: tuple[list[str], str] | None = None
+
+    async def export_session_points_for_snapshot(self, *, agent_id: str, session_id: str, limit: int | None = None) -> list[WorkingMemoryPoint]:
+        return self.points
+
+    async def mark_checkpointed(self, *, point_ids: Iterable[str], checkpoint_id: str) -> None:
+        self.checkpointed = (list(point_ids), checkpoint_id)
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.header_kwargs: dict[str, object] | None = None
+
+    async def create_snapshot_header(self, **kwargs: object) -> str:
+        self.header_kwargs = kwargs
+        return "snapshot-1"
+
+    async def insert_snapshot_points(self, *, snapshot_id: str, points: list[WorkingMemoryPoint]) -> None:
+        assert snapshot_id == "snapshot-1"
+        assert points
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.query = ""
+        self.args: tuple[object, ...] = ()
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object]:
+        self.query = query
+        self.args = args
+        return {"snapshot_id": UUID("00000000-0000-0000-0000-000000000999")}
+
+    async def fetch(self, query: str, *args: object) -> list[object]:
+        return []
+
+    async def execute(self, query: str, *args: object) -> str:
+        return "INSERT 0 1"
 
 
 def test_snapshot_checksum_is_stable_and_ignores_order() -> None:
@@ -63,6 +107,57 @@ def test_snapshot_epoch_uses_wall_clock_milliseconds(monkeypatch: pytest.MonkeyP
 
     assert first == 1_800_000_000_000
     assert second == 1_800_000_000_001
+
+
+async def test_create_session_snapshot_lets_repository_allocate_epoch() -> None:
+    created_at = datetime.now(UTC)
+    point = WorkingMemoryPoint(
+        point_id="a",
+        agent_id="agent",
+        session_id=SESSION_ID,
+        memory_kind="turn_summary",
+        vector=(0.1, 0.2),
+        vector_dim=2,
+        importance=0.5,
+        recency_ts=created_at,
+        created_at=created_at,
+        updated_at=created_at,
+        expires_at=created_at + timedelta(seconds=60),
+        ttl_seconds=60,
+        embedding_model="nomic",
+    )
+    store = FakeStore([point])
+    repository = FakeRepository()
+    service = SnapshotService(store=store, repository=repository)
+
+    result = await service.create_session_snapshot(agent_id=point.agent_id, session_id=str(point.session_id))
+
+    assert result["snapshot_id"] == "snapshot-1"
+    assert repository.header_kwargs is not None
+    assert repository.header_kwargs["snapshot_epoch"] is None
+    assert store.checkpointed == (["a"], "snapshot-1")
+
+
+async def test_checkpoint_repository_allocates_epoch_with_db_lock() -> None:
+    pool = FakePool()
+    repository = WorkingMemoryCheckpointRepository(pool)
+
+    await repository.create_snapshot_header(
+        agent_id="agent",
+        session_id=str(SESSION_ID),
+        snapshot_epoch=None,
+        collection_name="quimera_working_memory",
+        vector_name="working_memory",
+        embedding_model="nomic",
+        vector_dim=768,
+        snapshot_kind="full",
+        point_count=0,
+        checksum="abc",
+    )
+
+    assert "pg_advisory_xact_lock" in pool.query
+    assert "COALESCE(MAX(snapshot_epoch), 0) + 1" in pool.query
+    assert pool.args[2] is None
 
 
 def test_should_snapshot_policy() -> None:

--- a/tests/unit/test_wm_snapshot_service.py
+++ b/tests/unit/test_wm_snapshot_service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from backend.working_memory.models import WorkingMemoryPoint
+from backend.working_memory.snapshot_service import SnapshotService, compute_snapshot_checksum
+
+
+NOW = datetime(2026, 6, 6, 12, 0, tzinfo=UTC)
+SESSION_ID = UUID("00000000-0000-0000-0000-000000000123")
+
+
+def _point(point_id: str, *, expired: bool = False) -> WorkingMemoryPoint:
+    created_at = NOW - timedelta(seconds=120) if expired else NOW
+    return WorkingMemoryPoint(
+        point_id=point_id,
+        agent_id="agent",
+        session_id=SESSION_ID,
+        memory_kind="turn_summary",
+        vector=(0.1, 0.2),
+        vector_dim=2,
+        importance=0.5,
+        recency_ts=NOW,
+        created_at=created_at,
+        updated_at=created_at,
+        expires_at=NOW - timedelta(seconds=1) if expired else NOW + timedelta(seconds=60),
+        ttl_seconds=60,
+        embedding_model="nomic",
+    )
+
+
+def test_snapshot_checksum_is_stable_and_ignores_order() -> None:
+    left = compute_snapshot_checksum([_point("b"), _point("a")])
+    right = compute_snapshot_checksum([_point("a"), _point("b")])
+
+    assert left == right
+    assert len(left) == 64
+
+
+async def test_snapshot_service_filters_expired_points_and_epoch_is_monotonic() -> None:
+    service = SnapshotService(store=None, repository=None)
+    points = [_point("a"), _point("expired", expired=True)]
+
+    active = service.active_points(points, now=NOW)
+    epoch1 = service.next_snapshot_epoch("agent", str(uuid4()))
+    epoch2 = service.next_snapshot_epoch("agent", str(uuid4()))
+
+    assert [point.point_id for point in active] == ["a"]
+    assert epoch2 > epoch1
+
+
+def test_should_snapshot_policy() -> None:
+    service = SnapshotService(store=None, repository=None)
+
+    assert service.should_snapshot(write_count=20, elapsed_seconds=1)
+    assert service.should_snapshot(write_count=1, elapsed_seconds=300)
+    assert not service.should_snapshot(write_count=1, elapsed_seconds=1)


### PR DESCRIPTION
## Summary
- Adds Qdrant hot working memory with isolated collection quimera_working_memory and named vector work-dense.
- Adds Postgres/pgvector checkpoint SQL and asyncpg repository for durable restore.
- Adds snapshot/restore/cleanup services, safety gates, MCP tools/server on 127.0.0.1:8813/mcp, and LiteLLM registration.
- Adds PR-10 SDD, ADR-005, memory handoff doc, smoke artifact, unit and integration contracts.

## Validation
- uv run pytest tests/unit/test_wm_*.py tests/integration/test_wm_*.py -> 67 passed / 4 skipped
- PR-10 + LiteLLM/MCP registration block -> 75 passed / 4 skipped
- uv run pytest -> 1886 passed / 65 skipped
- scoped uv run mypy --strict -> success
- scoped uv run pyright -> 0 errors
- uv run python -m infra.litellm.config_validator -> success, one expected qdrant-semantic warning
- uv run python -m integration.working_memory_smoke -> generated safe skipped smoke artifact
- git diff --check -> clean

## Notes
- Full uv run mypy --strict . / uv run pyright are currently blocked by untracked local infra/sandbox files importing FastAPI; those files are not included in this PR.
- Live Qdrant/Postgres restore tests are opt-in and skip cleanly without explicit QUIMERA_TEST_WM_* env vars and test DSN.
- No HybridRAG/cache collection is mutated, no real collection delete is implemented, and Redis/Python/RAM backend is not decided.